### PR TITLE
[feat] 장소 찜 폴더 목록, 장소 찜 여부 조회 api 연결

### DIFF
--- a/android/app/src/main/java/com/on/turip/data/content/place/ContentPlaceMapper.kt
+++ b/android/app/src/main/java/com/on/turip/data/content/place/ContentPlaceMapper.kt
@@ -9,7 +9,6 @@ import com.on.turip.domain.trip.ContentPlace
 import com.on.turip.domain.trip.Place
 import com.on.turip.domain.trip.Trip
 import com.on.turip.domain.trip.TripDuration
-import kotlin.collections.map
 
 fun ContentPlacesResponse.toDomain(): Trip =
     Trip(
@@ -31,6 +30,7 @@ fun ContentPlaceResponse.toDomain(): ContentPlace =
         visitOrder = visitOrder,
         place = place.toDomain(),
         timeLine = timeLine,
+        isFavoritePlace = isFavoritePlace,
     )
 
 fun PlaceResponse.toDomain(): Place =

--- a/android/app/src/main/java/com/on/turip/data/content/place/dto/ContentPlaceResponse.kt
+++ b/android/app/src/main/java/com/on/turip/data/content/place/dto/ContentPlaceResponse.kt
@@ -15,4 +15,6 @@ data class ContentPlaceResponse(
     val visitOrder: Int,
     @SerialName("timeLine")
     val timeLine: String,
+    @SerialName("isFavoritePlace")
+    val isFavoritePlace: Boolean,
 )

