### PR TITLE
[refactor] 페이지네이션 메서드 통합

### DIFF
--- a/backend/src/main/java/turip/content/repository/ContentRepository.java
+++ b/backend/src/main/java/turip/content/repository/ContentRepository.java
@@ -13,87 +13,86 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
 
     Optional<Content> findByTitleAndUrl(String title, String url);
 
-    int countByCityName(String cityName);
+    @Query("""
+            SELECT COUNT(c) FROM Content c
+            WHERE c.city.name = :cityName
+            """)
+    int countByCityName(@Param("cityName") String cityName);
 
     @Query("""
-                SELECT COUNT(c) FROM Content c
-                JOIN c.city ct
-                JOIN ct.country co
-                WHERE ct.name NOT IN :cityNames AND co.name = '대한민국'
+            SELECT COUNT(c) FROM Content c
+            WHERE c.city.country.name = :countryName
             """)
-    int countDomesticEtcContents(List<String> cityNames);
-
     int countByCityCountryName(@Param("countryName") String countryName);
 
     @Query("""
-                SELECT COUNT(c) FROM Content c
-                JOIN c.city ct
-                JOIN ct.country co
-                WHERE co.name NOT IN :countryNames AND co.name != '대한민국'
+            SELECT COUNT(c) FROM Content c
+            JOIN c.city ct
+            JOIN ct.country co
+            WHERE ct.name NOT IN :cityNames AND co.name = '대한민국'
+            """)
+    int countDomesticEtcContents(@Param("cityNames") List<String> cityNames);
+
+    @Query("""
+            SELECT COUNT(c) FROM Content c
+            JOIN c.city ct
+            JOIN ct.country co
+            WHERE co.name NOT IN :countryNames AND co.name != '대한민국'
             """)
     int countOverseasEtcContents(@Param("countryNames") List<String> countryNames);
 
-    Slice<Content> findByCityNameOrderByIdDesc(String cityName, Pageable pageable);
-
-    Slice<Content> findByCityNameAndIdLessThanOrderByIdDesc(String cityName, Long lastId, Pageable pageable);
+    @Query("""
+            SELECT COUNT(DISTINCT c) FROM Content c
+             JOIN c.creator cr
+             LEFT JOIN ContentPlace cp ON c.id = cp.content.id
+             LEFT JOIN cp.place p
+             WHERE c.title LIKE %:keyword%
+                OR cr.channelName LIKE %:keyword%
+                OR p.name LIKE %:keyword%
+            """)
+    int countByKeywordContaining(@Param("keyword") String keyword);
 
     @Query("""
-            SELECT c FROM Content c JOIN c.city ct JOIN ct.country co
-            WHERE ct.name NOT IN :domesticCategoryNames AND co.name = '대한민국'
+            SELECT c FROM Content c
+            WHERE c.city.name = :cityName AND c.id < :lastId
             ORDER BY c.id DESC
             """)
-    Slice<Content> findDomesticEtcContents(@Param("domesticCategoryNames") List<String> domesticCategoryNames,
-                                           Pageable pageable);
+    Slice<Content> findByCityName(@Param("cityName") String cityName, @Param("lastId") Long lastId, Pageable pageable);
+
+    @Query("""
+            SELECT c FROM Content c
+            WHERE c.city.country.name = :countryName AND c.id < :lastId
+            ORDER BY c.id DESC
+            """)
+    Slice<Content> findByCityCountryName(@Param("countryName") String countryName, @Param("lastId") Long lastId,
+                                         Pageable pageable);
 
     @Query("""
             SELECT c FROM Content c JOIN c.city ct JOIN ct.country co
             WHERE ct.name NOT IN :domesticCategoryNames AND co.name = '대한민국' AND c.id < :lastId
             ORDER BY c.id DESC
             """)
-    Slice<Content> findDomesticEtcContentsWithLastId(@Param("domesticCategoryNames") List<String> domesticCategoryNames,
-                                                     @Param("lastId") Long lastId, Pageable pageable);
-
-    Slice<Content> findByCityCountryNameOrderByIdDesc(String countryName, Pageable pageable);
-
-    Slice<Content> findByCityCountryNameAndIdLessThanOrderByIdDesc(String countryName, Long lastId, Pageable pageable);
-
-    @Query("""
-            SELECT c FROM Content c JOIN c.city ct JOIN ct.country co
-            WHERE co.name NOT IN :overseasCategoryNames AND co.name != '대한민국'
-            ORDER BY c.id DESC
-            """)
-    Slice<Content> findOverseasEtcContents(@Param("overseasCategoryNames") List<String> overseasCategoryNames,
-                                           Pageable pageable);
+    Slice<Content> findDomesticEtcContents(@Param("domesticCategoryNames") List<String> domesticCategoryNames,
+                                           @Param("lastId") Long lastId, Pageable pageable);
 
     @Query("""
             SELECT c FROM Content c JOIN c.city ct JOIN ct.country co
             WHERE co.name NOT IN :overseasCategoryNames AND co.name != '대한민국' AND c.id < :lastId
             ORDER BY c.id DESC
             """)
