### PR TITLE
[fix] Release 버전일 때 로깅 숨기도록 수정

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -34,14 +34,22 @@ android {
     }
 
     buildTypes {
-        release {
+        debug {
             isMinifyEnabled = false
+            isDebuggable = true
+            applicationIdSuffix = ".debug"
+        }
+
+        release {
+            isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
             )
+            signingConfig = signingConfigs.getByName("debug")
         }
     }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -38,6 +38,8 @@ android {
             isMinifyEnabled = false
             isDebuggable = true
             applicationIdSuffix = ".debug"
+            versionNameSuffix = ".debug"
+            manifestPlaceholders["appName"] = "튜립.debug"
         }
 
         release {
@@ -47,6 +49,7 @@ android {
                 "proguard-rules.pro",
             )
             signingConfig = signingConfigs.getByName("debug")
+            manifestPlaceholders["appName"] = "튜립"
         }
     }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_turip_launcher"
-        android:label="@string/app_name"
+        android:label="${appName}"
         android:roundIcon="@mipmap/ic_turip_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Turip"

--- a/android/app/src/main/java/com/on/turip/data/network/NetworkClient.kt
+++ b/android/app/src/main/java/com/on/turip/data/network/NetworkClient.kt
@@ -18,7 +18,12 @@ object NetworkClient {
             .Builder()
             .addInterceptor(
                 HttpLoggingInterceptor().apply {
-                    level = HttpLoggingInterceptor.Level.BODY
+                    level =
+                        if (BuildConfig.DEBUG) {
+                            HttpLoggingInterceptor.Level.BODY
+                        } else {
+                            HttpLoggingInterceptor.Level.NONE
+                        }
                 },
             ).build()
     }


### PR DESCRIPTION
## Issues
- closed #100 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
- 빌드 타입 설정을 변경하였습니다.
- release일 때 HttpLoggingInterceptor가 로그 기록이 안되도록 수정하였습니다.
- 빌드 타입 별로 앱 네이밍을 분기 처리 하였습니다.

## 📷 Screenshot

### DeBug 빌드
<img width="2774" height="672" alt="스크린샷 2025-07-29 오전 1 02 30 blur" src="https://github.com/user-attachments/assets/1bfee638-c0fe-48b9-a149-2b096f85f21e" />


### Release 빌드
<img width="1392" height="198" alt="스크린샷 2025-07-29 오전 1 02 55" src="https://github.com/user-attachments/assets/661dcad8-2664-4519-8ce5-f9cbad9f4893" />

### 앱 네이밍
<img width="159" height="103" alt="스크린샷 2025-07-29 오전 11 30 27" src="https://github.com/user-attachments/assets/e94969d8-09e9-4853-bb44-75206654c1dd" />


## 📚 Reference
https://developer.android.com/build/build-variants?hl=ko

https://medium.com/@brandjunhoe/build-type-debug-release-을-활용한-앱-빌드-구분하기-f323f34a6264