--- a/android/app/src/main/java/com/on/turip/data/favorite/service/FavoriteService.kt
+++ b/android/app/src/main/java/com/on/turip/data/favorite/service/FavoriteService.kt
@@ -10,17 +10,17 @@ import retrofit2.http.POST
 import retrofit2.http.Query
 
 interface FavoriteService {
-    @POST("favorites")
+    @POST("favorite-contents")
     suspend fun postFavorite(
         @Body favoriteAddRequest: FavoriteAddRequest,
     ): Response<Unit>
 
-    @DELETE("favorites")
+    @DELETE("favorite-contents")
     suspend fun deleteFavorite(
         @Query("contentId") contentId: Long,
     ): Response<Unit>
 
-    @GET("favorites")
+    @GET("favorite-contents")
     suspend fun getFavoriteContents(
         @Query("size") size: Int,
         @Query("lastId") lastId: Long,

--- a/android/app/src/main/java/com/on/turip/data/folder/FolderMapper.kt
+++ b/android/app/src/main/java/com/on/turip/data/folder/FolderMapper.kt
@@ -3,7 +3,10 @@ package com.on.turip.data.folder
 import com.on.turip.data.folder.dto.FavoriteFolderAddRequest
 import com.on.turip.data.folder.dto.FavoriteFolderPatchRequest
 import com.on.turip.data.folder.dto.FavoriteFolderResponse
+import com.on.turip.data.folder.dto.FavoriteFolderStatusByPlaceResponse
 import com.on.turip.data.folder.dto.FavoriteFoldersResponse
+import com.on.turip.data.folder.dto.FavoriteFoldersStatusByPlaceResponse
+import com.on.turip.domain.folder.FavoriteFolder
 import com.on.turip.domain.folder.Folder
 
 fun FavoriteFoldersResponse.toDomain(): List<Folder> = favoriteFolderResponses.map { it.toDomain() }
@@ -19,3 +22,13 @@ fun FavoriteFolderResponse.toDomain(): Folder =
 fun String.toAddRequestDto(): FavoriteFolderAddRequest = FavoriteFolderAddRequest(name = this)
 
 fun String.toPatchRequestDto(): FavoriteFolderPatchRequest = FavoriteFolderPatchRequest(name = this)
+
+fun FavoriteFoldersStatusByPlaceResponse.toDomain(): List<FavoriteFolder> = favoriteFolders.map { it.toDomain() }
+
+fun FavoriteFolderStatusByPlaceResponse.toDomain(): FavoriteFolder =
+    FavoriteFolder(
+        id = id,
+        name = name,
+        isDefault = isDefault,
+        isFavorite = isFavoritePlace,
+    )

--- a/android/app/src/main/java/com/on/turip/data/folder/datasource/DefaultFolderRemoteDataSource.kt
+++ b/android/app/src/main/java/com/on/turip/data/folder/datasource/DefaultFolderRemoteDataSource.kt
@@ -7,9 +7,9 @@ import com.on.turip.data.folder.dto.FavoriteFolderPatchRequest
 import com.on.turip.data.folder.dto.FavoriteFoldersResponse
 import com.on.turip.data.folder.dto.FavoriteFoldersStatusByPlaceResponse
 import com.on.turip.data.folder.service.FolderService
-import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
 
 class DefaultFolderRemoteDataSource(
     private val folderService: FolderService,

--- a/android/app/src/main/java/com/on/turip/data/folder/datasource/DefaultFolderRemoteDataSource.kt
+++ b/android/app/src/main/java/com/on/turip/data/folder/datasource/DefaultFolderRemoteDataSource.kt
@@ -5,10 +5,11 @@ import com.on.turip.data.common.safeApiCall
 import com.on.turip.data.folder.dto.FavoriteFolderAddRequest
 import com.on.turip.data.folder.dto.FavoriteFolderPatchRequest
 import com.on.turip.data.folder.dto.FavoriteFoldersResponse
+import com.on.turip.data.folder.dto.FavoriteFoldersStatusByPlaceResponse
 import com.on.turip.data.folder.service.FolderService
+import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlin.coroutines.CoroutineContext
 
 class DefaultFolderRemoteDataSource(
     private val folderService: FolderService,
@@ -42,6 +43,13 @@ class DefaultFolderRemoteDataSource(
         withContext(coroutineContext) {
             safeApiCall {
                 folderService.deleteFavoriteFolder(folderId)
+            }
+        }
+
+    override suspend fun getFavoriteFoldersStatusByPlaceId(placeId: Long): TuripCustomResult<FavoriteFoldersStatusByPlaceResponse> =
+        withContext(coroutineContext) {
+            safeApiCall {
+                folderService.getFavoriteFoldersStatusByPlaceId(placeId)
             }
         }
 }

--- a/android/app/src/main/java/com/on/turip/data/folder/datasource/FolderRemoteDataSource.kt
+++ b/android/app/src/main/java/com/on/turip/data/folder/datasource/FolderRemoteDataSource.kt
@@ -4,6 +4,7 @@ import com.on.turip.data.common.TuripCustomResult
 import com.on.turip.data.folder.dto.FavoriteFolderAddRequest
 import com.on.turip.data.folder.dto.FavoriteFolderPatchRequest
 import com.on.turip.data.folder.dto.FavoriteFoldersResponse
+import com.on.turip.data.folder.dto.FavoriteFoldersStatusByPlaceResponse
 
 interface FolderRemoteDataSource {
     suspend fun getFavoriteFolders(): TuripCustomResult<FavoriteFoldersResponse>
@@ -16,4 +17,6 @@ interface FolderRemoteDataSource {
     ): TuripCustomResult<Unit>
 
     suspend fun deleteFavoriteFolder(folderId: Long): TuripCustomResult<Unit>
+
+    suspend fun getFavoriteFoldersStatusByPlaceId(placeId: Long): TuripCustomResult<FavoriteFoldersStatusByPlaceResponse>
 }

--- a/android/app/src/main/java/com/on/turip/data/folder/dto/FavoriteFolderStatusByPlaceResponse.kt
+++ b/android/app/src/main/java/com/on/turip/data/folder/dto/FavoriteFolderStatusByPlaceResponse.kt
@@ -1,0 +1,18 @@
+package com.on.turip.data.folder.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FavoriteFolderStatusByPlaceResponse(
+    @SerialName("id")
+    val id: Long,
+    @SerialName("isDefault")
+    val isDefault: Boolean,
+    @SerialName("isFavoritePlace")
+    val isFavoritePlace: Boolean,
+    @SerialName("memberId")
+    val memberId: Long,
+    @SerialName("name")
+    val name: String,
+)

--- a/android/app/src/main/java/com/on/turip/data/folder/dto/FavoriteFoldersStatusByPlaceResponse.kt
+++ b/android/app/src/main/java/com/on/turip/data/folder/dto/FavoriteFoldersStatusByPlaceResponse.kt
@@ -1,0 +1,10 @@
+package com.on.turip.data.folder.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FavoriteFoldersStatusByPlaceResponse(
+    @SerialName("favoriteFolders")
+    val favoriteFolders: List<FavoriteFolderStatusByPlaceResponse>,
+)

--- a/android/app/src/main/java/com/on/turip/data/folder/repository/DefaultFolderRepository.kt
+++ b/android/app/src/main/java/com/on/turip/data/folder/repository/DefaultFolderRepository.kt
@@ -6,6 +6,7 @@ import com.on.turip.data.folder.datasource.FolderRemoteDataSource
 import com.on.turip.data.folder.toAddRequestDto
 import com.on.turip.data.folder.toDomain
 import com.on.turip.data.folder.toPatchRequestDto
+import com.on.turip.domain.folder.FavoriteFolder
 import com.on.turip.domain.folder.Folder
 import com.on.turip.domain.folder.repository.FolderRepository
 
@@ -25,4 +26,9 @@ class DefaultFolderRepository(
 
     override suspend fun deleteFavoriteFolder(folderId: Long): TuripCustomResult<Unit> =
         folderRemoteDataSource.deleteFavoriteFolder(folderId)
+
+    override suspend fun loadFavoriteFoldersStatusByPlaceId(placeId: Long): TuripCustomResult<List<FavoriteFolder>> =
+        folderRemoteDataSource
+            .getFavoriteFoldersStatusByPlaceId(placeId)
+            .mapCatching { it.toDomain() }
 }

--- a/android/app/src/main/java/com/on/turip/data/folder/service/FolderService.kt
+++ b/android/app/src/main/java/com/on/turip/data/folder/service/FolderService.kt
@@ -3,6 +3,7 @@ package com.on.turip.data.folder.service
 import com.on.turip.data.folder.dto.FavoriteFolderAddRequest
 import com.on.turip.data.folder.dto.FavoriteFolderPatchRequest
 import com.on.turip.data.folder.dto.FavoriteFoldersResponse
+import com.on.turip.data.folder.dto.FavoriteFoldersStatusByPlaceResponse
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
@@ -10,6 +11,7 @@ import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
+import retrofit2.http.Query
 
 interface FolderService {
     @GET("favorite-folders")
@@ -30,4 +32,9 @@ interface FolderService {
     suspend fun deleteFavoriteFolder(
         @Path("favoriteFolderId") folderId: Long,
     ): Response<Unit>
+
+    @GET("favorite-folders/favorite-status")
+    suspend fun getFavoriteFoldersStatusByPlaceId(
+        @Query("placeId") placeId: Long,
+    ): Response<FavoriteFoldersStatusByPlaceResponse>
 }

--- a/android/app/src/main/java/com/on/turip/domain/favorite/FavoritePlaceFolder.kt
+++ b/android/app/src/main/java/com/on/turip/domain/favorite/FavoritePlaceFolder.kt
@@ -1,6 +1,0 @@
-package com.on.turip.domain.favorite
-
-data class FavoritePlaceFolder(
-    val name: String,
-    val placeCount: Int,
-)

--- a/android/app/src/main/java/com/on/turip/domain/folder/FavoriteFolder.kt
+++ b/android/app/src/main/java/com/on/turip/domain/folder/FavoriteFolder.kt
@@ -1,0 +1,9 @@
+package com.on.turip.domain.folder
+
+class FavoriteFolder(
+    val id: Long,
+    val name: String,
+    val isDefault: Boolean,
+    val isFavorite: Boolean,
+    val placeCount: Int = 0,
+)

--- a/android/app/src/main/java/com/on/turip/domain/folder/repository/FolderRepository.kt
+++ b/android/app/src/main/java/com/on/turip/domain/folder/repository/FolderRepository.kt
@@ -1,6 +1,7 @@
 package com.on.turip.domain.folder.repository
 
 import com.on.turip.data.common.TuripCustomResult
+import com.on.turip.domain.folder.FavoriteFolder
 import com.on.turip.domain.folder.Folder
 
 interface FolderRepository {
@@ -14,4 +15,6 @@ interface FolderRepository {
     ): TuripCustomResult<Unit>
 
     suspend fun deleteFavoriteFolder(folderId: Long): TuripCustomResult<Unit>
+
+    suspend fun loadFavoriteFoldersStatusByPlaceId(placeId: Long): TuripCustomResult<List<FavoriteFolder>>
 }

--- a/android/app/src/main/java/com/on/turip/domain/trip/ContentPlace.kt
+++ b/android/app/src/main/java/com/on/turip/domain/trip/ContentPlace.kt
@@ -6,4 +6,5 @@ data class ContentPlace(
     val visitOrder: Int,
     val place: Place,
     val timeLine: String,
+    val isFavoritePlace: Boolean,
 )

--- a/android/app/src/main/java/com/on/turip/ui/common/TuripSnackbar.kt
+++ b/android/app/src/main/java/com/on/turip/ui/common/TuripSnackbar.kt
@@ -18,7 +18,7 @@ import com.on.turip.R
  */
 class TuripSnackbar private constructor(
     private val rootView: View,
-    private val messageResource: Int,
+    private val message: String,
     private val duration: Int,
     private val layoutInflater: LayoutInflater,
 ) {
@@ -49,7 +49,7 @@ class TuripSnackbar private constructor(
     }
 
     fun show() {
-        val snackbar: Snackbar = Snackbar.make(rootView, messageResource, duration)
+        val snackbar: Snackbar = Snackbar.make(rootView, message, duration)
         snackbar.view.background = null
 
         val snackbarLayout: ViewGroup = snackbar.view as ViewGroup
@@ -57,7 +57,7 @@ class TuripSnackbar private constructor(
             layoutInflater.inflate(R.layout.layout_snackbar, snackbarLayout, false)
         snackbarLayout.addView(turipSnackbarView)
 
-        turipSnackbarView.findViewById<TextView>(R.id.tv_snackbar_message).setText(messageResource)
+        turipSnackbarView.findViewById<TextView>(R.id.tv_snackbar_message).text = message
         snackbarIconResource?.let { drawable: Int ->
             turipSnackbarView
                 .findViewById<ImageView>(R.id.iv_snackbar_icon)
@@ -85,9 +85,9 @@ class TuripSnackbar private constructor(
     companion object {
         fun make(
             rootView: View,
-            @StringRes messageResource: Int,
+            message: String,
             duration: Int,
             layoutInflater: LayoutInflater,
-        ): TuripSnackbar = TuripSnackbar(rootView, messageResource, duration, layoutInflater)
+        ): TuripSnackbar = TuripSnackbar(rootView, message, duration, layoutInflater)
     }
 }

--- a/android/app/src/main/java/com/on/turip/ui/folder/FolderViewModel.kt
+++ b/android/app/src/main/java/com/on/turip/ui/folder/FolderViewModel.kt
@@ -29,7 +29,7 @@ class FolderViewModel(
     val inputFolderName: LiveData<String> get() = _inputFolderName
 
     val folderNameStatus: LiveData<FolderNameStatusModel> =
-        inputFolderName.map { FolderNameStatusModel.of(it, LinkedHashSet()) }
+        inputFolderName.map { FolderNameStatusModel.of(it, folders.value ?: emptyList()) }
 
     val selectFolder: LiveData<FolderEditModel> =
         folders.map { folders: List<FolderEditModel> ->

--- a/android/app/src/main/java/com/on/turip/ui/folder/model/FolderNameStatusModel.kt
+++ b/android/app/src/main/java/com/on/turip/ui/folder/model/FolderNameStatusModel.kt
@@ -18,8 +18,11 @@ enum class FolderNameStatusModel(
     companion object {
         fun of(
             folderName: String,
-            originFolderNames: LinkedHashSet<String>,
+            originFolders: List<FolderEditModel>,
         ): FolderNameStatusModel {
+            val originFolderNames: LinkedHashSet<String> =
+                originFolders.map { it.name }.toCollection(LinkedHashSet())
+
             val folderNameStatus: FolderNameStatus =
                 FolderNameStatus.of(folderName, originFolderNames)
             return when (folderNameStatus) {

--- a/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoriteMapper.kt
+++ b/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoriteMapper.kt
@@ -1,7 +1,9 @@
 package com.on.turip.ui.main.favorite
 
 import androidx.core.net.toUri
+import com.on.turip.domain.folder.FavoriteFolder
 import com.on.turip.domain.trip.Place
+import com.on.turip.ui.main.favorite.model.FavoritePlaceFolderModel
 import com.on.turip.ui.main.favorite.model.FavoritePlaceModel
 
 fun Place.toUiModel(): FavoritePlaceModel =
@@ -11,4 +13,12 @@ fun Place.toUiModel(): FavoritePlaceModel =
         uri = url.toUri(),
         category = category.joinToString(),
         isFavorite = true,
+    )
+
+fun FavoriteFolder.toUiModel(): FavoritePlaceFolderModel =
+    FavoritePlaceFolderModel(
+        id = id,
+        name = name,
+        placeCount = placeCount,
+        isSelected = isFavorite,
     )

--- a/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceFolderBottomSheetFragment.kt
+++ b/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceFolderBottomSheetFragment.kt
@@ -10,6 +10,7 @@ import android.widget.FrameLayout
 import androidx.core.graphics.Insets
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.snackbar.Snackbar
@@ -19,6 +20,7 @@ import com.on.turip.ui.common.TuripSnackbar
 import com.on.turip.ui.common.base.BaseBottomSheetFragment
 import com.on.turip.ui.folder.FolderActivity
 import com.on.turip.ui.main.favorite.model.FavoritePlaceFolderModel
+import com.on.turip.ui.trip.detail.TripDetailViewModel
 
 class FavoritePlaceFolderBottomSheetFragment : BaseBottomSheetFragment<BottomSheetFragmentFavoritePlaceFolderBinding>() {
     private val viewModel: FavoritePlaceFolderViewModel by viewModels {
@@ -26,6 +28,8 @@ class FavoritePlaceFolderBottomSheetFragment : BaseBottomSheetFragment<BottomShe
             placeId = arguments?.getLong(ARGUMENTS_PLACE_ID) ?: 0L,
         )
     }
+    private val sharedViewModel: TripDetailViewModel by activityViewModels()
+
     private val favoritePlaceFolderAdapter: FavoritePlaceFolderAdapter by lazy {
         FavoritePlaceFolderAdapter { favoritePlaceFolderModel: FavoritePlaceFolderModel ->
             viewModel.updateFolder(
@@ -117,6 +121,12 @@ class FavoritePlaceFolderBottomSheetFragment : BaseBottomSheetFragment<BottomShe
     private fun setupObservers() {
         viewModel.favoritePlaceFolders.observe(viewLifecycleOwner) { folders: List<FavoritePlaceFolderModel> ->
             favoritePlaceFolderAdapter.submitList(folders)
+        }
+        viewModel.hasFavoriteFolderWithPlaceId.observe(viewLifecycleOwner) { hasFavoriteFolder: Boolean ->
+            sharedViewModel.updateHasFavoriteFolderInPlace(
+                hasFavoriteFolder,
+                arguments?.getLong(ARGUMENTS_PLACE_ID) ?: 0L,
+            )
         }
     }
 

--- a/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceFolderBottomSheetFragment.kt
+++ b/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceFolderBottomSheetFragment.kt
@@ -44,7 +44,11 @@ class FavoritePlaceFolderBottomSheetFragment : BaseBottomSheetFragment<BottomShe
         val updatedFavorites: Boolean = !favoritePlaceFolderModel.isSelected
 
         val messageResource: Int =
-            if (updatedFavorites) R.string.bottom_sheet_favorite_place_folder_save_with_folder_name else R.string.bottom_sheet_favorite_place_folder_remove_with_folder_name
+            if (updatedFavorites) {
+                R.string.bottom_sheet_favorite_place_folder_save_with_folder_name
+            } else {
+                R.string.bottom_sheet_favorite_place_folder_remove_with_folder_name
+            }
         val message: String = getString(messageResource, favoritePlaceFolderModel.name)
         val iconResource: Int =
             if (updatedFavorites) R.drawable.ic_heart_normal else R.drawable.ic_heart_empty

--- a/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceFolderBottomSheetFragment.kt
+++ b/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceFolderBottomSheetFragment.kt
@@ -1,6 +1,7 @@
 package com.on.turip.ui.main.favorite
 
 import android.app.Dialog
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -16,6 +17,7 @@ import com.on.turip.R
 import com.on.turip.databinding.BottomSheetFragmentFavoritePlaceFolderBinding
 import com.on.turip.ui.common.TuripSnackbar
 import com.on.turip.ui.common.base.BaseBottomSheetFragment
+import com.on.turip.ui.folder.FolderActivity
 import com.on.turip.ui.main.favorite.model.FavoritePlaceFolderModel
 
 class FavoritePlaceFolderBottomSheetFragment : BaseBottomSheetFragment<BottomSheetFragmentFavoritePlaceFolderBinding>() {
@@ -94,11 +96,19 @@ class FavoritePlaceFolderBottomSheetFragment : BaseBottomSheetFragment<BottomShe
     ) {
         super.onViewCreated(view, savedInstanceState)
         setupAdapters()
+        setupListeners()
         setupObservers()
     }
 
     private fun setupAdapters() {
         binding.rvBottomSheetFavoritePlaceFolderFolder.adapter = favoritePlaceFolderAdapter
+    }
+
+    private fun setupListeners() {
+        binding.ivBottomSheetFolderFavoritePlaceAddFolder.setOnClickListener {
+            val intent: Intent = FolderActivity.newIntent(requireContext())
+            startActivity(intent)
+        }
     }
 
     private fun setupObservers() {

--- a/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceFolderBottomSheetFragment.kt
+++ b/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceFolderBottomSheetFragment.kt
@@ -28,7 +28,10 @@ class FavoritePlaceFolderBottomSheetFragment : BaseBottomSheetFragment<BottomShe
     }
     private val favoritePlaceFolderAdapter: FavoritePlaceFolderAdapter by lazy {
         FavoritePlaceFolderAdapter { favoritePlaceFolderModel: FavoritePlaceFolderModel ->
-            viewModel.updateFolder(folderId = favoritePlaceFolderModel.id)
+            viewModel.updateFolder(
+                folderId = favoritePlaceFolderModel.id,
+                isFavorite = favoritePlaceFolderModel.isSelected,
+            )
             showSnackbar(favoritePlaceFolderModel)
         }
     }

--- a/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceFolderBottomSheetFragment.kt
+++ b/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceFolderBottomSheetFragment.kt
@@ -130,6 +130,11 @@ class FavoritePlaceFolderBottomSheetFragment : BaseBottomSheetFragment<BottomShe
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+        viewModel.loadFavoriteFoldersByPlaceId()
+    }
+
     companion object {
         private const val BASIC_VIEW_PERCENT: Float = 0.5f
         private const val ARGUMENTS_PLACE_ID = "PLACE_ID"

--- a/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceFolderViewHolder.kt
+++ b/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceFolderViewHolder.kt
@@ -13,8 +13,11 @@ class FavoritePlaceFolderViewHolder(
     private var favoritePlaceFolderModel: FavoritePlaceFolderModel? = null
 
     init {
-        favoritePlaceFolderModel?.let {
-            onFavoritePlaceFolderListener.onFavoriteFolderClick(it)
+
+        binding.ivFavoritePlaceFolderFavorite.setOnClickListener {
+            favoritePlaceFolderModel?.let { placeFolder: FavoritePlaceFolderModel ->
+                onFavoritePlaceFolderListener.onFavoriteFolderClick(placeFolder)
+            }
         }
     }
 

--- a/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceFolderViewModel.kt
+++ b/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceFolderViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
@@ -25,6 +26,11 @@ class FavoritePlaceFolderViewModel(
     private val _favoritePlaceFolders: MutableLiveData<List<FavoritePlaceFolderModel>> =
         MutableLiveData(emptyList())
     val favoritePlaceFolders: LiveData<List<FavoritePlaceFolderModel>> get() = _favoritePlaceFolders
+
+    val hasFavoriteFolderWithPlaceId: LiveData<Boolean> =
+        favoritePlaceFolders.map { folders: List<FavoritePlaceFolderModel> ->
+            folders.any { folder: FavoritePlaceFolderModel -> folder.isSelected }
+        }
 
     init {
         loadFavoriteFoldersByPlaceId(placeId)

--- a/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceFolderViewModel.kt
+++ b/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceFolderViewModel.kt
@@ -32,11 +32,7 @@ class FavoritePlaceFolderViewModel(
             folders.any { folder: FavoritePlaceFolderModel -> folder.isSelected }
         }
 
-    init {
-        loadFavoriteFoldersByPlaceId(placeId)
-    }
-
-    fun loadFavoriteFoldersByPlaceId(placeId: Long) {
+    fun loadFavoriteFoldersByPlaceId(placeId: Long = this.placeId) {
         viewModelScope.launch {
             folderRepository
                 .loadFavoriteFoldersStatusByPlaceId(placeId)

--- a/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceFolderViewModel.kt
+++ b/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceFolderViewModel.kt
@@ -1,0 +1,65 @@
+package com.on.turip.ui.main.favorite
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.on.turip.data.common.onFailure
+import com.on.turip.data.common.onSuccess
+import com.on.turip.di.RepositoryModule
+import com.on.turip.domain.folder.FavoriteFolder
+import com.on.turip.domain.folder.repository.FolderRepository
+import com.on.turip.ui.main.favorite.model.FavoritePlaceFolderModel
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+class FavoritePlaceFolderViewModel(
+    private val placeId: Long,
+    private val folderRepository: FolderRepository,
+) : ViewModel() {
+    private val _favoritePlaceFolders: MutableLiveData<List<FavoritePlaceFolderModel>> =
+        MutableLiveData(emptyList())
+    val favoritePlaceFolders: LiveData<List<FavoritePlaceFolderModel>> get() = _favoritePlaceFolders
+
+    init {
+        loadFavoriteFoldersByPlaceId(placeId)
+    }
+
+    fun loadFavoriteFoldersByPlaceId(placeId: Long) {
+        viewModelScope.launch {
+            folderRepository
+                .loadFavoriteFoldersStatusByPlaceId(placeId)
+                .onSuccess { favoriteFolders: List<FavoriteFolder> ->
+                    _favoritePlaceFolders.value = favoriteFolders.map { it.toUiModel() }
+                    Timber.d("상세 페이지에서 장소에 대한 찜 폴더 현황 데이터 불러오기 성공 ")
+                }.onFailure {
+                    Timber.e("상세 페이지에서 장소에 대한 찜 폴더 현황 데이터 불러오기 실패")
+                }
+        }
+    }
+
+    fun updateFolder(folderId: Long) {
+        _favoritePlaceFolders.value =
+            _favoritePlaceFolders.value?.map { folder: FavoritePlaceFolderModel ->
+                if (folder.id == folderId) folder.copy(isSelected = !folder.isSelected) else folder
+            }
+    }
+
+    companion object {
+        fun provideFactory(
+            placeId: Long,
+            folderRepository: FolderRepository = RepositoryModule.folderRepository,
+        ): ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer {
+                    FavoritePlaceFolderViewModel(
+                        placeId,
+                        folderRepository,
+                    )
+                }
+            }
+    }
+}

--- a/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceFolderViewModel.kt
+++ b/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceFolderViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.viewmodel.viewModelFactory
 import com.on.turip.data.common.onFailure
 import com.on.turip.data.common.onSuccess
 import com.on.turip.di.RepositoryModule
+import com.on.turip.domain.favorite.usecase.UpdateFavoritePlaceUseCase
 import com.on.turip.domain.folder.FavoriteFolder
 import com.on.turip.domain.folder.repository.FolderRepository
 import com.on.turip.ui.main.favorite.model.FavoritePlaceFolderModel
@@ -19,6 +20,7 @@ import timber.log.Timber
 class FavoritePlaceFolderViewModel(
     private val placeId: Long,
     private val folderRepository: FolderRepository,
+    private val updateFavoritePlaceUseCase: UpdateFavoritePlaceUseCase,
 ) : ViewModel() {
     private val _favoritePlaceFolders: MutableLiveData<List<FavoritePlaceFolderModel>> =
         MutableLiveData(emptyList())
@@ -41,23 +43,40 @@ class FavoritePlaceFolderViewModel(
         }
     }
 
-    fun updateFolder(folderId: Long) {
-        _favoritePlaceFolders.value =
-            _favoritePlaceFolders.value?.map { folder: FavoritePlaceFolderModel ->
-                if (folder.id == folderId) folder.copy(isSelected = !folder.isSelected) else folder
-            }
+    fun updateFolder(
+        folderId: Long,
+        isFavorite: Boolean,
+    ) {
+        viewModelScope.launch {
+            val updateFavoritesStatus: Boolean = !isFavorite
+            updateFavoritePlaceUseCase(folderId, placeId, updateFavoritesStatus)
+                .onSuccess {
+                    Timber.d("장소에 대한 찜 폴더들 현황에서 장소 찜 업데이트")
+                    _favoritePlaceFolders.value =
+                        _favoritePlaceFolders.value?.map { folder: FavoritePlaceFolderModel ->
+                            if (folder.id == folderId) folder.copy(isSelected = !folder.isSelected) else folder
+                        }
+                }.onFailure {
+                    Timber.e("장소에 대한 찜 폴더들 현황에서 장소 찜 실패")
+                }
+        }
     }
 
     companion object {
         fun provideFactory(
             placeId: Long,
             folderRepository: FolderRepository = RepositoryModule.folderRepository,
+            updateFavoritePlaceUseCase: UpdateFavoritePlaceUseCase =
+                UpdateFavoritePlaceUseCase(
+                    RepositoryModule.favoritePlaceRepository,
+                ),
         ): ViewModelProvider.Factory =
             viewModelFactory {
                 initializer {
                     FavoritePlaceFolderViewModel(
                         placeId,
                         folderRepository,
+                        updateFavoritePlaceUseCase,
                     )
                 }
             }

--- a/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceFragment.kt
+++ b/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceFragment.kt
@@ -34,7 +34,8 @@ class FavoritePlaceFragment : BaseFragment<FragmentFavoritePlaceBinding>() {
                 }
 
                 override fun onMapClick(uri: Uri) {
-                    // TODO: 지도 버튼 클릭 시 로직
+                    val intent: Intent = Intent(Intent.ACTION_VIEW, uri)
+                    startActivity(intent)
                 }
             },
         )
@@ -62,7 +63,11 @@ class FavoritePlaceFragment : BaseFragment<FragmentFavoritePlaceBinding>() {
             itemAnimator = null
             addOnItemTouchListener(RecyclerViewTouchInterceptor)
         }
-        binding.rvFavoritePlacePlace.adapter = placeAdapter
+
+        binding.rvFavoritePlacePlace.apply {
+            adapter = placeAdapter
+            itemAnimator = null
+        }
     }
 
     private fun setupListeners() {
@@ -77,25 +82,31 @@ class FavoritePlaceFragment : BaseFragment<FragmentFavoritePlaceBinding>() {
             folderNameAdapter.submitList(favoritePlaceFolders)
         }
 
-        viewModel.placeCount.observe(viewLifecycleOwner) { placeCount: Int ->
-            if (placeCount == 0) {
+        viewModel.places.observe(viewLifecycleOwner) { places: List<FavoritePlaceModel> ->
+            placeAdapter.submitList(places)
+
+            if (places.isEmpty()) {
                 binding.clFavoritePlaceEmpty.visibility = View.VISIBLE
                 binding.groupFavoritePlaceNotEmpty.visibility = View.GONE
             } else {
                 binding.clFavoritePlaceEmpty.visibility = View.GONE
                 binding.groupFavoritePlaceNotEmpty.visibility = View.VISIBLE
                 binding.tvFavoritePlacePlaceCount.text =
-                    getString(R.string.all_total_place_count, placeCount)
+                    getString(R.string.all_total_place_count, places.size)
             }
-        }
-        viewModel.places.observe(viewLifecycleOwner) { places: List<FavoritePlaceModel> ->
-            placeAdapter.submitList(places)
         }
     }
 
     override fun onResume() {
         super.onResume()
         viewModel.loadFoldersAndPlaces()
+    }
+
+    override fun onHiddenChanged(hidden: Boolean) {
+        super.onHiddenChanged(hidden)
+        if (!hidden) {
+            viewModel.loadFoldersAndPlaces()
+        }
     }
 
     companion object {

--- a/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceViewModel.kt
+++ b/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceViewModel.kt
@@ -42,18 +42,20 @@ class FavoritePlaceViewModel(
                     if (selectedFolderId == NOT_INITIALIZED) selectedFolderId = folders[0].id
                     _folders.value =
                         folders.map { folder: Folder -> folder.toUiModel(selectedFolderId) }
+
+                    loadPlacesInSelectFolder()
                 }.onFailure { Timber.e("장소 찜 목록 화면 폴더 불러오기 API 호출 실패") }
         }
+    }
 
-        viewModelScope.launch {
-            favoritePlaceRepository
-                .loadFavoritePlaces(selectedFolderId)
-                .onSuccess { places: List<Place> ->
-                    _places.value = places.map { place: Place -> place.toUiModel() }
-                }.onFailure {
-                    Timber.e("폴더에 담긴 장소들을 불러오는 API 호출 실패")
-                }
-        }
+    private suspend fun loadPlacesInSelectFolder() {
+        favoritePlaceRepository
+            .loadFavoritePlaces(selectedFolderId)
+            .onSuccess { places: List<Place> ->
+                _places.value = places.map { place: Place -> place.toUiModel() }
+            }.onFailure {
+                Timber.e("폴더에 담긴 장소들을 불러오는 API 호출 실패")
+            }
     }
 
     fun updateFavoritePlace(

--- a/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceViewModel.kt
+++ b/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
@@ -29,10 +28,6 @@ class FavoritePlaceViewModel(
 ) : ViewModel() {
     private val _folders: MutableLiveData<List<FavoritePlaceFolderModel>> = MutableLiveData()
     val folders: LiveData<List<FavoritePlaceFolderModel>> get() = _folders
-    val placeCount: LiveData<Int> =
-        folders.map { favoritePlaceFolders: List<FavoritePlaceFolderModel> ->
-            favoritePlaceFolders.firstOrNull { it.isSelected }?.placeCount ?: 0
-        }
     private val _places: MutableLiveData<List<FavoritePlaceModel>> = MutableLiveData()
     val places: LiveData<List<FavoritePlaceModel>> get() = _places
 
@@ -45,8 +40,19 @@ class FavoritePlaceViewModel(
                 .onSuccess { folders: List<Folder> ->
                     Timber.d("장소 찜 목록 화면 폴더 불러오기 성공")
                     if (selectedFolderId == NOT_INITIALIZED) selectedFolderId = folders[0].id
-                    _folders.value = folders.map { folder -> folder.toUiModel(selectedFolderId) }
+                    _folders.value =
+                        folders.map { folder: Folder -> folder.toUiModel(selectedFolderId) }
                 }.onFailure { Timber.e("장소 찜 목록 화면 폴더 불러오기 API 호출 실패") }
+        }
+
+        viewModelScope.launch {
+            favoritePlaceRepository
+                .loadFavoritePlaces(selectedFolderId)
+                .onSuccess { places: List<Place> ->
+                    _places.value = places.map { place: Place -> place.toUiModel() }
+                }.onFailure {
+                    Timber.e("폴더에 담긴 장소들을 불러오는 API 호출 실패")
+                }
         }
     }
 
@@ -54,14 +60,17 @@ class FavoritePlaceViewModel(
         placeId: Long,
         isFavorite: Boolean,
     ) {
-        val updateFavorite: Boolean = !isFavorite
+        val updatedFavorite: Boolean = !isFavorite
         viewModelScope.launch {
-            updateFavoritePlaceUseCase(selectedFolderId, placeId, updateFavorite)
+            updateFavoritePlaceUseCase(selectedFolderId, placeId, updatedFavorite)
                 .onSuccess {
-                    _folders.value =
-                        folders.value?.map { if (it.id == placeId) it.copy(isSelected = updateFavorite) else it }
+                    _places.value =
+                        places.value?.map {
+                            if (it.placeId == placeId) it.copy(isFavorite = updatedFavorite) else it
+                        }
+                    Timber.d("찜 목록 화면 폴더명에 해당하는 찜 장소들 업데이트 성공")
                 }.onFailure {
-                    Timber.e("장소 찜 업데이트 실패")
+                    Timber.e("찜 목록 화면 폴더명에 해당하는 찜 장소들 업데이트 실패 (placeId =$placeId)")
                 }
         }
     }

--- a/android/app/src/main/java/com/on/turip/ui/trip/detail/PlaceModel.kt
+++ b/android/app/src/main/java/com/on/turip/ui/trip/detail/PlaceModel.kt
@@ -9,6 +9,7 @@ data class PlaceModel(
     val category: String,
     val mapLink: String,
     val timeLine: String,
+    val isFavorite: Boolean,
 ) {
     val placeUri: Uri
         get() = mapLink.toUri()

--- a/android/app/src/main/java/com/on/turip/ui/trip/detail/PlaceModel.kt
+++ b/android/app/src/main/java/com/on/turip/ui/trip/detail/PlaceModel.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import androidx.core.net.toUri
 
 data class PlaceModel(
+    val id: Long,
     val name: String,
     val category: String,
     val mapLink: String,

--- a/android/app/src/main/java/com/on/turip/ui/trip/detail/TripDetailActivity.kt
+++ b/android/app/src/main/java/com/on/turip/ui/trip/detail/TripDetailActivity.kt
@@ -23,6 +23,7 @@ import com.on.turip.ui.common.base.BaseActivity
 import com.on.turip.ui.common.loadCircularImage
 import com.on.turip.ui.common.model.trip.TripModel
 import com.on.turip.ui.common.model.trip.toDisplayText
+import com.on.turip.ui.main.favorite.FavoritePlaceFolderBottomSheetFragment
 import com.on.turip.ui.trip.detail.webview.TuripWebChromeClient
 import com.on.turip.ui.trip.detail.webview.TuripWebViewClient
 import com.on.turip.ui.trip.detail.webview.applyVideoSettings
@@ -71,7 +72,9 @@ class TripDetailActivity : BaseActivity<ActivityTripDetailBinding>() {
                 }
 
                 override fun onFavoriteClick(placeModel: PlaceModel) {
-                    // TODO: 찜 선택 구현
+                    val bottomSheet: FavoritePlaceFolderBottomSheetFragment =
+                        FavoritePlaceFolderBottomSheetFragment.instance(placeModel.id)
+                    bottomSheet.show(supportFragmentManager, "favorite_place_folder")
                 }
             },
         )
@@ -226,7 +229,7 @@ class TripDetailActivity : BaseActivity<ActivityTripDetailBinding>() {
         TuripSnackbar
             .make(
                 rootView = binding.root,
-                messageResource = messageResource,
+                message = getString(messageResource),
                 duration = Snackbar.LENGTH_LONG,
                 layoutInflater = layoutInflater,
             ).topMarginInCoordinatorLayout(binding.tbTripDetail.height)

--- a/android/app/src/main/java/com/on/turip/ui/trip/detail/TripDetailViewModel.kt
+++ b/android/app/src/main/java/com/on/turip/ui/trip/detail/TripDetailViewModel.kt
@@ -192,6 +192,16 @@ class TripDetailViewModel(
         _bodyMaxLines.value = DEFAULT_CONTENT_TITLE_MAX_LINES
     }
 
+    fun updateHasFavoriteFolderInPlace(
+        hasFavoriteFolder: Boolean,
+        placeId: Long,
+    ) {
+        _places.value =
+            places.value?.map { place: PlaceModel ->
+                if (place.id == placeId) place.copy(isFavorite = hasFavoriteFolder) else place
+            }
+    }
+
     companion object {
         private const val DEFAULT_CONTENT_TITLE_MAX_LINES = 2
 

--- a/android/app/src/main/java/com/on/turip/ui/trip/detail/TripDetailViewModel.kt
+++ b/android/app/src/main/java/com/on/turip/ui/trip/detail/TripDetailViewModel.kt
@@ -131,6 +131,7 @@ class TripDetailViewModel(
                 val placeModels: List<PlaceModel> =
                     coursesForDay.map { course ->
                         PlaceModel(
+                            id = course.place.placeId,
                             name = course.place.name,
                             category = course.place.category.joinToString(),
                             mapLink = course.place.url,

--- a/android/app/src/main/java/com/on/turip/ui/trip/detail/TripDetailViewModel.kt
+++ b/android/app/src/main/java/com/on/turip/ui/trip/detail/TripDetailViewModel.kt
@@ -72,7 +72,7 @@ class TripDetailViewModel(
     init {
         loadContent()
         loadTrip()
-        handleFavoriteWithDebounce()
+        handleFavoriteContentWithDebounce()
     }
 
     private fun loadContent() {
@@ -129,13 +129,14 @@ class TripDetailViewModel(
                 val coursesForDay: List<ContentPlace> =
                     trip.contentPlaces.filter { it.visitDay == day }
                 val placeModels: List<PlaceModel> =
-                    coursesForDay.map { course ->
+                    coursesForDay.map { course: ContentPlace ->
                         PlaceModel(
                             id = course.place.placeId,
                             name = course.place.name,
                             category = course.place.category.joinToString(),
                             mapLink = course.place.url,
                             timeLine = course.timeLine,
+                            isFavorite = course.isFavoritePlace,
                         )
                     }
                 day to placeModels
@@ -143,7 +144,7 @@ class TripDetailViewModel(
     }
 
     @OptIn(FlowPreview::class)
-    private fun handleFavoriteWithDebounce() {
+    private fun handleFavoriteContentWithDebounce() {
         viewModelScope.launch {
             _isFavorite
                 .asFlow()

--- a/android/app/src/main/java/com/on/turip/ui/trip/detail/TripPlaceViewHolder.kt
+++ b/android/app/src/main/java/com/on/turip/ui/trip/detail/TripPlaceViewHolder.kt
@@ -39,6 +39,7 @@ class TripPlaceViewHolder(
                 R.string.travel_place_time_line,
                 placeModel.timeLine,
             )
+        binding.ivTravelPlaceFavorite.isSelected = placeModel.isFavorite
     }
 
     companion object {

--- a/android/app/src/main/res/layout/item_favorite_place.xml
+++ b/android/app/src/main/res/layout/item_favorite_place.xml
@@ -69,7 +69,6 @@
         app:layout_constraintDimensionRatio="1:1"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/md_favorite_place_icon_divider"
-        app:layout_constraintTop_toBottomOf="@id/tv_favorite_place_name"
-        app:tint="@color/turip_lemon_faff60" />
+        app:layout_constraintTop_toBottomOf="@id/tv_favorite_place_name" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -60,6 +60,8 @@
     <string name="trip_detail_travel_day">%d일차</string>
     <string name="trip_detail_snackbar_favorite_save">컨텐츠 찜 목록에 저장했어요</string>
     <string name="trip_detail_snackbar_favorite_remove">컨텐츠 찜 목록에서 삭제했어요</string>
+    <string name="bottom_sheet_favorite_place_folder_save_with_folder_name">%s에 저장했어요</string>
+    <string name="bottom_sheet_favorite_place_folder_remove_with_folder_name">%s에서 삭제했어요</string>
     <string name="travel_place_map">지도</string>
     <string name="travel_place_favorite">장소찜</string>
     <string name="travel_place_time_line">%s~</string>


### PR DESCRIPTION
## Issues
- closed #283

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
- 상세 페이지에서 장소 찜을 클릭하면 폴더 목록 다이얼로그가 나오며 넣고 싶은 폴더에 찜을 할 수 있다.
- UI/UX 개선 

## 📷 Screenshot

## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 장소 상세에서 즐겨찾기 클릭 시 폴더 선택 바텀시트로 저장/삭제 가능하며 스낵바로 안내
  - 장소별 폴더의 즐겨찾기 상태 조회 API 연동 및 폴더 상태 로드 기능 추가

- Improvements
  - 폴더별 즐겨찾기 토글(저장/제거) 및 목록/상세 간 즐겨찾기 상태 실시간 동기화
  - 즐겨찾기 목록에서 지도 열기 동작 구현

- UI/Style
  - 즐겨찾기 아이콘 선택 상태 동기화 추가
  - 일부 아이콘 틴트 제거로 시각적 일관성 개선
  - 스낵바가 문자열 메시지를 직접 받아 정확히 표시

- Localization
  - 폴더 저장/삭제 결과 안내 문자열 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->