### PR TITLE
[feat] 유튜브 링크 변환 담당 객체

### DIFF
--- a/android/app/src/main/java/com/on/turip/ui/common/TuripUrlConverter.kt
+++ b/android/app/src/main/java/com/on/turip/ui/common/TuripUrlConverter.kt
@@ -1,0 +1,16 @@
+package com.on.turip.ui.common
+
+object TuripUrlConverter {
+    private const val VIDEO_ID_POSITION = 1
+
+    private object VideoRegex {
+        val patternVParam = "v=([a-zA-Z0-9_-]{11})(?:&|$)".toRegex()
+        val patternShortUrl = "youtu\\.be/([a-zA-Z0-9_-]{11})".toRegex()
+    }
+
+    fun extractVideoId(videoUrl: String): String {
+        val matches =
+            VideoRegex.patternVParam.find(videoUrl) ?: VideoRegex.patternShortUrl.find(videoUrl)
+        return matches?.groups?.get(VIDEO_ID_POSITION)?.value ?: ""
+    }
+}

--- a/android/app/src/main/java/com/on/turip/ui/common/TuripUrlConverter.kt
+++ b/android/app/src/main/java/com/on/turip/ui/common/TuripUrlConverter.kt
@@ -5,13 +5,14 @@ object TuripUrlConverter {
     private const val VIDEO_ID_POSITION: Int = 1
 
     private object VideoRegex {
-        val patternVParam: Regex = "v=([a-zA-Z0-9_-]{11})(?:&|$)".toRegex()
+        val patternVideoPath: Regex = "v=([a-zA-Z0-9_-]{11})(?:&|$)".toRegex()
         val patternShortUrl: Regex = "youtu\\.be/([a-zA-Z0-9_-]{11})".toRegex()
     }
 
     fun extractVideoId(videoUrl: String): String {
         val matches: MatchResult? =
-            VideoRegex.patternVParam.find(videoUrl) ?: VideoRegex.patternShortUrl.find(videoUrl)
+            VideoRegex.patternVideoPath.find(videoUrl)
+                ?: VideoRegex.patternShortUrl.find(videoUrl)
         return matches?.groups?.get(VIDEO_ID_POSITION)?.value ?: ""
     }
 

--- a/android/app/src/main/java/com/on/turip/ui/common/TuripUrlConverter.kt
+++ b/android/app/src/main/java/com/on/turip/ui/common/TuripUrlConverter.kt
@@ -1,22 +1,22 @@
 package com.on.turip.ui.common
 
 object TuripUrlConverter {
-    private const val YOUTUBE_VIDEO_THUMBNAIL_FORM = "https://img.youtube.com/vi/%s/0.jpg"
-    private const val VIDEO_ID_POSITION = 1
+    private const val YOUTUBE_VIDEO_THUMBNAIL_FORM: String = "https://img.youtube.com/vi/%s/0.jpg"
+    private const val VIDEO_ID_POSITION: Int = 1
 
     private object VideoRegex {
-        val patternVParam = "v=([a-zA-Z0-9_-]{11})(?:&|$)".toRegex()
-        val patternShortUrl = "youtu\\.be/([a-zA-Z0-9_-]{11})".toRegex()
+        val patternVParam: Regex = "v=([a-zA-Z0-9_-]{11})(?:&|$)".toRegex()
+        val patternShortUrl: Regex = "youtu\\.be/([a-zA-Z0-9_-]{11})".toRegex()
     }
 
     fun extractVideoId(videoUrl: String): String {
-        val matches =
+        val matches: MatchResult? =
             VideoRegex.patternVParam.find(videoUrl) ?: VideoRegex.patternShortUrl.find(videoUrl)
         return matches?.groups?.get(VIDEO_ID_POSITION)?.value ?: ""
     }
 
     fun toVideoThumbnailUrl(videoUrl: String): String {
-        val videoId = extractVideoId(videoUrl)
+        val videoId: String = extractVideoId(videoUrl)
         return YOUTUBE_VIDEO_THUMBNAIL_FORM.format(videoId)
     }
 }

--- a/android/app/src/main/java/com/on/turip/ui/common/TuripUrlConverter.kt
+++ b/android/app/src/main/java/com/on/turip/ui/common/TuripUrlConverter.kt
@@ -1,6 +1,7 @@
 package com.on.turip.ui.common
 
 object TuripUrlConverter {
+    private const val YOUTUBE_VIDEO_THUMBNAIL_FORM = "https://img.youtube.com/vi/%s/0.jpg"
     private const val VIDEO_ID_POSITION = 1
 
     private object VideoRegex {
@@ -12,5 +13,10 @@ object TuripUrlConverter {
         val matches =
             VideoRegex.patternVParam.find(videoUrl) ?: VideoRegex.patternShortUrl.find(videoUrl)
         return matches?.groups?.get(VIDEO_ID_POSITION)?.value ?: ""
+    }
+
+    fun toVideoThumbnailUrl(videoUrl: String): String {
+        val videoId = extractVideoId(videoUrl)
+        return YOUTUBE_VIDEO_THUMBNAIL_FORM.format(videoId)
     }
 }

--- a/android/app/src/main/java/com/on/turip/ui/common/TuripUrlConverter.kt
+++ b/android/app/src/main/java/com/on/turip/ui/common/TuripUrlConverter.kt
@@ -16,7 +16,7 @@ object TuripUrlConverter {
         return matches?.groups?.get(VIDEO_ID_POSITION)?.value ?: ""
     }
 
-    fun toVideoThumbnailUrl(videoUrl: String): String {
+    fun convertVideoThumbnailUrl(videoUrl: String): String {
         val videoId: String = extractVideoId(videoUrl)
         return YOUTUBE_VIDEO_THUMBNAIL_FORM.format(videoId)
     }

--- a/android/app/src/main/java/com/on/turip/ui/trip/detail/TripDetailActivity.kt
+++ b/android/app/src/main/java/com/on/turip/ui/trip/detail/TripDetailActivity.kt
@@ -15,13 +15,13 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import com.on.turip.R
 import com.on.turip.databinding.ActivityTripDetailBinding
+import com.on.turip.ui.common.TuripUrlConverter
 import com.on.turip.ui.common.base.BaseActivity
 import com.on.turip.ui.common.loadCircularImage
 import com.on.turip.ui.trip.detail.webview.TuripWebChromeClient
 import com.on.turip.ui.trip.detail.webview.TuripWebViewClient
 import com.on.turip.ui.trip.detail.webview.WebViewVideoBridge
 import com.on.turip.ui.trip.detail.webview.applyVideoSettings
-import com.on.turip.ui.trip.detail.webview.extractVideoId
 
 class TripDetailActivity : BaseActivity<TripDetailViewModel, ActivityTripDetailBinding>() {
     override val binding: ActivityTripDetailBinding by lazy {
@@ -196,7 +196,7 @@ class TripDetailActivity : BaseActivity<TripDetailViewModel, ActivityTripDetailB
             binding.wvTripDetailVideo.apply {
                 addJavascriptInterface(
                     WebViewVideoBridge(
-                        url.extractVideoId(),
+                        TuripUrlConverter.extractVideoId(url),
                     ) { showWebViewErrorView() },
                     BRIDGE_NAME_IN_JS_FILE,
                 )

--- a/android/app/src/main/java/com/on/turip/ui/trip/detail/webview/WebViewUtils.kt
+++ b/android/app/src/main/java/com/on/turip/ui/trip/detail/webview/WebViewUtils.kt
@@ -2,8 +2,6 @@ package com.on.turip.ui.trip.detail.webview
 
 import android.annotation.SuppressLint
 import android.webkit.WebView
-import com.on.turip.ui.trip.detail.webview.VideoRegex.patternShortUrl
-import com.on.turip.ui.trip.detail.webview.VideoRegex.patternVParam
 
 @SuppressLint("SetJavaScriptEnabled")
 fun WebView.applyVideoSettings() {
@@ -13,15 +11,3 @@ fun WebView.applyVideoSettings() {
         allowFileAccess = false
     }
 }
-
-private object VideoRegex {
-    val patternVParam = "v=([a-zA-Z0-9_-]{11})(?:&|$)".toRegex()
-    val patternShortUrl = "youtu\\.be/([a-zA-Z0-9_-]{11})".toRegex()
-}
-
-fun String.extractVideoId(): String {
-    val matches = patternVParam.find(this) ?: patternShortUrl.find(this)
-    return matches?.groups?.get(VIDEO_ID_POSITION)?.value ?: ""
-}
-
-private const val VIDEO_ID_POSITION = 1

--- a/android/app/src/test/java/com/on/turip/ui/common/TuripUrlConverterTest.kt
+++ b/android/app/src/test/java/com/on/turip/ui/common/TuripUrlConverterTest.kt
@@ -24,7 +24,7 @@ class TuripUrlConverterTest {
         val expected = "https://img.youtube.com/vi/PIVg1paYVX8/0.jpg"
 
         // when:
-        val actual = TuripUrlConverter.toVideoThumbnailUrl(youtubeUrl)
+        val actual = TuripUrlConverter.convertVideoThumbnailUrl(youtubeUrl)
 
         // then:
         assertThat(actual).isEqualTo(expected)

--- a/android/app/src/test/java/com/on/turip/ui/common/TuripUrlConverterTest.kt
+++ b/android/app/src/test/java/com/on/turip/ui/common/TuripUrlConverterTest.kt
@@ -1,0 +1,32 @@
+package com.on.turip.ui.common
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class TuripUrlConverterTest {
+    @Test
+    fun `유튜브 영상 url에서 videoId를 추출한다`() {
+        // given:
+        val youtubeUrl = "https://www.youtube.com/watch?v=PIVg1paYVX8"
+        val expected = "PIVg1paYVX8"
+
+        // when:
+        val actual = TuripUrlConverter.extractVideoId(youtubeUrl)
+
+        // then:
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `유튜브 영상 url에서 유튜브 영상 썸네일 url로 변환한다`() {
+        // given:
+        val youtubeUrl = "https://www.youtube.com/watch?v=PIVg1paYVX8"
+        val expected = "https://img.youtube.com/vi/PIVg1paYVX8/0.jpg"
+
+        // when:
+        val actual = TuripUrlConverter.toVideoThumbnailUrl(youtubeUrl)
+
+        // then:
+        assertThat(actual).isEqualTo(expected)
+    }
+}


### PR DESCRIPTION
## Issues
- closed #107

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
- `WebViewUtils`에서 사용하던 `videoId` 추출하던 기능을 `TuripUrlConverter` 객체 생성 후, 내부로 이동
- 영상 url 에서 videoId 추출하는 기능
- 영상 url 에서 영상 썸네일 url 로 변환하는 기능

## 📷 Screenshot

<img width="458" height="107" alt="스크린샷 2025-07-31 00 01 09" src="https://github.com/user-attachments/assets/91a3e63a-66b1-47fe-8c28-ae9a7c94b364" />


## 📚 Reference
