### PR TITLE
[fix] db 예약어와 겹치는 테이블 필드명 수정

### DIFF
--- a/backend/src/main/java/turip/tripcourse/domain/TripCourse.java
+++ b/backend/src/main/java/turip/tripcourse/domain/TripCourse.java
@@ -22,9 +22,9 @@ public class TripCourse {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private int day;
+    private int visitDay;
 
-    private int order;
+    private int visitOrder;
 
     @OneToOne
     private Place place;


### PR DESCRIPTION
## Issues
- closed #48 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description

- 기존 TripCourse 엔티티의 order, day의 필드가 존재했는데, 예약어와 겹치기 때문에 테이블이 생성되지 않는 문제가 있어서 수정했습니다.

## 📷 Screenshot

## 📚 Reference
