### PR TITLE
[fix] 디버깅 로그 d 레벨로 찍히는 이슈 해결

### DIFF
--- a/android/app/src/main/java/com/on/turip/common/TuripDebugTree.kt
+++ b/android/app/src/main/java/com/on/turip/common/TuripDebugTree.kt
@@ -3,10 +3,12 @@ package com.on.turip.common
 import timber.log.Timber
 
 class TuripDebugTree : Timber.DebugTree() {
-    override fun createStackElementTag(element: StackTraceElement): String =
-        "$DEBUG_LOG_PREFIX ${element.className}:${element.lineNumber}#${element.methodName}"
+    override fun createStackElementTag(element: StackTraceElement): String {
+        val simpleClass: String = element.className.substringAfterLast('.')
+        return "$DEBUG_LOG_PREFIX $simpleClass:${element.lineNumber}#${element.methodName}"
+    }
 
     companion object {
-        private const val DEBUG_LOG_PREFIX = "moongjenut"
+        private const val DEBUG_LOG_PREFIX = "MJC"
     }
 }


### PR DESCRIPTION
## Issues
- closed #179

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
- error 레벨 로그가 debug 레벨로 찍히는 현상을 해결했습니다. 
- 이유는 안드로이드에서는 tag 길이를 23으로 제한하고 있는데 그것보다 훨씬 길어서 나타난 이슈였습니다 ㅠ

<img width="892" height="152" alt="스크린샷 2025-08-08 오전 1 18 07" src="https://github.com/user-attachments/assets/4e972718-67fe-4393-8972-b8fe8b4548b7" />

## 📷 Screenshot
<img width="1061" height="55" alt="스크린샷 2025-08-08 오전 1 15 36" src="https://github.com/user-attachments/assets/2af6301e-e369-441f-a033-37ebdf0589d3" />


## 📚 Reference
[ 안드로이드 로그 공식문서](https://developer.android.com/reference/android/util/Log#isLoggable(java.lang.String,%20int))