### PR TITLE
[feat] 영상 상세 화면 장소명 클릭 시, 화면 이동

### DIFF
--- a/android/app/src/main/java/com/on/turip/ui/trip/detail/TripDetailActivity.kt
+++ b/android/app/src/main/java/com/on/turip/ui/trip/detail/TripDetailActivity.kt
@@ -64,7 +64,7 @@ class TripDetailActivity : BaseActivity<ActivityTripDetailBinding>() {
     private val tripPlaceAdapter by lazy {
         TripPlaceAdapter(
             object : TripPlaceViewHolder.PlaceListener {
-                override fun onPlaceNameClick(placeModel: PlaceModel) {
+                override fun onItemClick(placeModel: PlaceModel) {
                     val intent: Intent =
                         SearchActivity.newIntent(this@TripDetailActivity, placeModel.name)
                     startActivity(intent)

--- a/android/app/src/main/java/com/on/turip/ui/trip/detail/TripPlaceViewHolder.kt
+++ b/android/app/src/main/java/com/on/turip/ui/trip/detail/TripPlaceViewHolder.kt
@@ -13,9 +13,9 @@ class TripPlaceViewHolder(
     private var placeModel: PlaceModel? = null
 
     init {
-        binding.tvTravelPlaceName.setOnClickListener {
+        itemView.setOnClickListener {
             placeModel?.let {
-                onClickListener.onPlaceNameClick(it)
+                onClickListener.onItemClick(it)
             }
         }
 
@@ -61,7 +61,7 @@ class TripPlaceViewHolder(
     }
 
     interface PlaceListener {
-        fun onPlaceNameClick(placeModel: PlaceModel)
+        fun onItemClick(placeModel: PlaceModel)
 
         fun onPlaceClick(placeModel: PlaceModel)
 


### PR DESCRIPTION
## Issues
- closed #318

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
- 영상 상세 화면에서 장소명 클릭 시, 장소명 기반으로 검색된 화면으로 이동한다

## 📷 Screenshot

https://github.com/user-attachments/assets/62d63fba-5f00-460c-868e-39902a54dbc7

## 📚 Reference
- 검색 후 돌아오면 기존에 보던 영상 정보들이 남아 있도록 쌓이는 구조로 만들었습니다 !

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 여행 장소 목록 아이템 전체를 탭하면 해당 장소 이름으로 검색 화면이 열립니다.
  * 목록 내 기존 동작(장소 링크 열기)은 그대로 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->