### PR TITLE
[feat] ServletException 관련 ExcepitonHandler 추가

### DIFF
--- a/backend/src/main/java/turip/common/exception/ErrorTag.java
+++ b/backend/src/main/java/turip/common/exception/ErrorTag.java
@@ -13,6 +13,7 @@ public enum ErrorTag {
     FORBIDDEN("접근 권한이 없습니다."),
 
     // 404 Not Found
+    NOT_FOUND("요청 정보를 찾을 수 없습니다."),
     MEMBER_NOT_FOUND("사용자를 찾을 수 없습니다."),
     CONTENT_NOT_FOUND("컨텐츠를 찾을 수 없습니다."),
     FAVORITE_FOLDER_NOT_FOUND("찜폴더를 찾을 수 없습니다."),

--- a/backend/src/main/java/turip/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/turip/common/exception/GlobalExceptionHandler.java
@@ -5,6 +5,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 import turip.common.exception.custom.HttpStatusException;
 import turip.common.exception.custom.IllegalArgumentException;
 
@@ -31,5 +33,19 @@ public class GlobalExceptionHandler {
         log.error(e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(new ErrorResponse(ErrorTag.INTERNAL_SERVER_ERROR));
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNoHandlerFoundException(NoHandlerFoundException e) {
+        log.warn(e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse(ErrorTag.NOT_FOUND));
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNoResourceFoundException(NoResourceFoundException e) {
+        log.warn(e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse(ErrorTag.NOT_FOUND));
     }
 }


### PR DESCRIPTION
## Issues
- closed #332 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description

잘못된 path로 요청이 오는 경우, DispatcherServlet 단에서 ServletException를 발생시키는데, 이 예외가 애초에 ExceptionHandler까지 전달되지 않아서, ExceptionHandler에 설정해둔 형식(tag만 응답)대로 응답을 내려주지 않는 상황이에요.

- 기대한 응답
```json
{
	"tag" : "NOT_FOUND"
}
```

- 실제 응답
```json
{
	"timestamp": "2025-09-14T15:48:40.832+00:00",
	"status": 404,
	"error": "Not Found",
	"path": "/region-categories/is-Korea"
}
```

그래서 이 경우도 tag를 응답하도록 하기 위해 핸들러를 추가했습니다!



## 📷 Screenshot

## 📚 Reference
