### PR TITLE
[feat] 지역 검색 결과 로딩 화면 수정

### DIFF
--- a/android/app/src/main/java/com/on/turip/ui/search/regionresult/RegionResultActivity.kt
+++ b/android/app/src/main/java/com/on/turip/ui/search/regionresult/RegionResultActivity.kt
@@ -79,11 +79,11 @@ class RegionResultActivity : BaseActivity<ActivityRegionResultBinding>() {
 
             regionResultAdapter.submitList(searchResultState.videoInformations)
 
-            setupVisible(searchResultState)
+            handleVisibility(searchResultState)
         }
     }
 
-    private fun setupVisible(searchResultState: RegionResultViewModel.SearchResultState) {
+    private fun handleVisibility(searchResultState: RegionResultViewModel.SearchResultState) {
         when (searchResultState.loading) {
             true -> {
                 binding.pbSearchRegionResult.visibility = View.VISIBLE

--- a/android/app/src/main/java/com/on/turip/ui/search/regionresult/RegionResultActivity.kt
+++ b/android/app/src/main/java/com/on/turip/ui/search/regionresult/RegionResultActivity.kt
@@ -84,14 +84,27 @@ class RegionResultActivity : BaseActivity<ActivityRegionResultBinding>() {
     }
 
     private fun setupVisible(searchResultState: RegionResultViewModel.SearchResultState) {
-        binding.rvRegionResult.visibility =
-            if (searchResultState.isExist) View.VISIBLE else View.GONE
+        when (searchResultState.loading) {
+            true -> {
+                binding.pbSearchRegionResult.visibility = View.VISIBLE
+                binding.groupRegionResultEmpty.visibility = View.GONE
+                binding.tvRegionResultCount.visibility = View.GONE
+                binding.rvRegionResult.visibility = View.GONE
+            }
 
-        binding.groupRegionResultEmpty.visibility =
-            if (searchResultState.isExist) View.GONE else View.VISIBLE
-
-        binding.tvRegionResultLoading.visibility =
-            if (searchResultState.loading) View.VISIBLE else View.GONE
+            false -> {
+                binding.pbSearchRegionResult.visibility = View.GONE
+                if (searchResultState.isExist) {
+                    binding.groupRegionResultEmpty.visibility = View.GONE
+                    binding.tvRegionResultCount.visibility = View.VISIBLE
+                    binding.rvRegionResult.visibility = View.VISIBLE
+                } else {
+                    binding.groupRegionResultEmpty.visibility = View.VISIBLE
+                    binding.tvRegionResultCount.visibility = View.GONE
+                    binding.rvRegionResult.visibility = View.GONE
+                }
+            }
+        }
     }
 
     companion object {

--- a/android/app/src/main/res/layout/activity_region_result.xml
+++ b/android/app/src/main/res/layout/activity_region_result.xml
@@ -35,11 +35,11 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_marginTop="14dp"
-        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         android:orientation="vertical"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/tv_region_result_count"
-        app:layout_constraintBottom_toBottomOf="parent"
         tools:itemCount="10"
         tools:listitem="@layout/item_result" />
 
@@ -75,13 +75,15 @@
         android:visibility="gone"
         app:constraint_referenced_ids="iv_region_result_empty,tv_region_result_empty" />
 
-    <TextView
-        android:id="@+id/tv_region_result_loading"
+    <ProgressBar
+        android:id="@+id/pb_search_region_result"
+        style="?android:attr/progressBarStyleLarge"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:text="@string/all_loading"
-        android:gravity="center"
-        android:textColor="@color/pure_black_151515"
-        android:textAppearance="@style/display"
-        android:background="@color/pure_white_ffffff" />
+        android:layout_height="wrap_content"
+        android:background="@color/pure_white_ffffff"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Issues
- closed #290

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
- 기존 로딩 중일 때 `로딩중` 텍스트가 뜨던 것을 프로그래스 바로 수정했습니다.

## 📷 Screenshot
[로딩 개선.webm](https://github.com/user-attachments/assets/62ce360d-dc3e-4b63-8f49-c5b653611dcf)



## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 검색 결과 개수 표시를 추가했습니다.
* 리팩터링
  * 화면 가시성을 단일 상태(loading + 결과 존재 여부)로 통합해 제어합니다.
  * 로딩 중에는 중앙에 대형 프로그레스바를 표시하고, 로딩 해제 후 결과가 있으면 목록과 개수를, 없으면 빈 화면을 노출합니다.
  * 레이아웃 제약을 정리해 목록의 상·하 고정을 유지했습니다.
  * 퍼블릭 API 변경 사항은 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->