### PR TITLE
[fix] 안드로이드 CI working-directory 설정 누락 재수정

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -11,6 +11,14 @@ jobs:
     name: Build APK
     runs-on: ubuntu-latest
 
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./android
+
+    permissions:
+      contents: read
+
     steps:
     - uses: actions/checkout@v4
       with:
@@ -35,16 +43,22 @@ jobs:
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-      working-directory: ./android
-    
+      
     - name: Build with Gradle
       run: ./gradlew build --stacktrace
-      working-directory: ./android
-    
+      
   lint:
     name: Ktlint Check
     runs-on: ubuntu-latest
     needs: build
+
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./android
+
+    permissions:
+      contents: read
     
     steps:
     - uses: actions/checkout@v4
@@ -58,16 +72,22 @@ jobs:
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-      working-directory: ./android
 
     - name: Run ktlintCheck
       run: ./gradlew ktlintCheck --stacktrace
-      working-directory: ./android
 
   test:
     name: Run Unit Tests
     runs-on: ubuntu-latest
     needs: build
+    
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./android
+
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@v4
@@ -81,11 +101,9 @@ jobs:
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-      working-directory: ./android
     
     - name: Run tests
       run: ./gradlew test --stacktrace
-      working-directory: ./android
     
     - name: Publish Unit Test Results
       uses: EnricoMi/publish-unit-test-result-action@v2


### PR DESCRIPTION
## Issues
- closed #이슈번호

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
working-directory 를 defaults 로 job 마다 설정

## 📷 Screenshot

## 📚 Reference
