### PR TITLE
[fix] 안드로이드 CI working-directory 설정 누락

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -6,6 +6,7 @@ on:
     branches: [ "develop" ]
 
 jobs:
+
   build:
     name: Build APK
     runs-on: ubuntu-latest
@@ -34,9 +35,11 @@ jobs:
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
+      working-directory: ./android
     
     - name: Build with Gradle
       run: ./gradlew build --stacktrace
+      working-directory: ./android
     
   lint:
     name: Ktlint Check
@@ -55,9 +58,11 @@ jobs:
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
+      working-directory: ./android
 
     - name: Run ktlintCheck
       run: ./gradlew ktlintCheck --stacktrace
+      working-directory: ./android
 
   test:
     name: Run Unit Tests
@@ -76,9 +81,11 @@ jobs:
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
+      working-directory: ./android
     
     - name: Run tests
       run: ./gradlew test --stacktrace
+      working-directory: ./android
     
     - name: Publish Unit Test Results
       uses: EnricoMi/publish-unit-test-result-action@v2


### PR DESCRIPTION
## Issues
- closed #19

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
CI 파일 누락된 working-directory 경로 설정

## 📷 Screenshot

## 📚 Reference
