### PR TITLE
[feat] 잘못된 경로 요청에 대한 응답 코드 수정

### DIFF
--- a/backend/src/main/java/turip/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/turip/exception/GlobalExceptionHandler.java
@@ -25,10 +25,8 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponse(e.getMessage()));
     }
 
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleNotCaughtExceptions(
-            final Exception e
-    ) {
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ErrorResponse> handleNotCaughtExceptions(final RuntimeException e) {
         log.error(e.getMessage());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(new ErrorResponse("서버에서 예기치 못한 예외가 발생하였습니다."));

--- a/backend/src/main/java/turip/log/LoggingInterceptor.java
+++ b/backend/src/main/java/turip/log/LoggingInterceptor.java
@@ -19,6 +19,10 @@ public class LoggingInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
             throws Exception {
+
+        if ("/error".equals(request.getRequestURI())) {
+            return true;
+        }
         String traceId = UUID.randomUUID().toString().substring(0, 8);
 
         request.setAttribute(REQUEST_ID_ATTRIBUTE, traceId);


### PR DESCRIPTION
## Issues
- closed #194 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description

- 핸들러 메서드가 Exception이 아닌 RuntimeException을 잡도록 수정
- /error 엔드포인트에 대해 로그를 남기지 않도록 수정

컨트롤러에 없는 uri로 요청이 오는 경우 DispatcherServlet에 의해 `ServletException`이 발생한다고 해요. 그런데 이 ServletException은 Exception을 상속받기 때문에, 아래 핸들러 메서드에서 잡혀서 500이 내려지는 상황입니다.

```java
@ExceptionHandler(**Exception**.class)
public ResponseEntity<ErrorResponse> handleNotCaughtExceptions(final Exception e) {
    log.error(e.getMessage());
    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
            .body(new ErrorResponse("서버에서 예기치 못한 예외가 발생하였습니다."));
}
```

제가 이 핸들러 메서드를 작성한 의도는, 예기치 못한 예외의 경우 500을 내려줘야 한다고 생각했기 때문이에요. DispatcherServlet이 처리하는 ServletException은 잡지 않으면서도, 예기치 못한 예외상황에 500을 내려준다는 의미를 유지하기 위해서, 핸들러가 **Exception이 아닌 RuntimeException을 잡도록** 수정했어요.

```java
@ExceptionHandler(**RuntimeException**.class)
public ResponseEntity<ErrorResponse> handleNotCaughtExceptions(final RuntimeException e) {
    log.error(e.getMessage());
    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
            .body(new ErrorResponse("서버에서 예기치 못한 예외가 발생하였습니다."));
}
```

이를 통해 예기치 못한 예외(언체크 예외)는 잡아서 500을 내려준다는 의미도 유지하고, DispatcherServlet이 알아서 처리하는 에러 상황(컨트롤러에 없는 uri로 요청이 온 경우 등)은 잡히지 않아요! 

근데 이렇게 설정하면 다시 /error 엔드포인트에 대한 로그가 뜨더라구요. 

```java
{"timestamp":"2025-08-08 01:31:59.796","level":"INFO","message":"API 요청","traceId":"62e9841c","userAgent":"PostmanRuntime/7.45.0","method":"GET","uri":"/region-categoriess","remoteAddr":"0:0:0:0:0:0:0:1"}
{"timestamp":"2025-08-08 01:31:59.803","level":"INFO","message":"API 응답","traceId":"62e9841c","duration":"7ms","method":"GET","httpStatus":"404","userAgent":"PostmanRuntime/7.45.0","uri":"/region-categoriess","remoteAddr":"0:0:0:0:0:0:0:1"}
{"timestamp":"2025-08-08 01:31:59.808","level":"INFO","message":"API 요청","traceId":"cd3e37a6","userAgent":"PostmanRuntime/7.45.0","method":"GET","uri":"**/error**","remoteAddr":"0:0:0:0:0:0:0:1"}
{"timestamp":"2025-08-08 01:31:59.856","level":"INFO","message":"API 응답","traceId":"cd3e37a6","duration":"49ms","method":"GET","httpStatus":"404","userAgent":"PostmanRuntime/7.45.0","uri":"**/error**","remoteAddr":"0:0:0:0:0:0:0:1"}
```

핸들러에서 안 잡히니까 서블릿이 에러를 처리하는 과정(/error로 포워딩)이 진행되기 때문인데, /error에 대한 로그는 찍지 않도록 interceptor에 조건문 코드를 추가했습니다!

## 📷 Screenshot

## 📚 Reference