-    Slice<Content> findOverseasEtcContentsWithLastId(@Param("overseasCategoryNames") List<String> overseasCategoryNames,
-                                                     @Param("lastId") Long lastId, Pageable pageable);
+    Slice<Content> findOverseasEtcContents(@Param("overseasCategoryNames") List<String> overseasCategoryNames,
+                                           @Param("lastId") Long lastId, Pageable pageable);
 
     @Query("""
-               SELECT COUNT(DISTINCT c) FROM Content c
-                JOIN c.creator cr
-                LEFT JOIN ContentPlace cp ON c.id = cp.content.id
-                LEFT JOIN cp.place p
-                WHERE c.title LIKE %:keyword% 
-                   OR cr.channelName LIKE %:keyword%
-                   OR p.name LIKE %:keyword%
-            """)
-    int countByKeywordContaining(@Param("keyword") String keyword);
-
-    @Query("""
-                SELECT DISTINCT c FROM Content c
-                JOIN c.creator cr
-                LEFT JOIN ContentPlace cp ON c.id = cp.content.id
-                LEFT JOIN cp.place p
-                WHERE c.id < :lastId
-                AND (c.title LIKE %:keyword% 
-                     OR cr.channelName LIKE %:keyword%
-                     OR p.name LIKE %:keyword%)
-                ORDER BY c.id DESC
+            SELECT DISTINCT c FROM Content c
+            JOIN c.creator cr
+            LEFT JOIN ContentPlace cp ON c.id = cp.content.id
+            LEFT JOIN cp.place p
+            WHERE c.id < :lastId
+            AND (c.title LIKE %:keyword%
+                 OR cr.channelName LIKE %:keyword%
+                 OR p.name LIKE %:keyword%)
+            ORDER BY c.id DESC
             """)
     Slice<Content> findByKeywordContaining(@Param("keyword") String keyword, @Param("lastId") Long lastId,
                                            Pageable pageable);

--- a/backend/src/main/java/turip/member/repository/MemberRepository.java
+++ b/backend/src/main/java/turip/member/repository/MemberRepository.java
@@ -5,5 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import turip.member.domain.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
     Optional<Member> findByDeviceFid(String deviceFid);
 }


### PR DESCRIPTION
## Issues
- closed #355 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
`findByCityNameOrderByIdDesc`, `findOverseasEtcContentsWithLastId`, `findDomesticEtcContentsWithLastId`, `findByCityCountryNameAndIdLessThanOrderByIdDesc` 메서드를 하나의 메서드로 통합했습니다.

변경 전 서비스 코드 -> 메서드 내에서 한 번 더 분기처리
```java
 private Slice<Content> findContentSlicesByRegionCategory(
            String regionCategory,
            long lastId,
            int size
    ) {
        Pageable pageable = PageRequest.of(0, size);
        boolean isFirstPage = lastId == 0;

        if (OTHER_DOMESTIC.matchesDisplayName(regionCategory)) {
            return findDomesticEtcContents(lastId, pageable, isFirstPage);
        }
        if (OTHER_OVERSEAS.matchesDisplayName(regionCategory)) {
            return findOverseasEtcContents(lastId, pageable, isFirstPage);
        }
        if (DomesticRegionCategory.containsName(regionCategory)) {
            return findContentsByCityName(regionCategory, lastId, pageable, isFirstPage);
        }
        return findContentsByCountryName(regionCategory, lastId, pageable, isFirstPage);
    }
````
변경 후 -> 첫 번째 페이지인 경우 Long.MAX_VALUE를 사용해 모든 콘텐츠를 조회하도록 설정하고 바로 레포지터리 메서드로 조회
```java
  private Slice<Content> findContentSlicesByRegionCategory(
            String regionCategory,
            long lastId,
            int size
    ) {
        Pageable pageable = PageRequest.of(0, size);
        if (lastId == 0) {
            lastId = Long.MAX_VALUE;
        }

        if (OTHER_DOMESTIC.matchesDisplayName(regionCategory)) {
            List<String> domesticCategoryNames = DomesticRegionCategory.getDisplayNamesExcludingEtc();
            return contentRepository.findDomesticEtcContents(domesticCategoryNames, lastId, pageable);
        }
        if (OTHER_OVERSEAS.matchesDisplayName(regionCategory)) {
            List<String> overseasCategoryNames = OverseasRegionCategory.getDisplayNamesExcludingEtc();
            return contentRepository.findOverseasEtcContents(overseasCategoryNames, lastId, pageable);
        }
        if (DomesticRegionCategory.containsName(regionCategory)) {
            return contentRepository.findByCityName(regionCategory, lastId, pageable);
        }
        if (OverseasRegionCategory.containsName(regionCategory)) {
            return contentRepository.findByCityCountryName(regionCategory, lastId, pageable);
        }
        throw new BadRequestException(ErrorTag.REGION_CATEGORY_INVALID);
    }
```

## 📷 Screenshot

## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 키워드 기반 콘텐츠 총개수 제공으로 검색 피드백 강화
  - 기기 식별자(device FID) 기반 회원 조회 지원

- 개선
  - 도시/국가/국내·해외 카테고리별 콘텐츠 탐색 성능 및 일관성 개선
  - lastId 기반 페이지네이션(무한 스크롤) 로직 정비로 더 부드러운 로딩 경험 제공
  - 키워드 검색 범위(제목/채널명/장소명) 정교화 및 페이징 연동

- 오류 처리
  - 유효하지 않은 지역 카테고리 요청에 대해 명확한 잘못된 요청(400) 응답 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->