### PR TITLE
[feat] Android CD 적용

### DIFF
--- a/.github/workflows/android-cd.yml
+++ b/.github/workflows/android-cd.yml
@@ -84,13 +84,13 @@ jobs:
         if: ${{ success() }}
         run: |
           curl -H "Content-Type: application/json" \
-            -d '{"username": "Plantory Android", "content": "✅ Plantory Android PR Check Success 🎉"}' \
+            -d '{"username": "Turip Android", "content": "✅ Turip Android PR Check Success 🎉"}' \
             ${{ secrets.DISCORD_WEBHOOK_URL }}
 
       - name: If Fail, Send notification on Discord
         if: ${{ failure() }}
         run: |
           curl -H "Content-Type: application/json" \
-            -d '{"username": "Plantory Android", "content": "❌ Plantory Android PR Check Failure - Please Check!"}' \
+            -d '{"username": "Turip Android", "content": "❌ Turip Android PR Check Failure - Please Check!"}' \
             ${{ secrets.DISCORD_WEBHOOK_URL }}
 

--- a/.github/workflows/android-cd.yml
+++ b/.github/workflows/android-cd.yml
@@ -8,7 +8,8 @@ env:
 # release 브랜치에 PR을 올릴 시 트리거
 on:
   pull_request:
-    branches: ["test" ]
+    branches:
+      - "release/*"
     paths:
       - "android/**"
 

--- a/.github/workflows/android-cd.yml
+++ b/.github/workflows/android-cd.yml
@@ -1,0 +1,95 @@
+name: Android CD
+
+# JVM 옵션을 설정, 최대 힙 메모리를 4GB로
+env:
+  GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+  GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: true
+
+# release 브랜치에 PR을 올릴 시 트리거
+on:
+  pull_request:
+    branches: ["test" ]
+    paths:
+      - "android/**"
+
+# 전체 워크플로우에 대한 권한 설정
+permissions:
+  contents: write
+
+jobs:
+  cd-build:
+    name: Build & Release APK/AAB
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./android
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Create local.properties
+        run: |
+          echo "base_url=${{ secrets.BASE_URL }}" > local.properties
+          echo "keyAlias=${{ secrets.KEY_ALIAS }}" >> local.properties
+          echo "keyPassword=${{ secrets.KEY_PASSWORD }}" >> local.properties
+          echo "storePassword=${{ secrets.STORE_PASSWORD }}" >> local.properties
+
+      - name: Write google-services.json for release
+        run: |
+          mkdir -p ./app
+          echo '${{ secrets.GOOGLE_SERVICES_JSON_RELEASE }}' > ./app/google-services.json
+
+      - name: Generate Keystore
+        run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > ./app/release-keystore.jks
+
+      - name: Build Release AAB
+        run: ./gradlew bundleRelease --stacktrace
+
+      - name: Build Release APK
+        run: ./gradlew assembleRelease --stacktrace
+
+      - name: Upload Release Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-release-builds
+          path: |
+            android/app/build/outputs/bundle/release/app-release.aab
+            android/app/build/outputs/apk/release/app-release.apk
+          if-no-files-found: error
+
+      - name: Upload APK to Firebase App Distribution
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        with:
+          appId: ${{ secrets.FIREBASE_APP_ID }}
+          serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
+          groups: testers
+          file: android/app/build/outputs/apk/release/app-release.apk
+
+      - name: If Success, Send notification on Discord
+        if: ${{ success() }}
+        run: |
+          curl -H "Content-Type: application/json" \
+            -d '{"username": "Plantory Android", "content": "✅ Plantory Android PR Check Success 🎉"}' \
+            ${{ secrets.DISCORD_WEBHOOK_URL }}
+
+      - name: If Fail, Send notification on Discord
+        if: ${{ failure() }}
+        run: |
+          curl -H "Content-Type: application/json" \
+            -d '{"username": "Plantory Android", "content": "❌ Plantory Android PR Check Failure - Please Check!"}' \
+            ${{ secrets.DISCORD_WEBHOOK_URL }}
+


### PR DESCRIPTION
## Issues
- closed #266 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
- release/# 으로 시작하는 브랜치로 pr을 날리고 android에서 변경사항이 생기면 android-cd가 시작됩니다.
- CD가 돌면서 APK와 AAB를 생성하고 그 중 APK파일만 Firebase App Distribution 로 APK 업로드 및 Artifacts 에 저장을 하게 됩니다.
- 성공 및 실패 여부를 웹훅을 통해 알려줍니다.
## 📷 Screenshot
### 테스터들에게 이메일을 통해 자동 배포
<img width="974" height="413" alt="스크린샷 2025-08-20 오전 12 46 45" src="https://github.com/user-attachments/assets/875c1902-8a83-43d8-8054-47d4f05417a5" />

### 웹훅을 통한 성공 및 실패 여부 확인
<img width="461" height="226" alt="스크린샷 2025-08-20 오전 12 47 06" src="https://github.com/user-attachments/assets/99ce2ecd-b7ce-41f9-a618-65f6c02abcb2" />

### Artifacts로 나온 APK
<img width="2324" height="404" alt="제목 없는 디자인-5" src="https://github.com/user-attachments/assets/824fad07-3be0-4614-8bf8-50d85dfb9eb3" />

## 📚 Reference
[웹훅 연결 하는 법](https://sxunea.tistory.com/entry/Android-안드로이드-앱-CI-CD-적용하기-with-Github-Actions-1-CI-적용)
[CD 코드 작성](https://sxunea.tistory.com/entry/Android-안드로이드-앱-CI-CD-적용하기-with-Github-Actions-2-CD-적용?category=1190875)
