### PR TITLE
[feat] 에러 태그 추가

### DIFF
--- a/backend/src/main/java/turip/auth/AuthMemberArgumentResolver.java
+++ b/backend/src/main/java/turip/auth/AuthMemberArgumentResolver.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
+import turip.common.exception.ErrorTag;
+import turip.common.exception.custom.IllegalArgumentException;
 import turip.member.service.MemberService;
 
 @Component
@@ -29,7 +31,7 @@ public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver
     ) {
         String deviceFid = webRequest.getHeader("device-fid");
         if (deviceFid == null || deviceFid.isBlank()) {
-            throw new IllegalArgumentException("회원 정보(device-fid 헤더)가 존재하지 않습니다.");
+            throw new IllegalArgumentException(ErrorTag.MEMBER_NOT_FOUND);
         }
 
         AuthMember ann = parameter.getParameterAnnotation(AuthMember.class);

--- a/backend/src/main/java/turip/common/exception/ErrorResponse.java
+++ b/backend/src/main/java/turip/common/exception/ErrorResponse.java
@@ -1,6 +1,6 @@
 package turip.common.exception;
 
 public record ErrorResponse(
-        String message
+        ErrorTag tag
 ) {
 }

--- a/backend/src/main/java/turip/common/exception/ErrorTag.java
+++ b/backend/src/main/java/turip/common/exception/ErrorTag.java
@@ -2,10 +2,11 @@ package turip.common.exception;
 
 public enum ErrorTag {
 
+    BAD_REQUEST("올바르지 않은 요청입니다."),
     FAVORITE_FOLDER_NAME_BLANK("찜폴더 이름은 비워둘 수 없습니다."),
     FAVORITE_FOLDER_NAME_TOO_LONG("찜폴더 이름의 최대 길이를 초과했습니다."),
     IS_DEFAULT_FAVORITE_FOLDER("기본 찜폴더에는 이 작업을 수행할 수 없습니다."),
-    PLACE_CATEGORY_WRONG("잘못된 지역 카테고리입니다."),
+    REGION_CATEGORY_WRONG("잘못된 지역 카테고리입니다."),
 
     FORBIDDEN("접근 권한이 없습니다."),
 
@@ -19,7 +20,9 @@ public enum ErrorTag {
 
     FAVORITE_FOLDER_NAME_CONFLICT("이미 존재하는 찜폴더 이름입니다."),
     FAVORITE_CONTENT_CONFLICT("이미 찜한 컨텐츠입니다."),
-    FAVORITE_PLACE_CONFLICT("해당 폴더에 이미 찜한 장소입니다.");
+    FAVORITE_PLACE_CONFLICT("해당 폴더에 이미 찜한 장소입니다."),
+
+    INTERNAL_SERVER_ERROR("서버에서 예기치 못한 에러가 발생했습니다.");
 
     private final String message;
 
@@ -29,5 +32,10 @@ public enum ErrorTag {
 
     public String getMessage() {
         return message;
+    }
+
+    @Override
+    public String toString() {
+        return this.name();
     }
 }

--- a/backend/src/main/java/turip/common/exception/ErrorTag.java
+++ b/backend/src/main/java/turip/common/exception/ErrorTag.java
@@ -1,0 +1,32 @@
+package turip.common.exception;
+
+public enum ErrorTag {
+
+    FAVORITE_FOLDER_NAME_BLANK("찜폴더 이름은 비워둘 수 없습니다."),
+    FAVORITE_FOLDER_NAME_TOO_LONG("찜폴더 이름은 20자를 초과할 수 없습니다."),
+    IS_DEFAULT_FAVORITE_FOLDER("기본 찜폴더에는 이 작업을 수행할 수 없습니다."),
+    PLACE_CATEGORY_WRONG("잘못된 지역 카테고리입니다."),
+
+    FORBIDDEN("접근 권한이 없습니다."),
+
+    MEMBER_NOT_FOUND("사용자를 찾을 수 없습니다."),
+    CONTENT_NOT_FOUND("컨텐츠를 찾을 수 없습니다."),
+    FAVORITE_FOLDER_NOT_FOUND("찜폴더를 찾을 수 없습니다."),
+    PLACE_NOT_FOUND("장소를 찾을 수 없습니다."),
+    FAVORITE_PLACE_NOT_FOUND("찜한 장소를 찾을 수 없습니다."),
+    CREATOR_NOT_FOUND("크리에이터를 찾을 수 없습니다."),
+
+    FAVORITE_FOLDER_NAME_CONFLICT("이미 존재하는 찜폴더 이름입니다."),
+    FAVORITE_CONTENT_CONFLICT("이미 찜한 컨텐츠입니다."),
+    FAVORITE_PLACE_CONFLICT("이미 찜한 장소입니다.");
+
+    private final String message;
+
+    ErrorTag(final String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/backend/src/main/java/turip/common/exception/ErrorTag.java
+++ b/backend/src/main/java/turip/common/exception/ErrorTag.java
@@ -2,14 +2,17 @@ package turip.common.exception;
 
 public enum ErrorTag {
 
+    // 400 Bad Request
     BAD_REQUEST("올바르지 않은 요청입니다."),
     FAVORITE_FOLDER_NAME_BLANK("찜폴더 이름은 비워둘 수 없습니다."),
     FAVORITE_FOLDER_NAME_TOO_LONG("찜폴더 이름의 최대 길이를 초과했습니다."),
-    IS_DEFAULT_FAVORITE_FOLDER("기본 찜폴더에는 이 작업을 수행할 수 없습니다."),
-    REGION_CATEGORY_WRONG("잘못된 지역 카테고리입니다."),
+    DEFAULT_FAVORITE_FOLDER_OPERATION_NOT_ALLOWED("기본 찜폴더에는 이 작업을 수행할 수 없습니다."),
+    REGION_CATEGORY_INVALID("잘못된 지역 카테고리입니다."),
 
+    // 403 Forbidden
     FORBIDDEN("접근 권한이 없습니다."),
 
+    // 404 Not Found
     MEMBER_NOT_FOUND("사용자를 찾을 수 없습니다."),
     CONTENT_NOT_FOUND("컨텐츠를 찾을 수 없습니다."),
     FAVORITE_FOLDER_NOT_FOUND("찜폴더를 찾을 수 없습니다."),
@@ -18,10 +21,12 @@ public enum ErrorTag {
     CREATOR_NOT_FOUND("크리에이터를 찾을 수 없습니다."),
     FAVORITE_CONTENT_NOT_FOUND("찜한 컨텐츠를 찾을 수 없습니다."),
 
+    // 409 Conflict
     FAVORITE_FOLDER_NAME_CONFLICT("이미 존재하는 찜폴더 이름입니다."),
     FAVORITE_CONTENT_CONFLICT("이미 찜한 컨텐츠입니다."),
-    FAVORITE_PLACE_CONFLICT("해당 폴더에 이미 찜한 장소입니다."),
+    FAVORITE_PLACE_IN_FOLDER_CONFLICT("해당 폴더에 이미 찜한 장소입니다."),
 
+    // 500 Internal Server Error
     INTERNAL_SERVER_ERROR("서버에서 예기치 못한 에러가 발생했습니다.");
 
     private final String message;

--- a/backend/src/main/java/turip/common/exception/ErrorTag.java
+++ b/backend/src/main/java/turip/common/exception/ErrorTag.java
@@ -3,7 +3,7 @@ package turip.common.exception;
 public enum ErrorTag {
 
     FAVORITE_FOLDER_NAME_BLANK("찜폴더 이름은 비워둘 수 없습니다."),
-    FAVORITE_FOLDER_NAME_TOO_LONG("찜폴더 이름은 20자를 초과할 수 없습니다."),
+    FAVORITE_FOLDER_NAME_TOO_LONG("찜폴더 이름의 최대 길이를 초과했습니다."),
     IS_DEFAULT_FAVORITE_FOLDER("기본 찜폴더에는 이 작업을 수행할 수 없습니다."),
     PLACE_CATEGORY_WRONG("잘못된 지역 카테고리입니다."),
 
@@ -15,10 +15,11 @@ public enum ErrorTag {
     PLACE_NOT_FOUND("장소를 찾을 수 없습니다."),
     FAVORITE_PLACE_NOT_FOUND("찜한 장소를 찾을 수 없습니다."),
     CREATOR_NOT_FOUND("크리에이터를 찾을 수 없습니다."),
+    FAVORITE_CONTENT_NOT_FOUND("찜한 컨텐츠를 찾을 수 없습니다."),
 
     FAVORITE_FOLDER_NAME_CONFLICT("이미 존재하는 찜폴더 이름입니다."),
     FAVORITE_CONTENT_CONFLICT("이미 찜한 컨텐츠입니다."),
-    FAVORITE_PLACE_CONFLICT("이미 찜한 장소입니다.");
+    FAVORITE_PLACE_CONFLICT("해당 폴더에 이미 찜한 장소입니다.");
 
     private final String message;
 

--- a/backend/src/main/java/turip/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/turip/common/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import turip.common.exception.custom.HttpStatusException;
+import turip.common.exception.custom.IllegalArgumentException;
 
 @Slf4j
 @RestControllerAdvice
@@ -15,20 +16,20 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleHttpStatusException(HttpStatusException e) {
         log.warn(e.getMessage(), e);
         return ResponseEntity.status(e.getStatus())
-                .body(new ErrorResponse(e.getMessage()));
+                .body(new ErrorResponse(e.getErrorTag()));
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
         log.warn(e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(new ErrorResponse(e.getMessage()));
+                .body(new ErrorResponse(e.getErrorTag()));
     }
 
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ErrorResponse> handleNotCaughtExceptions(final RuntimeException e) {
         log.error(e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(new ErrorResponse("서버에서 예기치 못한 예외가 발생하였습니다."));
+                .body(new ErrorResponse(ErrorTag.INTERNAL_SERVER_ERROR));
     }
 }

--- a/backend/src/main/java/turip/common/exception/custom/BadRequestException.java
+++ b/backend/src/main/java/turip/common/exception/custom/BadRequestException.java
@@ -1,10 +1,11 @@
 package turip.common.exception.custom;
 
 import org.springframework.http.HttpStatus;
+import turip.common.exception.ErrorTag;
 
 public class BadRequestException extends HttpStatusException {
 
-    public BadRequestException(String message) {
-        super(message, HttpStatus.BAD_REQUEST);
+    public BadRequestException(ErrorTag errorTag) {
+        super(HttpStatus.BAD_REQUEST, errorTag);
     }
 }

--- a/backend/src/main/java/turip/common/exception/custom/ConflictException.java
+++ b/backend/src/main/java/turip/common/exception/custom/ConflictException.java
@@ -1,10 +1,11 @@
 package turip.common.exception.custom;
 
 import org.springframework.http.HttpStatus;
+import turip.common.exception.ErrorTag;
 
 public class ConflictException extends HttpStatusException {
 
-    public ConflictException(String message) {
-        super(message, HttpStatus.CONFLICT);
+    public ConflictException(ErrorTag errorTag) {
+        super(HttpStatus.CONFLICT, errorTag);
     }
 }

--- a/backend/src/main/java/turip/common/exception/custom/ForbiddenException.java
+++ b/backend/src/main/java/turip/common/exception/custom/ForbiddenException.java
@@ -1,10 +1,11 @@
 package turip.common.exception.custom;
 
 import org.springframework.http.HttpStatus;
+import turip.common.exception.ErrorTag;
 
 public class ForbiddenException extends HttpStatusException {
 
-    public ForbiddenException(String message) {
-        super(message, HttpStatus.FORBIDDEN);
+    public ForbiddenException(ErrorTag errorTag) {
+        super(HttpStatus.FORBIDDEN, errorTag);
     }
 }

--- a/backend/src/main/java/turip/common/exception/custom/HttpStatusException.java
+++ b/backend/src/main/java/turip/common/exception/custom/HttpStatusException.java
@@ -17,4 +17,8 @@ public class HttpStatusException extends RuntimeException {
     public HttpStatus getStatus() {
         return status;
     }
+
+    public ErrorTag getErrorTag() {
+        return errorTag;
+    }
 }

--- a/backend/src/main/java/turip/common/exception/custom/HttpStatusException.java
+++ b/backend/src/main/java/turip/common/exception/custom/HttpStatusException.java
@@ -1,14 +1,17 @@
 package turip.common.exception.custom;
 
 import org.springframework.http.HttpStatus;
+import turip.common.exception.ErrorTag;
 
 public class HttpStatusException extends RuntimeException {
 
     private final HttpStatus status;
+    private final ErrorTag errorTag;
 
-    public HttpStatusException(String message, HttpStatus status) {
-        super(message);
+    public HttpStatusException(HttpStatus status, ErrorTag errorTag) {
+        super(errorTag.getMessage());
         this.status = status;
+        this.errorTag = errorTag;
     }
 
     public HttpStatus getStatus() {

--- a/backend/src/main/java/turip/common/exception/custom/IllegalArgumentException.java
+++ b/backend/src/main/java/turip/common/exception/custom/IllegalArgumentException.java
@@ -1,0 +1,17 @@
+package turip.common.exception.custom;
+
+import turip.common.exception.ErrorTag;
+
+public class IllegalArgumentException extends RuntimeException {
+
+    private final ErrorTag errorTag;
+
+    public IllegalArgumentException(final ErrorTag errorTag) {
+        super(errorTag.getMessage());
+        this.errorTag = errorTag;
+    }
+
+    public ErrorTag getErrorTag() {
+        return errorTag;
+    }
+}

--- a/backend/src/main/java/turip/common/exception/custom/NotFoundException.java
+++ b/backend/src/main/java/turip/common/exception/custom/NotFoundException.java
@@ -1,10 +1,11 @@
 package turip.common.exception.custom;
 
 import org.springframework.http.HttpStatus;
+import turip.common.exception.ErrorTag;
 
 public class NotFoundException extends HttpStatusException {
 
-    public NotFoundException(String message) {
-        super(message, HttpStatus.NOT_FOUND);
+    public NotFoundException(ErrorTag errorTag) {
+        super(HttpStatus.NOT_FOUND, errorTag);
     }
 }

--- a/backend/src/main/java/turip/content/controller/ContentController.java
+++ b/backend/src/main/java/turip/content/controller/ContentController.java
@@ -66,7 +66,7 @@ public class ContentController {
                                     summary = "지역 카테고리가 올바르지 않음",
                                     value = """
                                             {
-                                                "message": "지역 카테고리가 올바르지 않습니다."
+                                                "tag": "PLACE_CATEGORY_WRONG"
                                             }
                                             """
                             )
@@ -183,7 +183,7 @@ public class ContentController {
                                     summary = "지역 카테고리가 올바르지 않음",
                                     value = """
                                             {
-                                                "message": "지역 카테고리가 올바르지 않습니다."
+                                                "tag": "PLACE_CATEGORY_WRONG"
                                             }
                                             """
                             )
@@ -328,7 +328,7 @@ public class ContentController {
                                     summary = "id에 대한 컨텐츠가 존재하지 않음",
                                     value = """
                                             {
-                                                "message": "컨텐츠를 찾을 수 없습니다."
+                                                "tag": "CONTENT_NOT_FOUND"
                                             }
                                             """
                             )

--- a/backend/src/main/java/turip/content/controller/ContentController.java
+++ b/backend/src/main/java/turip/content/controller/ContentController.java
@@ -66,7 +66,7 @@ public class ContentController {
                                     summary = "지역 카테고리가 올바르지 않음",
                                     value = """
                                             {
-                                                "tag": "PLACE_CATEGORY_WRONG"
+                                                "tag": "REGION_CATEGORY_WRONG"
                                             }
                                             """
                             )
@@ -183,7 +183,7 @@ public class ContentController {
                                     summary = "지역 카테고리가 올바르지 않음",
                                     value = """
                                             {
-                                                "tag": "PLACE_CATEGORY_WRONG"
+                                                "tag": "REGION_CATEGORY_WRONG"
                                             }
                                             """
                             )

--- a/backend/src/main/java/turip/content/controller/ContentPlaceController.java
+++ b/backend/src/main/java/turip/content/controller/ContentPlaceController.java
@@ -108,7 +108,7 @@ public class ContentPlaceController {
                                     summary = "컨텐츠를 찾을 수 없음",
                                     value = """
                                             {
-                                                "message": "해당 id에 대한 컨텐츠가 존재하지 않습니다."
+                                                "tag": "CONTENT_NOT_FOUND"
                                             }
                                             """
                             )

--- a/backend/src/main/java/turip/content/service/ContentPlaceService.java
+++ b/backend/src/main/java/turip/content/service/ContentPlaceService.java
@@ -3,6 +3,7 @@ package turip.content.service;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import turip.common.exception.ErrorTag;
 import turip.common.exception.custom.NotFoundException;
 import turip.content.controller.dto.response.place.ContentPlaceDetailResponse;
 import turip.content.controller.dto.response.place.ContentPlaceResponse;
@@ -47,7 +48,7 @@ public class ContentPlaceService {
     private void validateContentExists(Long contentId) {
         boolean isContentExists = contentRepository.existsById(contentId);
         if (!isContentExists) {
-            throw new NotFoundException("해당 id에 대한 컨텐츠가 존재하지 않습니다.");
+            throw new NotFoundException(ErrorTag.CONTENT_NOT_FOUND);
         }
     }
 

--- a/backend/src/main/java/turip/content/service/ContentService.java
+++ b/backend/src/main/java/turip/content/service/ContentService.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
+import turip.common.exception.ErrorTag;
 import turip.common.exception.custom.BadRequestException;
 import turip.common.exception.custom.NotFoundException;
 import turip.content.controller.dto.response.content.ContentCountResponse;
@@ -43,7 +44,7 @@ public class ContentService {
 
     public ContentResponse getContentWithFavoriteStatus(Long contentId, Member member) {
         Content content = contentRepository.findById(contentId)
-                .orElseThrow(() -> new NotFoundException("컨텐츠를 찾을 수 없습니다."));
+                .orElseThrow(() -> new NotFoundException(ErrorTag.CONTENT_NOT_FOUND));
         boolean isFavorite = favoriteContentRepository.existsByMemberIdAndContentId(member.getId(), content.getId());
         return ContentResponse.of(content, isFavorite);
     }
@@ -116,7 +117,7 @@ public class ContentService {
         if (OverseasRegionCategory.containsName(regionCategory)) {
             return contentRepository.countByCityCountryName(regionCategory);
         }
-        throw new BadRequestException("지역 카테고리가 올바르지 않습니다.");
+        throw new BadRequestException(ErrorTag.PLACE_CATEGORY_WRONG);
     }
 
     private int calculateDomesticEtcCount() {
@@ -218,7 +219,7 @@ public class ContentService {
     private int getTripPlaceCount(Content content) {
         boolean isContentExists = contentRepository.existsById(content.getId());
         if (!isContentExists) {
-            throw new NotFoundException("컨텐츠를 찾을 수 없습니다.");
+            throw new NotFoundException(ErrorTag.CONTENT_NOT_FOUND);
         }
         return contentPlaceService.countByContentId(content.getId());
     }

--- a/backend/src/main/java/turip/content/service/ContentService.java
+++ b/backend/src/main/java/turip/content/service/ContentService.java
@@ -117,7 +117,7 @@ public class ContentService {
         if (OverseasRegionCategory.containsName(regionCategory)) {
             return contentRepository.countByCityCountryName(regionCategory);
         }
-        throw new BadRequestException(ErrorTag.PLACE_CATEGORY_WRONG);
+        throw new BadRequestException(ErrorTag.REGION_CATEGORY_WRONG);
     }
 
     private int calculateDomesticEtcCount() {

--- a/backend/src/main/java/turip/content/service/ContentService.java
+++ b/backend/src/main/java/turip/content/service/ContentService.java
@@ -117,7 +117,7 @@ public class ContentService {
         if (OverseasRegionCategory.containsName(regionCategory)) {
             return contentRepository.countByCityCountryName(regionCategory);
         }
-        throw new BadRequestException(ErrorTag.REGION_CATEGORY_WRONG);
+        throw new BadRequestException(ErrorTag.REGION_CATEGORY_INVALID);
     }
 
     private int calculateDomesticEtcCount() {

--- a/backend/src/main/java/turip/creator/controller/CreatorController.java
+++ b/backend/src/main/java/turip/creator/controller/CreatorController.java
@@ -60,7 +60,7 @@ public class CreatorController {
                                     summary = "크리에이터가 존재하지 않음",
                                     value = """
                                             {
-                                                "message": "크리에이터를 찾을 수 없습니다."
+                                                "tag": "CREATOR_NOT_FOUND"
                                             }
                                             """
                             )

--- a/backend/src/main/java/turip/creator/service/CreatorService.java
+++ b/backend/src/main/java/turip/creator/service/CreatorService.java
@@ -2,6 +2,7 @@ package turip.creator.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import turip.common.exception.ErrorTag;
 import turip.common.exception.custom.NotFoundException;
 import turip.creator.controller.dto.response.CreatorResponse;
 import turip.creator.domain.Creator;
@@ -15,7 +16,7 @@ public class CreatorService {
 
     public CreatorResponse getById(Long id) {
         Creator creator = creatorRepository.findById(id)
-                .orElseThrow(() -> new NotFoundException("크리에이터를 찾을 수 없습니다."));
+                .orElseThrow(() -> new NotFoundException(ErrorTag.CREATOR_NOT_FOUND));
         return CreatorResponse.from(creator);
     }
 }

--- a/backend/src/main/java/turip/favorite/controller/FavoriteContentController.java
+++ b/backend/src/main/java/turip/favorite/controller/FavoriteContentController.java
@@ -86,7 +86,7 @@ public class FavoriteContentController {
                                             summary = "컨텐츠를 찾을 수 없음",
                                             value = """
                                                     {
-                                                        "message": "존재하지 않는 컨텐츠입니다."
+                                                        "tag": "CONTENT_NOT_FOUND"
                                                     }
                                                     """
                                     )
@@ -105,7 +105,7 @@ public class FavoriteContentController {
                                             summary = "이미 찜 한 컨텐츠",
                                             value = """
                                                     {
-                                                        "message": "이미 찜한 컨텐츠입니다."
+                                                        "tag": "FAVORITE_CONTENT_CONFLICT"
                                                     }
                                                     """
                                     )
@@ -179,7 +179,7 @@ public class FavoriteContentController {
                                             summary = "올바르지 않은 device-fid",
                                             value = """
                                                     {
-                                                        "message": "사용자 정보를 조회할 수 없습니다."
+                                                        "tag": "MEMBER_NOT_FOUND"
                                                     }
                                                     """
                                     )
@@ -219,7 +219,7 @@ public class FavoriteContentController {
                                             summary = "컨텐츠를 찾을 수 없음",
                                             value = """
                                                     {
-                                                        "message": "존재하지 않는 컨텐츠입니다."
+                                                        "tag": "CONTENT_NOT_FOUND"
                                                     }
                                                     """
                                     ),
@@ -228,7 +228,7 @@ public class FavoriteContentController {
                                             summary = "존재하지 않는 사용자",
                                             value = """
                                                     {
-                                                        "message": "존재하지 않는 사용자입니다."
+                                                        "tag": "MEMBER_NOT_FOUND"
                                                     }
                                                     """
                                     ),
@@ -237,7 +237,7 @@ public class FavoriteContentController {
                                             summary = "찜하지 않은 컨텐츠",
                                             value = """
                                                     {
-                                                        "message": "해당 컨텐츠는 찜한 상태가 아닙니다."
+                                                        "tag": "FAVORITE_CONTENT_NOT_FOUND"
                                                     }
                                                     """
                                     )

--- a/backend/src/main/java/turip/favorite/controller/FavoriteContentController.java
+++ b/backend/src/main/java/turip/favorite/controller/FavoriteContentController.java
@@ -168,7 +168,7 @@ public class FavoriteContentController {
                     )
             ),
             @ApiResponse(
-                    responseCode = "400",
+                    responseCode = "404",
                     description = "실패 예시",
                     content = @Content(
                             mediaType = "application/json",

--- a/backend/src/main/java/turip/favorite/controller/FavoriteFolderController.java
+++ b/backend/src/main/java/turip/favorite/controller/FavoriteFolderController.java
@@ -76,7 +76,7 @@ public class FavoriteFolderController {
                                             summary = "장소 찜 폴더 이름이 공백인 경우",
                                             value = """
                                                     {
-                                                        "message": "장소 찜 폴더 이름은 빈 칸이 될 수 없습니다."
+                                                        "tag": "FAVORITE_FOLDER_NAME_BLANK"
                                                     }
                                                     """
                                     ),
@@ -85,7 +85,7 @@ public class FavoriteFolderController {
                                             summary = "장소 찜 폴더 이름이 20글자를 초과하는 경우",
                                             value = """
                                                     {
-                                                        "message": "장소 찜 폴더 이름은 최대 20글자 입니다."
+                                                        "tag": "FAVORITE_FOLDER_NAME_TOO_LONG"
                                                     }
                                                     """
                                     )

--- a/backend/src/main/java/turip/favorite/controller/FavoriteFolderController.java
+++ b/backend/src/main/java/turip/favorite/controller/FavoriteFolderController.java
@@ -104,7 +104,7 @@ public class FavoriteFolderController {
                                             summary = "같은 이름의 폴더가 이미 존재하는 경우",
                                             value = """
                                                     {
-                                                        "message": "중복된 폴더 이름이 존재합니다."
+                                                        "tag": "FAVORITE_FOLDER_NAME_CONFLICT"
                                                     }
                                                     """
                                     )
@@ -214,7 +214,7 @@ public class FavoriteFolderController {
                                     summary = "placeId에 대한 장소가 존재하지 않는 경우",
                                     value = """
                                             {
-                                                "message": "해당 id에 대한 장소가 존재하지 않습니다."
+                                                "tag": "PLACE_NOT_FOUND"
                                             }
                                             """
                             )
@@ -267,7 +267,7 @@ public class FavoriteFolderController {
                                             summary = "장소 찜 폴더 이름이 공백인 경우",
                                             value = """
                                                     {
-                                                        "message": "장소 찜 폴더 이름은 빈 칸이 될 수 없습니다."
+                                                        "tag": "FAVORITE_FOLDER_NAME_BLANK"
                                                     }
                                                     """
                                     ),
@@ -276,7 +276,7 @@ public class FavoriteFolderController {
                                             summary = "장소 찜 폴더 이름이 20글자를 초과하는 경우",
                                             value = """
                                                     {
-                                                        "message": "장소 찜 폴더 이름은 최대 20글자 입니다."
+                                                        "tag": "FAVORITE_FOLDER_NAME_TOO_LONG"
                                                     }
                                                     """
                                     ),
@@ -285,7 +285,7 @@ public class FavoriteFolderController {
                                             summary = "장소 찜 폴더가 기본 폴더인 경우",
                                             value = """
                                                     {
-                                                        "message": "기본 폴더는 수정할 수 없습니다."
+                                                        "tag": "IS_DEFAULT_FAVORITE_FOLDER"
                                                     }
                                                     """
                                     )
@@ -304,7 +304,7 @@ public class FavoriteFolderController {
                                             summary = "폴더 소유자의 기기id와 요청자의 기기id가 같지 않은 경우",
                                             value = """
                                                     {
-                                                        "message" : "폴더 소유자의 기기id와 요청자의 기기id가 같지 않습니다."
+                                                        "tag" : "FORBIDDEN"
                                                     }
                                                     """
                                     )
@@ -323,7 +323,7 @@ public class FavoriteFolderController {
                                             summary = "device-fid에 대한 회원을 찾을 수 없는 경우",
                                             value = """
                                                     {
-                                                        "message" : "해당 id에 대한 회원이 존재하지 않습니다."
+                                                        "tag" : "MEMBER_NOT_FOUND"
                                                     }
                                                     """
                                     ),
@@ -332,7 +332,7 @@ public class FavoriteFolderController {
                                             summary = "id에 대한 폴더를 찾을 수 없는 경우",
                                             value = """
                                                     {
-                                                        "message" : "해당 id에 대한 폴더가 존재하지 않습니다."
+                                                        "tag" : "FAVORITE_FOLDER_NOT_FOUND"
                                                     }
                                                     """
                                     )
@@ -351,7 +351,7 @@ public class FavoriteFolderController {
                                             summary = "중복되는 폴더 이름이 존재하는 경우",
                                             value = """
                                                     {
-                                                        "message" : "중복된 폴더 이름이 존재합니다."
+                                                        "tag" : "FAVORITE_FOLDER_NAME_CONFLICT"
                                                     }
                                                     """
                                     )
@@ -389,7 +389,7 @@ public class FavoriteFolderController {
                                     summary = "삭제하려는 폴더가 기본 폴더인 경우",
                                     value = """
                                             {
-                                                "message" : "기본 폴더는 삭제할 수 없습니다."
+                                                "tag" : "IS_DEFAULT_FAVORITE_FOLDER"
                                             }
                                             """
                             )
@@ -406,7 +406,7 @@ public class FavoriteFolderController {
                                     summary = "폴더 소유자의 기기id와 요청자의 기기id가 같지 않은 경우",
                                     value = """
                                             {
-                                                "message" : "폴더 소유자의 기기id와 요청자의 기기id가 같지 않습니다."
+                                                "tag" : "FORBIDDEN"
                                             }
                                             """
                             )
@@ -424,7 +424,7 @@ public class FavoriteFolderController {
                                             summary = "device-fid에 대한 회원을 찾을 수 없는 경우",
                                             value = """
                                                     {
-                                                        "message" : "해당 id에 대한 회원이 존재하지 않습니다."
+                                                        "tag" : "MEMBER_NOT_FOUND"
                                                     }
                                                     """
                                     ),
@@ -433,7 +433,7 @@ public class FavoriteFolderController {
                                             summary = "id에 대한 폴더를 찾을 수 없는 경우",
                                             value = """
                                                     {
-                                                        "message" : "해당 id에 대한 폴더가 존재하지 않습니다."
+                                                        "tag" : "FAVORITE_FOLDER_NOT_FOUND"
                                                     }
                                                     """
                                     )

--- a/backend/src/main/java/turip/favorite/controller/FavoriteFolderController.java
+++ b/backend/src/main/java/turip/favorite/controller/FavoriteFolderController.java
@@ -285,7 +285,7 @@ public class FavoriteFolderController {
                                             summary = "장소 찜 폴더가 기본 폴더인 경우",
                                             value = """
                                                     {
-                                                        "tag": "IS_DEFAULT_FAVORITE_FOLDER"
+                                                        "tag": "DEFAULT_FAVORITE_FOLDER_OPERATION_NOT_ALLOWED"
                                                     }
                                                     """
                                     )
@@ -389,7 +389,7 @@ public class FavoriteFolderController {
                                     summary = "삭제하려는 폴더가 기본 폴더인 경우",
                                     value = """
                                             {
-                                                "tag" : "IS_DEFAULT_FAVORITE_FOLDER"
+                                                "tag" : "DEFAULT_FAVORITE_FOLDER_OPERATION_NOT_ALLOWED"
                                             }
                                             """
                             )

--- a/backend/src/main/java/turip/favorite/controller/FavoritePlaceController.java
+++ b/backend/src/main/java/turip/favorite/controller/FavoritePlaceController.java
@@ -69,7 +69,7 @@ public class FavoritePlaceController {
                                             summary = "폴더 소유자의 기기id와 요청자의 기기id가 같지 않은 경우",
                                             value = """
                                                     {
-                                                        "message" : "폴더 소유자의 기기id와 요청자의 기기id가 같지 않습니다."
+                                                        "tag" : "FORBIDDEN"
                                                     }
                                                     """
                                     )
@@ -88,7 +88,7 @@ public class FavoritePlaceController {
                                             summary = "favoriteFolderId에 대한 폴더를 찾을 수 없는 경우",
                                             value = """
                                                     {
-                                                        "message" : "해당 id에 대한 폴더가 존재하지 않습니다."
+                                                        "tag" : "FAVORITE_FOLDER_NOT_FOUND"
                                                     }
                                                     """
                                     ),
@@ -97,7 +97,7 @@ public class FavoritePlaceController {
                                             summary = "placeId에 대한 장소를 찾을 수 없는 경우",
                                             value = """
                                                     {
-                                                        "message" : "해당 id에 대한 장소가 존재하지 않습니다."
+                                                        "tag" : "FAVORITE_PLACE_NOT_FOUND"
                                                     }
                                                     """
                                     )
@@ -116,7 +116,7 @@ public class FavoritePlaceController {
                                             summary = "이미 해당 폴더에 찜한 상태인 경우",
                                             value = """
                                                     {
-                                                        "message": "이미 해당 폴더에 찜한 장소입니다."
+                                                        "tag": "FAVORITE_PLACE_CONFLICT"
                                                     }
                                                     """
                                     )
@@ -203,7 +203,7 @@ public class FavoritePlaceController {
                                             summary = "favoriteFolderId에 대한 폴더가 존재하지 않는 경우",
                                             value = """
                                                     {
-                                                        "message" : "해당 id에 대한 폴더가 존재하지 않습니다."
+                                                        "tag" : "FAVORITE_FOLDER_NOT_FOUND"
                                                     }
                                                     """
                                     )
@@ -240,7 +240,7 @@ public class FavoritePlaceController {
                                             summary = "폴더 소유자의 기기id와 요청자의 기기id가 같지 않은 경우",
                                             value = """
                                                     {
-                                                        "message" : "폴더 소유자의 기기id와 요청자의 기기id가 같지 않습니다."
+                                                        "tag" : "FORBIDDEN"
                                                     }
                                                     """
                                     )
@@ -259,7 +259,7 @@ public class FavoritePlaceController {
                                             summary = "deviceFid에 대한 회원을 찾을 수 없는 경우",
                                             value = """
                                                     {
-                                                        "message" : "해당 id에 대한 회원이 존재하지 않습니다."
+                                                        "tag" : "MEMBER_NOT_FOUND"
                                                     }
                                                     """
                                     ),
@@ -268,7 +268,7 @@ public class FavoritePlaceController {
                                             summary = "favoriteFolderId에 대한 폴더를 찾을 수 없는 경우",
                                             value = """
                                                     {
-                                                        "message" : "해당 id에 대한 폴더가 존재하지 않습니다."
+                                                        "tag" : "FAVORITE_FOLDER_NOT_FOUND"
                                                     }
                                                     """
                                     ),
@@ -277,7 +277,7 @@ public class FavoritePlaceController {
                                             summary = "placeId에 대한 장소를 찾을 수 없는 경우",
                                             value = """
                                                     {
-                                                        "message" : "해당 id에 대한 장소가 존재하지 않습니다."
+                                                        "tag" : "PLACE_NOT_FOUND"
                                                     }
                                                     """
                                     ),
@@ -286,7 +286,7 @@ public class FavoritePlaceController {
                                             summary = "해당 폴더에 장소 찜이 되어있지 않은 경우",
                                             value = """
                                                     {
-                                                        "message" : "삭제하려는 장소 찜이 존재하지 않습니다."
+                                                        "tag" : "FAVORITE_PLACE_NOT_FOUND"
                                                     }
                                                     """
                                     )

--- a/backend/src/main/java/turip/favorite/controller/FavoritePlaceController.java
+++ b/backend/src/main/java/turip/favorite/controller/FavoritePlaceController.java
@@ -116,7 +116,7 @@ public class FavoritePlaceController {
                                             summary = "이미 해당 폴더에 찜한 상태인 경우",
                                             value = """
                                                     {
-                                                        "tag": "FAVORITE_PLACE_CONFLICT"
+                                                        "tag": "FAVORITE_PLACE_IN_FOLDER_CONFLICT"
                                                     }
                                                     """
                                     )

--- a/backend/src/main/java/turip/favorite/domain/FavoriteFolder.java
+++ b/backend/src/main/java/turip/favorite/domain/FavoriteFolder.java
@@ -15,6 +15,8 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import turip.common.exception.ErrorTag;
+import turip.common.exception.custom.IllegalArgumentException;
 import turip.member.domain.Member;
 
 @Getter
@@ -64,10 +66,10 @@ public class FavoriteFolder {
 
     private static void validateName(String name) {
         if (name.isBlank()) {
-            throw new IllegalArgumentException("장소 찜 폴더 이름은 빈 칸이 될 수 없습니다.");
+            throw new IllegalArgumentException(ErrorTag.FAVORITE_FOLDER_NAME_BLANK);
         }
         if (name.length() > 20) {
-            throw new IllegalArgumentException("장소 찜 폴더 이름은 최대 20글자 입니다.");
+            throw new IllegalArgumentException(ErrorTag.FAVORITE_FOLDER_NAME_TOO_LONG);
         }
     }
 

--- a/backend/src/main/java/turip/favorite/service/FavoriteContentService.java
+++ b/backend/src/main/java/turip/favorite/service/FavoriteContentService.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import turip.common.exception.ErrorTag;
 import turip.common.exception.custom.ConflictException;
 import turip.common.exception.custom.NotFoundException;
 import turip.content.controller.dto.response.content.ContentDetailResponse;
@@ -34,9 +35,9 @@ public class FavoriteContentService {
     public FavoriteContentResponse create(FavoriteContentRequest request, Member member) {
         Long contentId = request.contentId();
         Content content = contentRepository.findById(contentId)
-                .orElseThrow(() -> new NotFoundException("존재하지 않는 컨텐츠입니다."));
+                .orElseThrow(() -> new NotFoundException(ErrorTag.CONTENT_NOT_FOUND));
         if (favoriteContentRepository.existsByMemberIdAndContentId(member.getId(), content.getId())) {
-            throw new ConflictException("이미 찜한 컨텐츠입니다.");
+            throw new ConflictException(ErrorTag.FAVORITE_CONTENT_CONFLICT);
         }
         FavoriteContent favoriteContent = new FavoriteContent(LocalDate.now(), member, content);
         FavoriteContent savedFavoriteContent = favoriteContentRepository.save(favoriteContent);
@@ -61,10 +62,10 @@ public class FavoriteContentService {
     @Transactional
     public void remove(Member member, Long contentId) {
         Content content = contentRepository.findById(contentId)
-                .orElseThrow(() -> new NotFoundException("존재하지 않는 컨텐츠입니다."));
+                .orElseThrow(() -> new NotFoundException(ErrorTag.CONTENT_NOT_FOUND));
         FavoriteContent favoriteContent = favoriteContentRepository.findByMemberIdAndContentId(member.getId(),
                         content.getId())
-                .orElseThrow(() -> new NotFoundException("해당 컨텐츠는 찜한 상태가 아닙니다."));
+                .orElseThrow(() -> new NotFoundException(ErrorTag.FAVORITE_CONTENT_NOT_FOUND));
         favoriteContentRepository.delete(favoriteContent);
     }
 
@@ -89,7 +90,7 @@ public class FavoriteContentService {
     private void validateContentExists(Long contentId) {
         boolean isContentExists = contentRepository.existsById(contentId);
         if (!isContentExists) {
-            throw new NotFoundException("컨텐츠를 찾을 수 없습니다.");
+            throw new NotFoundException(ErrorTag.CONTENT_NOT_FOUND);
         }
     }
 }

--- a/backend/src/main/java/turip/favorite/service/FavoriteFolderService.java
+++ b/backend/src/main/java/turip/favorite/service/FavoriteFolderService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import turip.common.exception.ErrorTag;
 import turip.common.exception.custom.BadRequestException;
 import turip.common.exception.custom.ConflictException;
 import turip.common.exception.custom.ForbiddenException;
@@ -72,7 +73,7 @@ public class FavoriteFolderService {
                                              FavoriteFolderNameRequest request) {
         FavoriteFolder favoriteFolder = getById(favoriteFolderId);
         if (favoriteFolder.isDefault()) {
-            throw new BadRequestException("기본 폴더는 수정할 수 없습니다.");
+            throw new BadRequestException(ErrorTag.IS_DEFAULT_FAVORITE_FOLDER);
         }
 
         String newName = FavoriteFolder.formatName(request.name());
@@ -88,7 +89,7 @@ public class FavoriteFolderService {
         FavoriteFolder favoriteFolder = getById(favoriteFolderId);
 
         if (favoriteFolder.isDefault()) {
-            throw new BadRequestException("기본 폴더는 삭제할 수 없습니다.");
+            throw new BadRequestException(ErrorTag.IS_DEFAULT_FAVORITE_FOLDER);
         }
         validateOwnership(member, favoriteFolder);
 
@@ -97,23 +98,23 @@ public class FavoriteFolderService {
 
     private void validateDuplicatedName(String folderName, Member member) {
         if (favoriteFolderRepository.existsByNameAndMember(folderName, member)) {
-            throw new ConflictException("중복된 폴더 이름이 존재합니다.");
+            throw new ConflictException(ErrorTag.FAVORITE_FOLDER_NAME_CONFLICT);
         }
     }
 
     private Place getPlaceById(Long id) {
         return placeRepository.findById(id)
-                .orElseThrow(() -> new NotFoundException("해당 id에 대한 장소가 존재하지 않습니다."));
+                .orElseThrow(() -> new NotFoundException(ErrorTag.PLACE_NOT_FOUND));
     }
 
     private FavoriteFolder getById(Long favoriteFolderId) {
         return favoriteFolderRepository.findById(favoriteFolderId)
-                .orElseThrow(() -> new NotFoundException("해당 id에 대한 폴더가 존재하지 않습니다."));
+                .orElseThrow(() -> new NotFoundException(ErrorTag.FAVORITE_FOLDER_NOT_FOUND));
     }
 
     private void validateOwnership(Member requestMember, FavoriteFolder favoriteFolder) {
         if (!favoriteFolder.isOwner(requestMember)) {
-            throw new ForbiddenException("폴더 소유자의 기기id와 요청자의 기기id가 같지 않습니다.");
+            throw new ForbiddenException(ErrorTag.FORBIDDEN);
         }
     }
 }

--- a/backend/src/main/java/turip/favorite/service/FavoriteFolderService.java
+++ b/backend/src/main/java/turip/favorite/service/FavoriteFolderService.java
@@ -73,7 +73,7 @@ public class FavoriteFolderService {
                                              FavoriteFolderNameRequest request) {
         FavoriteFolder favoriteFolder = getById(favoriteFolderId);
         if (favoriteFolder.isDefault()) {
-            throw new BadRequestException(ErrorTag.IS_DEFAULT_FAVORITE_FOLDER);
+            throw new BadRequestException(ErrorTag.DEFAULT_FAVORITE_FOLDER_OPERATION_NOT_ALLOWED);
         }
 
         String newName = FavoriteFolder.formatName(request.name());
@@ -89,7 +89,7 @@ public class FavoriteFolderService {
         FavoriteFolder favoriteFolder = getById(favoriteFolderId);
 
         if (favoriteFolder.isDefault()) {
-            throw new BadRequestException(ErrorTag.IS_DEFAULT_FAVORITE_FOLDER);
+            throw new BadRequestException(ErrorTag.DEFAULT_FAVORITE_FOLDER_OPERATION_NOT_ALLOWED);
         }
         validateOwnership(member, favoriteFolder);
 

--- a/backend/src/main/java/turip/favorite/service/FavoritePlaceService.java
+++ b/backend/src/main/java/turip/favorite/service/FavoritePlaceService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import turip.common.exception.ErrorTag;
 import turip.common.exception.custom.ConflictException;
 import turip.common.exception.custom.ForbiddenException;
 import turip.common.exception.custom.NotFoundException;
@@ -64,29 +65,29 @@ public class FavoritePlaceService {
 
     private FavoriteFolder getFavoriteFolderById(Long favoriteFolderId) {
         return favoriteFolderRepository.findById(favoriteFolderId)
-                .orElseThrow(() -> new NotFoundException("해당 id에 대한 폴더가 존재하지 않습니다."));
+                .orElseThrow(() -> new NotFoundException(ErrorTag.FAVORITE_FOLDER_NOT_FOUND));
     }
 
     private Place getPlaceById(Long placeId) {
         return placeRepository.findById(placeId)
-                .orElseThrow(() -> new NotFoundException("해당 id에 대한 장소가 존재하지 않습니다."));
+                .orElseThrow(() -> new NotFoundException(ErrorTag.PLACE_NOT_FOUND));
     }
 
     private void validateOwnership(Member requestMember, FavoriteFolder favoriteFolder) {
         if (!favoriteFolder.isOwner(requestMember)) {
-            throw new ForbiddenException("폴더 소유자의 기기id와 요청자의 기기id가 같지 않습니다.");
+            throw new ForbiddenException(ErrorTag.FORBIDDEN);
         }
     }
 
     private void validateDuplicated(FavoriteFolder favoriteFolder, Place place) {
         boolean isAlreadyFavorite = favoritePlaceRepository.existsByFavoriteFolderAndPlace(favoriteFolder, place);
         if (isAlreadyFavorite) {
-            throw new ConflictException("이미 해당 폴더에 찜한 장소입니다.");
+            throw new ConflictException(ErrorTag.FAVORITE_PLACE_CONFLICT);
         }
     }
 
     private FavoritePlace getByFavoriteFolderAndPlace(FavoriteFolder favoriteFolder, Place place) {
         return favoritePlaceRepository.findByFavoriteFolderAndPlace(favoriteFolder, place)
-                .orElseThrow(() -> new NotFoundException("삭제하려는 장소 찜이 존재하지 않습니다."));
+                .orElseThrow(() -> new NotFoundException(ErrorTag.FAVORITE_PLACE_NOT_FOUND));
     }
 }

--- a/backend/src/main/java/turip/favorite/service/FavoritePlaceService.java
+++ b/backend/src/main/java/turip/favorite/service/FavoritePlaceService.java
@@ -82,7 +82,7 @@ public class FavoritePlaceService {
     private void validateDuplicated(FavoriteFolder favoriteFolder, Place place) {
         boolean isAlreadyFavorite = favoritePlaceRepository.existsByFavoriteFolderAndPlace(favoriteFolder, place);
         if (isAlreadyFavorite) {
-            throw new ConflictException(ErrorTag.FAVORITE_PLACE_CONFLICT);
+            throw new ConflictException(ErrorTag.FAVORITE_PLACE_IN_FOLDER_CONFLICT);
         }
     }
 

--- a/backend/src/main/java/turip/member/service/MemberService.java
+++ b/backend/src/main/java/turip/member/service/MemberService.java
@@ -3,6 +3,7 @@ package turip.member.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import turip.common.exception.ErrorTag;
 import turip.common.exception.custom.NotFoundException;
 import turip.favorite.domain.FavoriteFolder;
 import turip.favorite.repository.FavoriteFolderRepository;
@@ -29,6 +30,6 @@ public class MemberService {
 
     public Member getMemberByDeviceId(String deviceFid) {
         return memberRepository.findByDeviceFid(deviceFid)
-                .orElseThrow(() -> new NotFoundException("해당 id에 대한 회원이 존재하지 않습니다."));
+                .orElseThrow(() -> new NotFoundException(ErrorTag.MEMBER_NOT_FOUND));
     }
 }

--- a/backend/src/main/java/turip/place/domain/GoogleMapCategoryMapper.java
+++ b/backend/src/main/java/turip/place/domain/GoogleMapCategoryMapper.java
@@ -1,0 +1,6 @@
+package turip.place.domain;
+
+public enum GoogleMapCategoryMapper {
+
+    
+}

--- a/backend/src/main/java/turip/region/domain/DomesticRegionCategory.java
+++ b/backend/src/main/java/turip/region/domain/DomesticRegionCategory.java
@@ -26,7 +26,7 @@ public enum DomesticRegionCategory {
 
     public static boolean containsName(String regionCategoryName) {
         if (StringUtils.isBlank(regionCategoryName)) {
-            throw new IllegalArgumentException(ErrorTag.REGION_CATEGORY_WRONG);
+            throw new IllegalArgumentException(ErrorTag.REGION_CATEGORY_INVALID);
         }
 
         for (DomesticRegionCategory category : values()) {

--- a/backend/src/main/java/turip/region/domain/DomesticRegionCategory.java
+++ b/backend/src/main/java/turip/region/domain/DomesticRegionCategory.java
@@ -5,6 +5,8 @@ import java.util.Arrays;
 import java.util.List;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import turip.common.exception.ErrorTag;
+import turip.common.exception.custom.IllegalArgumentException;
 
 @Getter
 @RequiredArgsConstructor
@@ -24,7 +26,7 @@ public enum DomesticRegionCategory {
 
     public static boolean containsName(String regionCategoryName) {
         if (StringUtils.isBlank(regionCategoryName)) {
-            throw new IllegalArgumentException("지역 카테고리 명이 빈 값입니다.");
+            throw new IllegalArgumentException(ErrorTag.REGION_CATEGORY_WRONG);
         }
 
         for (DomesticRegionCategory category : values()) {

--- a/backend/src/main/java/turip/region/domain/OverseasRegionCategory.java
+++ b/backend/src/main/java/turip/region/domain/OverseasRegionCategory.java
@@ -21,7 +21,7 @@ public enum OverseasRegionCategory {
 
     public static boolean containsName(String regionCategoryName) {
         if (StringUtils.isBlank(regionCategoryName)) {
-            throw new IllegalArgumentException(ErrorTag.REGION_CATEGORY_WRONG);
+            throw new IllegalArgumentException(ErrorTag.REGION_CATEGORY_INVALID);
         }
 
         for (OverseasRegionCategory category : values()) {

--- a/backend/src/main/java/turip/region/domain/OverseasRegionCategory.java
+++ b/backend/src/main/java/turip/region/domain/OverseasRegionCategory.java
@@ -5,6 +5,8 @@ import java.util.Arrays;
 import java.util.List;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import turip.common.exception.ErrorTag;
+import turip.common.exception.custom.IllegalArgumentException;
 
 @Getter
 @RequiredArgsConstructor
@@ -19,7 +21,7 @@ public enum OverseasRegionCategory {
 
     public static boolean containsName(String regionCategoryName) {
         if (StringUtils.isBlank(regionCategoryName)) {
-            throw new IllegalArgumentException("지역 카테고리 명이 빈 값입니다.");
+            throw new IllegalArgumentException(ErrorTag.REGION_CATEGORY_WRONG);
         }
 
         for (OverseasRegionCategory category : values()) {

--- a/backend/src/test/java/turip/favorite/domain/FavoriteFolderTest.java
+++ b/backend/src/test/java/turip/favorite/domain/FavoriteFolderTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import turip.common.exception.ErrorTag;
+import turip.common.exception.custom.IllegalArgumentException;
 import turip.member.domain.Member;
 
 class FavoriteFolderTest {
@@ -52,7 +54,7 @@ class FavoriteFolderTest {
             // when & then
             assertThatThrownBy(() -> FavoriteFolder.customFolderOf(null, name))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("장소 찜 폴더 이름은 빈 칸이 될 수 없습니다.");
+                    .hasMessage(ErrorTag.FAVORITE_FOLDER_NAME_BLANK.getMessage());
         }
 
         @DisplayName("폴더 이름이 20자를 초과하는 경우 IllegalArgumentException을 발생시킨다")
@@ -67,7 +69,7 @@ class FavoriteFolderTest {
                     () -> assertDoesNotThrow(() -> FavoriteFolder.customFolderOf(null, nameOfLength20)),
                     () -> assertThatThrownBy(() -> FavoriteFolder.customFolderOf(null, nameOfLength21))
                             .isInstanceOf(IllegalArgumentException.class)
-                            .hasMessage("장소 찜 폴더 이름은 최대 20글자 입니다.")
+                            .hasMessage(ErrorTag.FAVORITE_FOLDER_NAME_TOO_LONG.getMessage())
             );
         }
     }

--- a/backend/src/test/java/turip/favorite/service/FavoriteContentServiceTest.java
+++ b/backend/src/test/java/turip/favorite/service/FavoriteContentServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.SliceImpl;
+import turip.common.exception.ErrorTag;
 import turip.common.exception.custom.ConflictException;
 import turip.common.exception.custom.NotFoundException;
 import turip.content.controller.dto.response.content.ContentsDetailWithLoadableResponse;
@@ -259,7 +260,8 @@ class FavoriteContentServiceTest {
 
             // when & then
             assertThatThrownBy(() -> favoriteContentService.remove(member, contentId))
-                    .isInstanceOf(NotFoundException.class);
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessageContaining(ErrorTag.FAVORITE_CONTENT_NOT_FOUND.getMessage());
         }
     }
 }

--- a/backend/src/test/java/turip/favorite/service/FavoriteFolderServiceTest.java
+++ b/backend/src/test/java/turip/favorite/service/FavoriteFolderServiceTest.java
@@ -365,7 +365,7 @@ class FavoriteFolderServiceTest {
             // when & then
             assertThatThrownBy(() -> favoriteFolderService.updateName(member, folderId, request))
                     .isInstanceOf(BadRequestException.class)
-                    .hasMessage(ErrorTag.IS_DEFAULT_FAVORITE_FOLDER.getMessage());
+                    .hasMessage(ErrorTag.DEFAULT_FAVORITE_FOLDER_OPERATION_NOT_ALLOWED.getMessage());
         }
     }
 
@@ -458,7 +458,7 @@ class FavoriteFolderServiceTest {
             // when & then
             assertThatThrownBy(() -> favoriteFolderService.remove(member, folderId))
                     .isInstanceOf(BadRequestException.class)
-                    .hasMessage(ErrorTag.IS_DEFAULT_FAVORITE_FOLDER.getMessage());
+                    .hasMessage(ErrorTag.DEFAULT_FAVORITE_FOLDER_OPERATION_NOT_ALLOWED.getMessage());
         }
     }
 }

--- a/backend/src/test/java/turip/favorite/service/FavoriteFolderServiceTest.java
+++ b/backend/src/test/java/turip/favorite/service/FavoriteFolderServiceTest.java
@@ -21,6 +21,7 @@ import turip.common.exception.ErrorTag;
 import turip.common.exception.custom.BadRequestException;
 import turip.common.exception.custom.ConflictException;
 import turip.common.exception.custom.ForbiddenException;
+import turip.common.exception.custom.IllegalArgumentException;
 import turip.common.exception.custom.NotFoundException;
 import turip.favorite.controller.dto.request.FavoriteFolderNameRequest;
 import turip.favorite.controller.dto.request.FavoriteFolderRequest;

--- a/backend/src/test/java/turip/favorite/service/FavoriteFolderServiceTest.java
+++ b/backend/src/test/java/turip/favorite/service/FavoriteFolderServiceTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import turip.common.exception.ErrorTag;
 import turip.common.exception.custom.BadRequestException;
 import turip.common.exception.custom.ConflictException;
 import turip.common.exception.custom.ForbiddenException;
@@ -209,7 +210,7 @@ class FavoriteFolderServiceTest {
             // when
             assertThatThrownBy(() -> favoriteFolderService.findAllWithFavoriteStatusByDeviceId(savedMember, placeId))
                     .isInstanceOf(NotFoundException.class)
-                    .hasMessage("해당 id에 대한 장소가 존재하지 않습니다.");
+                    .hasMessage(ErrorTag.PLACE_NOT_FOUND.getMessage());
         }
     }
 
@@ -265,7 +266,7 @@ class FavoriteFolderServiceTest {
             // when & then
             assertThatThrownBy(() -> favoriteFolderService.updateName(member, nonExistentFolderId, request))
                     .isInstanceOf(NotFoundException.class)
-                    .hasMessageContaining("해당 id에 대한 폴더가 존재하지 않습니다");
+                    .hasMessageContaining(ErrorTag.FAVORITE_FOLDER_NOT_FOUND.getMessage());
         }
 
         @DisplayName("요청 회원 정보와 폴더 소유자의 정보가 일치하지 않는 경우 ForbiddenException을 발생시킨다")
@@ -363,7 +364,7 @@ class FavoriteFolderServiceTest {
             // when & then
             assertThatThrownBy(() -> favoriteFolderService.updateName(member, folderId, request))
                     .isInstanceOf(BadRequestException.class)
-                    .hasMessage("기본 폴더는 수정할 수 없습니다.");
+                    .hasMessage(ErrorTag.IS_DEFAULT_FAVORITE_FOLDER.getMessage());
         }
     }
 
@@ -410,7 +411,7 @@ class FavoriteFolderServiceTest {
             // when & then
             assertThatThrownBy(() -> favoriteFolderService.remove(member, nonExistentFolderId))
                     .isInstanceOf(NotFoundException.class)
-                    .hasMessageContaining("해당 id에 대한 폴더가 존재하지 않습니다");
+                    .hasMessageContaining(ErrorTag.FAVORITE_FOLDER_NOT_FOUND.getMessage());
         }
 
         @DisplayName("요청 회원 정보와 폴더 소유자의 정보가 일치하지 않는 경우 ForbiddenException을 발생시킨다")
@@ -456,7 +457,7 @@ class FavoriteFolderServiceTest {
             // when & then
             assertThatThrownBy(() -> favoriteFolderService.remove(member, folderId))
                     .isInstanceOf(BadRequestException.class)
-                    .hasMessage("기본 폴더는 삭제할 수 없습니다.");
+                    .hasMessage(ErrorTag.IS_DEFAULT_FAVORITE_FOLDER.getMessage());
         }
     }
 }

--- a/backend/src/test/java/turip/favorite/service/FavoritePlaceServiceTest.java
+++ b/backend/src/test/java/turip/favorite/service/FavoritePlaceServiceTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import turip.common.exception.ErrorTag;
 import turip.common.exception.custom.ConflictException;
 import turip.common.exception.custom.ForbiddenException;
 import turip.common.exception.custom.NotFoundException;
@@ -120,7 +121,7 @@ class FavoritePlaceServiceTest {
             // when & then
             assertThatThrownBy(() -> favoritePlaceService.create(member, favoriteFolderId, placeId))
                     .isInstanceOf(NotFoundException.class)
-                    .hasMessage("해당 id에 대한 폴더가 존재하지 않습니다.");
+                    .hasMessage(ErrorTag.FAVORITE_FOLDER_NOT_FOUND.getMessage());
         }
 
         @DisplayName("placeId에 대한 장소가 존재하지 않는 경우 NotFoundException을 발생시킨다")
@@ -142,7 +143,7 @@ class FavoritePlaceServiceTest {
             // when & then
             assertThatThrownBy(() -> favoritePlaceService.create(member, favoriteFolderId, placeId))
                     .isInstanceOf(NotFoundException.class)
-                    .hasMessage("해당 id에 대한 장소가 존재하지 않습니다.");
+                    .hasMessage(ErrorTag.PLACE_NOT_FOUND.getMessage());
         }
 
         @DisplayName("해당 폴더에 장소 찜이 되어있는 경우 ConflictException을 발생시킨다")
@@ -214,7 +215,7 @@ class FavoritePlaceServiceTest {
             // when & then
             assertThatThrownBy(() -> favoritePlaceService.findAllByFolder(favoriteFolderId))
                     .isInstanceOf(NotFoundException.class)
-                    .hasMessage("해당 id에 대한 폴더가 존재하지 않습니다.");
+                    .hasMessage(ErrorTag.FAVORITE_FOLDER_NOT_FOUND.getMessage());
         }
     }
 
@@ -286,7 +287,7 @@ class FavoritePlaceServiceTest {
             // when & then
             assertThatThrownBy(() -> favoritePlaceService.remove(member, favoriteFolderId, placeId))
                     .isInstanceOf(NotFoundException.class)
-                    .hasMessage("해당 id에 대한 폴더가 존재하지 않습니다.");
+                    .hasMessage(ErrorTag.FAVORITE_FOLDER_NOT_FOUND.getMessage());
         }
 
         @DisplayName("placeId에 대한 장소가 존재하지 않는 경우 NotFoundException을 발생시킨다")
@@ -308,7 +309,7 @@ class FavoritePlaceServiceTest {
             // when & then
             assertThatThrownBy(() -> favoritePlaceService.remove(member, favoriteFolderId, placeId))
                     .isInstanceOf(NotFoundException.class)
-                    .hasMessage("해당 id에 대한 장소가 존재하지 않습니다.");
+                    .hasMessage(ErrorTag.PLACE_NOT_FOUND.getMessage());
         }
 
         @DisplayName("삭제하려는 장소 찜이 존재하지 않는 경우 NotFoundException을 발생시킨다")
@@ -333,7 +334,7 @@ class FavoritePlaceServiceTest {
             // when & then
             assertThatThrownBy(() -> favoritePlaceService.remove(member, favoriteFolderId, placeId))
                     .isInstanceOf(NotFoundException.class)
-                    .hasMessage("삭제하려는 장소 찜이 존재하지 않습니다.");
+                    .hasMessage(ErrorTag.FAVORITE_PLACE_NOT_FOUND.getMessage());
         }
     }
 }

--- a/backend/src/test/java/turip/region/domain/DomesticRegionCategoryTest.java
+++ b/backend/src/test/java/turip/region/domain/DomesticRegionCategoryTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import turip.common.exception.custom.IllegalArgumentException;
 
 class DomesticRegionCategoryTest {
 

--- a/backend/src/test/java/turip/region/domain/OverseasRegionCategoryTest.java
+++ b/backend/src/test/java/turip/region/domain/OverseasRegionCategoryTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import turip.common.exception.custom.IllegalArgumentException;
 
 class OverseasRegionCategoryTest {
 


### PR DESCRIPTION
## Issues
- closed #321 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
- 각 예외 상황을 나타내기 위해 기존 message를 넘겨주는 방식에서 커스텀 에러 태그를 넘겨주는 방식으로 수정했습니다!
- 에러 태그 목록은 노션 명세서에 업로드 해두겠습니다!

---

### 📍 도입 배경

기존에 저희가 에러 상황에서 내려주던 응답은 다음과 같아요.
```json
{
  "message": "device-fid에 대한 회원 정보를 찾을 수 없습니다."
}
```

이는 서버에서 에러 상황을 구분하기 위한 메시지이고, 개발자 친화적인 메시지에요. 그런데 안드로이드에서 에러뷰를 도입하면서 사용자 친화적 메시지가 필요한 상황이었고, 사용자에게 보여줄 메시지는 안드로이드에서 저장하는게 책임이 맞다고 생각했어요.

따라서 어떤 상황에서 발생한 에러인지 구분하는 수단으로 에러 태그를 도입하면 좋겠다고 생각했어요. 예를 들어 같은 409 코드여도, 해당 에러가 발생할 수 있는 상황은 다양하기 때문에, 각 상황을 구분하는 수단이 필요했습니다!
```java
FAVORITE_FOLDER_NAME_CONFLICT("이미 존재하는 찜폴더 이름입니다."),  
FAVORITE_CONTENT_CONFLICT("이미 찜한 컨텐츠입니다."),  
FAVORITE_PLACE_CONFLICT("해당 폴더에 이미 찜한 장소입니다."),
```

이제 안드에서는 이 태그에 대응하는 사용자 친화적 메시지를 에러뷰에 띄우는 방향으로 진행될 것 같습니다 😀

---

### 📍 `ErrorTag` 네이밍

기존에는 "에러 코드"라는 용어로 소통했으나, 안드로이드와 페어를 하는 과정에서 "코드"가 HTTP Status Code(400 Bad Request, 404 Not Found ...)와 헷갈린다는 의견이 나왔어요. 

따라서 안드 - 서버끼리의 통신을 위해 필요한 에러 상황을 나타내기 위한 수단을 "에러 태그"로 구분해서, 헷갈리지 않도록 했습니다!

---

### 📍 구현 내용

에러 상황에 대한 응답(ErrorResponse dto)을 아래 포맷으로 수정하려 해요.

- 기존
```json
{
  "message": "존재하지 않는 컨텐츠입니다."
}
```

- 수정
```json
{
  "tag" : "CONTENT_NOT_FOUND"
}

```

다만 이렇게 수정할 경우, 모든 예외에 tag값이 존재해야 해요. 그래서 저희가 사용하던 커스텀 예외에는 `ErrorTag`를 추가했는데, 도메인 코드에서는 `IllegalArgumentException`을 던지고 있어요. 그래서 코드를 포함시킨 `IllegalArgumentException` 을 커스텀 예외로 새로 만들었고, 앞으로 도메인에서 예외를 던질 때 이 예외를 던지면 될 것 같아요!

```java
public class IllegalArgumentException extends RuntimeException {

    private final ErrorTag errorTag;

    public IllegalArgumentException(final ErrorTag errorTag) {
        super(errorTag.getMessage());
        this.errorTag = errorTag;
    }
}
```

```java
if (deviceFid == null || deviceFid.isBlank()) {
    throw new IllegalArgumentException(ErrorTag.MEMBER_NOT_FOUND);
}
```

다만 고민이 되는건 JDK에서 제공하는 `IllegalArgumentException`과 이름이 겹친다는건데.. 
1. 현재 상태 유지
2. `IllegalArgumentException`을 확장한 다음 새로운 이름 부여
  - `IllegalRequestArgumentException`
  - `IllegalArgumentWithTagException`

의견 부탁드려요!

## 📷 Screenshot

## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - 오류 응답을 문자열 대신 중앙화된 오류 태그(ErrorTag)로 일관화했습니다.
- New Features
  - 태그 기반 오류 페이로드와 태그를 포함하는 예외 유형이 추가되어 클라이언트에 코드형 오류 태그가 반환됩니다.
- Documentation
  - 여러 API의 예제 오류 응답을 "message"에서 "tag" 기반 코드로 갱신했습니다.
- Tests
  - 테스트들을 오류 태그 기반 메시지 검증으로 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->