### PR TITLE
[feat] 헬스 체크를 위한 actuator 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
     implementation 'org.flywaydb:flyway-core'

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -30,6 +30,11 @@ spring:
     baseline-on-migrate: true
     validate-on-migrate: true
     encoding: UTF-8
+    
+management:
+  endpoint:
+    health:
+      show-details: always
 
 # CSV Import 설정
 csv:

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -30,7 +30,7 @@ spring:
     baseline-on-migrate: true
     validate-on-migrate: true
     encoding: UTF-8
-    
+
 management:
   endpoint:
     health:


### PR DESCRIPTION
## Issues
- closed #257 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
의존성만 추가해주면 /actuator/health 는 기본으로 제공된다고 하네요. 상황별 응답은 아래와 같습니다!

- 스프링 애플리케이션이 정상적으로 떠있는 경우 응답
```json
{
    "status": "UP"
}
```
  - 앱은 떠있지만 문제있는 경우(ex. db 연결실패)
```json
{
    "status": "DOWN"
}
```
  - 스프링 안 뜬 경우 그냥 요청 자체가 실패
  
---

또한 detail한 내용을 응답하도록 설정할 수 있는데, 현재 디스크 상태와, 다양한 헬스 체크 대상에 대해 독립적인 헬스 체크 결과를 확인할 수 있었어요.

```json
{
    "status": "UP",
    "components": {
        "db": {
            "status": "UP",
            "details": {
                "database": "H2",
                "validationQuery": "isValid()"
            }
        },
        "diskSpace": {
            "status": "UP",
            "details": {
                "total": 494384795648,
                "free": 182736826368,
                "threshold": 10485760,
                "path": "~~",
                "exists": true
            }
        },
        "ping": {
            "status": "UP"
        },
        "ssl": {
            "status": "UP",
            "details": {
                "validChains": [],
                "invalidChains": []
            }
        }
    }
}
```

유용하긴 한데, 운영 환경에서는 서버의 자세한 상태를 확인하는 api를 공개해두는 것이 보안상 좋지 않을 것 같아서, 나중에 spring security를 도입한 후 이용하면 좋을 것 같다고 생각했어요. 그래서 일단 개발 환경에만 설정해두었습니다!

[feat: 개발 환경에서 actuator 헬스 체크 상세 정보 확인 기능 추가](https://github.com/woowacourse-teams/2025-Turip/pull/295/commits/03fb3f64be70e241af91dfca45cfd57b95239196)

## 📷 Screenshot

## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 운영 및 모니터링 엔드포인트(Health, Metrics, Info 등)가 활성화되었습니다. (환경 설정에 따라 접근 권한 및 노출 범위가 적용됩니다.)
  * 개발 환경에서 상태 응답의 상세 정보가 항상 표시되도록 변경되었습니다(진단 시 더 상세한 헬스 정보 제공).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->