### PR TITLE
[feat] 컨텐츠에 대한 부가 정보 조회 기능 구현

### DIFF
--- a/backend/src/main/java/turip/content/domain/Content.java
+++ b/backend/src/main/java/turip/content/domain/Content.java
@@ -44,7 +44,24 @@ public class Content {
 
     private LocalDate uploadedDate;
 
+    public Content(Creator creator, Region region, List<TripCourse> tripCourses, String title, String url,
+                   LocalDate uploadedDate) {
+        this.creator = creator;
+        this.region = region;
+        this.tripCourses = tripCourses;
+        this.title = title;
+        this.url = url;
+        this.uploadedDate = uploadedDate;
+    }
+
     public int getTripCourseCount() {
         return tripCourses.size();
+    }
+
+    public int getTripDurationDays() {
+        return tripCourses.stream()
+                .mapToInt(TripCourse::getVisitDay)
+                .max()
+                .orElse(0);
     }
 }

--- a/backend/src/main/java/turip/content/domain/Content.java
+++ b/backend/src/main/java/turip/content/domain/Content.java
@@ -43,4 +43,8 @@ public class Content {
     private String url;
 
     private LocalDate uploadedDate;
+
+    public int getTripCourseCount() {
+        return tripCourses.size();
+    }
 }

--- a/backend/src/main/java/turip/content/domain/Content.java
+++ b/backend/src/main/java/turip/content/domain/Content.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.time.LocalDate;
@@ -34,6 +35,7 @@ public class Content {
     private Region region;
 
     @OneToMany
+    @JoinColumn(name = "content_id")
     private List<TripCourse> tripCourses;
 
     private String title;

--- a/backend/src/main/java/turip/content/repository/ContentRepository.java
+++ b/backend/src/main/java/turip/content/repository/ContentRepository.java
@@ -1,4 +1,7 @@
 package turip.content.repository;
 
-public interface ContentRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import turip.content.domain.Content;
+
+public interface ContentRepository extends JpaRepository<Content, Long> {
 }

--- a/backend/src/main/java/turip/content/service/ContentService.java
+++ b/backend/src/main/java/turip/content/service/ContentService.java
@@ -20,4 +20,8 @@ public class ContentService {
     private int getTripCourseCount(Content content) {
         return content.getTripCourseCount();
     }
+
+    private int calculateDurationDays(Content content) {
+        return content.getTripDurationDays();
+    }
 }

--- a/backend/src/main/java/turip/content/service/ContentService.java
+++ b/backend/src/main/java/turip/content/service/ContentService.java
@@ -1,4 +1,23 @@
 package turip.content.service;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import turip.content.domain.Content;
+import turip.content.repository.ContentRepository;
+import turip.exception.NotFoundException;
+
+@Service
+@RequiredArgsConstructor
 public class ContentService {
+
+    private final ContentRepository contentRepository;
+
+    private Content getById(Long id) {
+        return contentRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("컨텐츠를 찾을 수 없습니다."));
+    }
+
+    private int getTripCourseCount(Content content) {
+        return content.getTripCourseCount();
+    }
 }

--- a/backend/src/main/java/turip/tripcourse/domain/TripCourse.java
+++ b/backend/src/main/java/turip/tripcourse/domain/TripCourse.java
@@ -28,4 +28,10 @@ public class TripCourse {
 
     @OneToOne
     private Place place;
+
+    public TripCourse(int visitDay, int visitOrder, Place place) {
+        this.visitDay = visitDay;
+        this.visitOrder = visitOrder;
+        this.place = place;
+    }
 }

--- a/backend/src/test/java/turip/content/domain/ContentTest.java
+++ b/backend/src/test/java/turip/content/domain/ContentTest.java
@@ -1,0 +1,34 @@
+package turip.content.domain;
+
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import turip.tripcourse.domain.TripCourse;
+
+class ContentTest {
+
+    @DisplayName("해당 컨텐츠 여행 일수를 확인할 수 있다")
+    @Test
+    void getTripDurationDays1() {
+        // given
+        TripCourse firstDayCourse = new TripCourse(1, 1, null);
+        TripCourse secondDayCourse = new TripCourse(2, 1, null);
+        Content content = new Content(null, null, List.of(firstDayCourse, secondDayCourse), null, null, null);
+
+        // when & then
+        Assertions.assertThat(content.getTripDurationDays())
+                .isEqualTo(2);
+    }
+
+    @DisplayName("해당 컨텐츠 여행 코스 정보가 존재하지 않는 경우, 여행 일수는 0을 반환한다")
+    @Test
+    void getTripDurationDays2() {
+        // given
+        Content content = new Content(null, null, List.of(), null, null, null);
+
+        // when & then
+        Assertions.assertThat(content.getTripDurationDays())
+                .isEqualTo(0);
+    }
+}


### PR DESCRIPTION
## Issues
- closed #53 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
- `Content`의 전체 코스 수 확인, 여행 일수 확인 기능 구현했습니다.

## 📷 Screenshot

## 📚 Reference
