### PR TITLE
[feat] 컨텐츠, 찜 여부 조회 API 구현

### DIFF
--- a/backend/src/main/java/turip/content/controller/ContentController.java
+++ b/backend/src/main/java/turip/content/controller/ContentController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -37,9 +38,12 @@ public class ContentController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<ContentResponse> readContent(@PathVariable Long id) {
-        ContentResponse response = contentService.getById(id);
+    @GetMapping("/{contentId}")
+    public ResponseEntity<ContentResponse> readContent(
+            @RequestHeader(value = "device-fid", required = false) String deviceFid,
+            @PathVariable Long contentId
+    ) {
+        ContentResponse response = contentService.getContentWithFavoriteStatus(contentId, deviceFid);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/turip/content/controller/dto/response/ContentResponse.java
+++ b/backend/src/main/java/turip/content/controller/dto/response/ContentResponse.java
@@ -9,16 +9,18 @@ public record ContentResponse(
         Long cityId,
         String title,
         String url,
-        LocalDate uploadedDate
+        LocalDate uploadedDate,
+        boolean isFavorite
 ) {
-    public static ContentResponse from(Content content) {
+    public static ContentResponse of(Content content, boolean isFavorite) {
         return new ContentResponse(
                 content.getId(),
                 content.getCreator().getId(),
                 content.getCity().getId(),
                 content.getTitle(),
                 content.getUrl(),
-                content.getUploadedDate()
+                content.getUploadedDate(),
+                isFavorite
         );
     }
 }

--- a/backend/src/main/java/turip/favorite/controller/dto/response/FavoriteResponse.java
+++ b/backend/src/main/java/turip/favorite/controller/dto/response/FavoriteResponse.java
@@ -16,7 +16,7 @@ public record FavoriteResponse(
                 favorite.getId(),
                 favorite.getCreatedAt(),
                 favorite.getMember().getId(),
-                ContentResponse.from(favorite.getContent())
+                ContentResponse.of(favorite.getContent(), true)
         );
     }
 }

--- a/backend/src/test/java/turip/content/api/ContentApiTest.java
+++ b/backend/src/test/java/turip/content/api/ContentApiTest.java
@@ -34,6 +34,8 @@ public class ContentApiTest {
         jdbcTemplate.update("DELETE FROM city");
         jdbcTemplate.update("DELETE FROM country");
         jdbcTemplate.update("DELETE FROM province");
+        jdbcTemplate.update("DELETE FROM favorite");
+        jdbcTemplate.update("DELETE FROM member");
 
         jdbcTemplate.update("ALTER TABLE trip_course ALTER COLUMN id RESTART WITH 1");
         jdbcTemplate.update("ALTER TABLE place ALTER COLUMN id RESTART WITH 1");
@@ -44,6 +46,8 @@ public class ContentApiTest {
         jdbcTemplate.update("ALTER TABLE province ALTER COLUMN id RESTART WITH 1");
         jdbcTemplate.update("ALTER TABLE category ALTER COLUMN id RESTART WITH 1");
         jdbcTemplate.update("ALTER TABLE place_category ALTER COLUMN id RESTART WITH 1");
+        jdbcTemplate.update("ALTER TABLE favorite ALTER COLUMN id RESTART WITH 1");
+        jdbcTemplate.update("ALTER TABLE member ALTER COLUMN id RESTART WITH 1");
     }
 
     @DisplayName("/contents/count GET 컨텐츠 수 조회 테스트")
@@ -73,20 +77,20 @@ public class ContentApiTest {
         }
     }
 
-    @DisplayName("/contents/{id} GET 컨텐츠 단건 조회 테스트")
+    @DisplayName("/contents/{contentId} GET 컨텐츠 단건 조회 테스트")
     @Nested
-    class readContentById {
-        @DisplayName("id로 컨텐츠 단건 조회 성공 시 200 OK 코드와 컨텐츠 정보를 응답한다")
+    class readContent {
+        @DisplayName("contentId로 컨텐츠 단건 조회 성공 시 200 OK 코드와 컨텐츠 정보를 응답한다")
         @Test
         void readContentById() {
             // given
             jdbcTemplate.update(
-                    "INSERT INTO Creator (profile_image, channel_name) VALUES (?, ?)",
+                    "INSERT INTO creator (profile_image, channel_name) VALUES (?, ?)",
                     "https://image.example.com/creator1.jpg", "TravelMate");
             jdbcTemplate.update("INSERT INTO country (name) VALUES ('korea')");
             jdbcTemplate.update("INSERT INTO city (name, country_id) VALUES ('seoul', 1)");
             jdbcTemplate.update(
-                    "INSERT INTO Content (creator_id, city_id, url, title, uploaded_date) VALUES (?, ?, ?, ?, ?)",
+                    "INSERT INTO content (creator_id, city_id, url, title, uploaded_date) VALUES (?, ?, ?, ?, ?)",
                     1, 1, "https://youtube.com/watch?v=abcd1", "서울 데이트 코스 추천", "2024-07-01");
 
             // when & then
@@ -99,7 +103,40 @@ public class ContentApiTest {
                     .body("cityId", is(1))
                     .body("title", is("서울 데이트 코스 추천"))
                     .body("url", is("https://youtube.com/watch?v=abcd1"))
-                    .body("uploadedDate", is("2024-07-01"));
+                    .body("uploadedDate", is("2024-07-01"))
+                    .body("isFavorite", is(false));
+        }
+
+        @DisplayName("device-fid 헤더가 존재하며 찜이 되어 있는 경우 isFavorite이 true로 응답된다")
+        @Test
+        void readContentById_withDeviceFidHeader() {
+            // given
+            jdbcTemplate.update(
+                    "INSERT INTO creator (profile_image, channel_name) VALUES (?, ?)",
+                    "https://image.example.com/creator1.jpg", "TravelMate");
+            jdbcTemplate.update("INSERT INTO country (name) VALUES ('korea')");
+            jdbcTemplate.update("INSERT INTO city (name, country_id) VALUES ('seoul', 1)");
+            jdbcTemplate.update(
+                    "INSERT INTO content (creator_id, city_id, url, title, uploaded_date) VALUES (?, ?, ?, ?, ?)",
+                    1, 1, "https://youtube.com/watch?v=abcd1", "서울 데이트 코스 추천", "2024-07-01");
+            jdbcTemplate.update(
+                    "INSERT INTO member (device_fid) VALUES (?)", "testDeviceFid");
+            jdbcTemplate.update(
+                    "INSERT INTO favorite (member_id, content_id) VALUES (?, ?)", 1, 1);
+
+            // when & then
+            RestAssured.given().port(port)
+                    .header("device-fid", "testDeviceFid")
+                    .when().get("/contents/{id}", 1)
+                    .then()
+                    .statusCode(200)
+                    .body("id", is(1))
+                    .body("creatorId", is(1))
+                    .body("cityId", is(1))
+                    .body("title", is("서울 데이트 코스 추천"))
+                    .body("url", is("https://youtube.com/watch?v=abcd1"))
+                    .body("uploadedDate", is("2024-07-01"))
+                    .body("isFavorite", is(true));
         }
     }
 }


### PR DESCRIPTION
## Issues
- closed #131 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
- 컨텐츠, 찜 여부 조회 API 구현
- 기존에 컨텐츠만 조회하던 API에 찜 여부를 함께 응답하도록 변경했습니다.
## 📷 Screenshot

## 📚 Reference
