### PR TITLE
[feat] 장소 찜 순서 변경 api 연동

### DIFF
--- a/android/app/src/main/java/com/on/turip/data/place/PlaceMapper.kt
+++ b/android/app/src/main/java/com/on/turip/data/place/PlaceMapper.kt
@@ -1,19 +1,23 @@
 package com.on.turip.data.place
 
 import com.on.turip.data.place.dto.FavoritePlacesResponse
+import com.on.turip.domain.favorite.FavoritePlace
 import com.on.turip.domain.trip.Place
 
-fun FavoritePlacesResponse.toDomain(): List<Place> =
-    favoritePlaceResponses.map { place ->
-        with(place.placeResponse) {
-            Place(
-                placeId = id,
-                name = name,
-                url = url,
-                address = address,
-                latitude = latitude,
-                longitude = longitude,
-                category = categories.map { it.name },
-            )
-        }
+fun FavoritePlacesResponse.toDomain(): List<FavoritePlace> =
+    favoritePlaceResponses.map { favoritePlace ->
+        FavoritePlace(
+            id = favoritePlace.id,
+            order = favoritePlace.order,
+            place =
+                Place(
+                    placeId = favoritePlace.placeResponse.id,
+                    name = favoritePlace.placeResponse.name,
+                    url = favoritePlace.placeResponse.url,
+                    address = favoritePlace.placeResponse.address,
+                    latitude = favoritePlace.placeResponse.latitude,
+                    longitude = favoritePlace.placeResponse.longitude,
+                    category = favoritePlace.placeResponse.categories.map { it.name },
+                ),
+        )
     }

--- a/android/app/src/main/java/com/on/turip/data/place/datasource/DefaultFavoritePlaceRemoteDataSource.kt
+++ b/android/app/src/main/java/com/on/turip/data/place/datasource/DefaultFavoritePlaceRemoteDataSource.kt
@@ -2,6 +2,7 @@ package com.on.turip.data.place.datasource
 
 import com.on.turip.data.common.TuripCustomResult
 import com.on.turip.data.common.safeApiCall
+import com.on.turip.data.place.dto.FavoritePlaceOrderRequest
 import com.on.turip.data.place.dto.FavoritePlacesResponse
 import com.on.turip.data.place.service.PlaceService
 
@@ -20,4 +21,15 @@ class DefaultFavoritePlaceRemoteDataSource(
         favoriteFolderId: Long,
         placeId: Long,
     ): TuripCustomResult<Unit> = safeApiCall { placeService.deleteFavoritePlace(favoriteFolderId, placeId) }
+
+    override suspend fun patchFavoritePlacesOrder(
+        favoriteFolderId: Long,
+        favoritePlaceOrderRequest: FavoritePlaceOrderRequest,
+    ): TuripCustomResult<Unit> =
+        safeApiCall {
+            placeService.patchFavoritePlaceOrder(
+                favoriteFolderId,
+                favoritePlaceOrderRequest,
+            )
+        }
 }

--- a/android/app/src/main/java/com/on/turip/data/place/datasource/FavoritePlaceRemoteDataSource.kt
+++ b/android/app/src/main/java/com/on/turip/data/place/datasource/FavoritePlaceRemoteDataSource.kt
@@ -1,6 +1,7 @@
 package com.on.turip.data.place.datasource
 
 import com.on.turip.data.common.TuripCustomResult
+import com.on.turip.data.place.dto.FavoritePlaceOrderRequest
 import com.on.turip.data.place.dto.FavoritePlacesResponse
 
 interface FavoritePlaceRemoteDataSource {
@@ -14,5 +15,10 @@ interface FavoritePlaceRemoteDataSource {
     suspend fun deleteFavoritePlace(
         favoriteFolderId: Long,
         placeId: Long,
+    ): TuripCustomResult<Unit>
+
+    suspend fun patchFavoritePlacesOrder(
+        favoriteFolderId: Long,
+        favoritePlaceOrderRequest: FavoritePlaceOrderRequest,
     ): TuripCustomResult<Unit>
 }

--- a/android/app/src/main/java/com/on/turip/data/place/dto/FavoritePlaceOrderRequest.kt
+++ b/android/app/src/main/java/com/on/turip/data/place/dto/FavoritePlaceOrderRequest.kt
@@ -1,0 +1,10 @@
+package com.on.turip.data.place.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FavoritePlaceOrderRequest(
+    @SerialName("favoritePlaceIdsOrder")
+    val favoritePlaceIdsOrder: List<Long>,
+)

--- a/android/app/src/main/java/com/on/turip/data/place/dto/FavoritePlaceResponse.kt
+++ b/android/app/src/main/java/com/on/turip/data/place/dto/FavoritePlaceResponse.kt
@@ -9,4 +9,6 @@ data class FavoritePlaceResponse(
     val id: Long,
     @SerialName("place")
     val placeResponse: PlaceResponse,
+    @SerialName("favoriteOrder")
+    val order: Int,
 )

--- a/android/app/src/main/java/com/on/turip/data/place/dto/FavoritePlaceResponse.kt
+++ b/android/app/src/main/java/com/on/turip/data/place/dto/FavoritePlaceResponse.kt
@@ -10,5 +10,5 @@ data class FavoritePlaceResponse(
     @SerialName("place")
     val placeResponse: PlaceResponse,
     @SerialName("favoriteOrder")
-    val order: Int,
+    val order: Long,
 )

--- a/android/app/src/main/java/com/on/turip/data/place/repository/DefaultFavoritePlaceRepository.kt
+++ b/android/app/src/main/java/com/on/turip/data/place/repository/DefaultFavoritePlaceRepository.kt
@@ -37,7 +37,7 @@ class DefaultFavoritePlaceRepository(
     override suspend fun updateFavoritePlacesOrder(
         favoriteFolderId: Long,
         updatedOrder: List<Long>,
-    ) {
+    ): TuripCustomResult<Unit> =
         favoritePlaceRemoteDataSource.patchFavoritePlacesOrder(
             favoriteFolderId = favoriteFolderId,
             favoritePlaceOrderRequest =
@@ -45,5 +45,4 @@ class DefaultFavoritePlaceRepository(
                     favoritePlaceIdsOrder = updatedOrder,
                 ),
         )
-    }
 }

--- a/android/app/src/main/java/com/on/turip/data/place/repository/DefaultFavoritePlaceRepository.kt
+++ b/android/app/src/main/java/com/on/turip/data/place/repository/DefaultFavoritePlaceRepository.kt
@@ -4,13 +4,14 @@ import com.on.turip.data.common.TuripCustomResult
 import com.on.turip.data.common.mapCatching
 import com.on.turip.data.place.datasource.FavoritePlaceRemoteDataSource
 import com.on.turip.data.place.toDomain
+import com.on.turip.domain.favorite.FavoritePlace
 import com.on.turip.domain.favorite.repository.FavoritePlaceRepository
 import com.on.turip.domain.trip.Place
 
 class DefaultFavoritePlaceRepository(
     private val favoritePlaceRemoteDataSource: FavoritePlaceRemoteDataSource,
 ) : FavoritePlaceRepository {
-    override suspend fun loadFavoritePlaces(favoriteFolderId: Long): TuripCustomResult<List<Place>> =
+    override suspend fun loadFavoritePlaces(favoriteFolderId: Long): TuripCustomResult<List<FavoritePlace>> =
         favoritePlaceRemoteDataSource.getFavoritePlaces(favoriteFolderId).mapCatching {
             it.toDomain()
         }

--- a/android/app/src/main/java/com/on/turip/data/place/repository/DefaultFavoritePlaceRepository.kt
+++ b/android/app/src/main/java/com/on/turip/data/place/repository/DefaultFavoritePlaceRepository.kt
@@ -3,10 +3,10 @@ package com.on.turip.data.place.repository
 import com.on.turip.data.common.TuripCustomResult
 import com.on.turip.data.common.mapCatching
 import com.on.turip.data.place.datasource.FavoritePlaceRemoteDataSource
+import com.on.turip.data.place.dto.FavoritePlaceOrderRequest
 import com.on.turip.data.place.toDomain
 import com.on.turip.domain.favorite.FavoritePlace
 import com.on.turip.domain.favorite.repository.FavoritePlaceRepository
-import com.on.turip.domain.trip.Place
 
 class DefaultFavoritePlaceRepository(
     private val favoritePlaceRemoteDataSource: FavoritePlaceRemoteDataSource,
@@ -33,4 +33,17 @@ class DefaultFavoritePlaceRepository(
             favoriteFolderId = favoriteFolderId,
             placeId = placeId,
         )
+
+    override suspend fun updateFavoritePlacesOrder(
+        favoriteFolderId: Long,
+        updatedOrder: List<Long>,
+    ) {
+        favoritePlaceRemoteDataSource.patchFavoritePlacesOrder(
+            favoriteFolderId = favoriteFolderId,
+            favoritePlaceOrderRequest =
+                FavoritePlaceOrderRequest(
+                    favoritePlaceIdsOrder = updatedOrder,
+                ),
+        )
+    }
 }

--- a/android/app/src/main/java/com/on/turip/data/place/service/PlaceService.kt
+++ b/android/app/src/main/java/com/on/turip/data/place/service/PlaceService.kt
@@ -1,9 +1,12 @@
 package com.on.turip.data.place.service
 
+import com.on.turip.data.place.dto.FavoritePlaceOrderRequest
 import com.on.turip.data.place.dto.FavoritePlacesResponse
 import retrofit2.Response
+import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Query
 
@@ -23,5 +26,11 @@ interface PlaceService {
     suspend fun deleteFavoritePlace(
         @Query("favoriteFolderId") favoriteFolderId: Long,
         @Query("placeId") placeId: Long,
+    ): Response<Unit>
+
+    @PATCH("favorites/places/favorite-order")
+    suspend fun patchFavoritePlaceOrder(
+        @Query("favoriteFolderId") favoriteFolderId: Long,
+        @Body favoritePlaceOrderRequest: FavoritePlaceOrderRequest,
     ): Response<Unit>
 }

--- a/android/app/src/main/java/com/on/turip/domain/favorite/FavoritePlace.kt
+++ b/android/app/src/main/java/com/on/turip/domain/favorite/FavoritePlace.kt
@@ -1,0 +1,9 @@
+package com.on.turip.domain.favorite
+
+import com.on.turip.domain.trip.Place
+
+data class FavoritePlace(
+    val id: Long,
+    val place: Place,
+    val order: Int,
+)

--- a/android/app/src/main/java/com/on/turip/domain/favorite/FavoritePlace.kt
+++ b/android/app/src/main/java/com/on/turip/domain/favorite/FavoritePlace.kt
@@ -5,5 +5,5 @@ import com.on.turip.domain.trip.Place
 data class FavoritePlace(
     val id: Long,
     val place: Place,
-    val order: Int,
+    val order: Long,
 )

--- a/android/app/src/main/java/com/on/turip/domain/favorite/repository/FavoritePlaceRepository.kt
+++ b/android/app/src/main/java/com/on/turip/domain/favorite/repository/FavoritePlaceRepository.kt
@@ -19,5 +19,5 @@ interface FavoritePlaceRepository {
     suspend fun updateFavoritePlacesOrder(
         favoriteFolderId: Long,
         updatedOrder: List<Long>,
-    )
+    ): TuripCustomResult<Unit>
 }

--- a/android/app/src/main/java/com/on/turip/domain/favorite/repository/FavoritePlaceRepository.kt
+++ b/android/app/src/main/java/com/on/turip/domain/favorite/repository/FavoritePlaceRepository.kt
@@ -1,10 +1,10 @@
 package com.on.turip.domain.favorite.repository
 
 import com.on.turip.data.common.TuripCustomResult
-import com.on.turip.domain.trip.Place
+import com.on.turip.domain.favorite.FavoritePlace
 
 interface FavoritePlaceRepository {
-    suspend fun loadFavoritePlaces(favoriteFolderId: Long): TuripCustomResult<List<Place>>
+    suspend fun loadFavoritePlaces(favoriteFolderId: Long): TuripCustomResult<List<FavoritePlace>>
 
     suspend fun createFavoritePlace(
         favoriteFolderId: Long,

--- a/android/app/src/main/java/com/on/turip/domain/favorite/repository/FavoritePlaceRepository.kt
+++ b/android/app/src/main/java/com/on/turip/domain/favorite/repository/FavoritePlaceRepository.kt
@@ -15,4 +15,9 @@ interface FavoritePlaceRepository {
         favoriteFolderId: Long,
         placeId: Long,
     ): TuripCustomResult<Unit>
+
+    suspend fun updateFavoritePlacesOrder(
+        favoriteFolderId: Long,
+        updatedOrder: List<Long>,
+    )
 }

--- a/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoriteMapper.kt
+++ b/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoriteMapper.kt
@@ -1,17 +1,19 @@
 package com.on.turip.ui.main.favorite
 
 import androidx.core.net.toUri
+import com.on.turip.domain.favorite.FavoritePlace
 import com.on.turip.domain.folder.FavoriteFolder
-import com.on.turip.domain.trip.Place
 import com.on.turip.ui.main.favorite.model.FavoritePlaceFolderModel
 import com.on.turip.ui.main.favorite.model.FavoritePlaceModel
 
-fun Place.toUiModel(): FavoritePlaceModel =
+fun FavoritePlace.toUiModel(): FavoritePlaceModel =
     FavoritePlaceModel(
-        placeId = placeId,
-        name = name,
-        uri = url.toUri(),
-        category = category.joinToString(),
+        favoritePlaceId = id,
+        order = order,
+        placeId = place.placeId,
+        name = place.name,
+        uri = place.url.toUri(),
+        category = place.category.joinToString(),
         isFavorite = true,
     )
 

--- a/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceAdapter.kt
+++ b/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceAdapter.kt
@@ -7,7 +7,7 @@ import com.on.turip.ui.main.favorite.model.FavoritePlaceModel
 
 class FavoritePlaceAdapter(
     private val favoritePlaceListener: FavoritePlaceViewHolder.FavoritePlaceListener,
-    private val onChangeOrder: (favoritePlaceIdsOrder: List<Long>) -> Unit,
+    private val onChange: (favoritePlaces: List<FavoritePlaceModel>) -> Unit,
 ) : ListAdapter<FavoritePlaceModel, FavoritePlaceViewHolder>(FavoritePlaceDiffUtil) {
     override fun onCreateViewHolder(
         parent: ViewGroup,
@@ -29,7 +29,7 @@ class FavoritePlaceAdapter(
         val item = mutableList.removeAt(from)
         mutableList.add(to, item)
         submitList(mutableList.toList()) {
-            onChangeOrder(mutableList.map { it.favoritePlaceId })
+            onChange(mutableList.toList())
         }
     }
 

--- a/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceAdapter.kt
+++ b/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceAdapter.kt
@@ -28,8 +28,9 @@ class FavoritePlaceAdapter(
         val mutableList = currentList.toMutableList()
         val item = mutableList.removeAt(from)
         mutableList.add(to, item)
-        submitList(mutableList)
-        onChangeOrder(mutableList.toList().map { it.favoritePlaceId })
+        submitList(mutableList.toList()) {
+            onChangeOrder(mutableList.map { it.favoritePlaceId })
+        }
     }
 
     private object FavoritePlaceDiffUtil : DiffUtil.ItemCallback<FavoritePlaceModel>() {

--- a/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceAdapter.kt
+++ b/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceAdapter.kt
@@ -7,6 +7,7 @@ import com.on.turip.ui.main.favorite.model.FavoritePlaceModel
 
 class FavoritePlaceAdapter(
     private val favoritePlaceListener: FavoritePlaceViewHolder.FavoritePlaceListener,
+    private val onChangeOrder: (favoritePlaceIdsOrder: List<Long>) -> Unit,
 ) : ListAdapter<FavoritePlaceModel, FavoritePlaceViewHolder>(FavoritePlaceDiffUtil) {
     override fun onCreateViewHolder(
         parent: ViewGroup,
@@ -28,6 +29,7 @@ class FavoritePlaceAdapter(
         val item = mutableList.removeAt(from)
         mutableList.add(to, item)
         submitList(mutableList)
+        onChangeOrder(mutableList.toList().map { it.favoritePlaceId })
     }
 
     private object FavoritePlaceDiffUtil : DiffUtil.ItemCallback<FavoritePlaceModel>() {

--- a/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceFragment.kt
+++ b/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceFragment.kt
@@ -78,7 +78,6 @@ class FavoritePlaceFragment : BaseFragment<FragmentFavoritePlaceBinding>() {
 
         binding.rvFavoritePlacePlace.apply {
             adapter = placeAdapter
-            itemAnimator = null
         }
 
         val itemTouchHelper =
@@ -102,6 +101,16 @@ class FavoritePlaceFragment : BaseFragment<FragmentFavoritePlaceBinding>() {
                         viewHolder: RecyclerView.ViewHolder,
                         direction: Int,
                     ) = Unit
+
+                    override fun isLongPressDragEnabled(): Boolean = true
+
+                    override fun interpolateOutOfBoundsScroll(
+                        recyclerView: RecyclerView,
+                        viewSize: Int,
+                        viewSizeOutOfBounds: Int,
+                        totalSize: Int,
+                        msSinceStartScroll: Long,
+                    ): Int = viewSizeOutOfBounds / 10
                 },
             )
 
@@ -159,9 +168,7 @@ class FavoritePlaceFragment : BaseFragment<FragmentFavoritePlaceBinding>() {
 
     override fun onHiddenChanged(hidden: Boolean) {
         super.onHiddenChanged(hidden)
-        if (!hidden) {
-            viewModel.loadFoldersAndPlaces()
-        }
+        viewModel.loadFoldersAndPlaces()
     }
 
     companion object {

--- a/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceFragment.kt
+++ b/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceFragment.kt
@@ -38,7 +38,7 @@ class FavoritePlaceFragment : BaseFragment<FragmentFavoritePlaceBinding>() {
                     startActivity(intent)
                 }
             },
-            onChangeOrder = { viewModel.updateFavoritePlacesOrder(it) },
+            onChange = { viewModel.updateFavoritePlacesOrder(it) },
         )
     }
 

--- a/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceFragment.kt
+++ b/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceFragment.kt
@@ -38,6 +38,7 @@ class FavoritePlaceFragment : BaseFragment<FragmentFavoritePlaceBinding>() {
                     startActivity(intent)
                 }
             },
+            onChangeOrder = { viewModel.updateFavoritePlacesOrder(it) },
         )
     }
 
@@ -75,7 +76,10 @@ class FavoritePlaceFragment : BaseFragment<FragmentFavoritePlaceBinding>() {
             addOnItemTouchListener(RecyclerViewTouchInterceptor)
         }
 
-        binding.rvFavoritePlacePlace.adapter = placeAdapter
+        binding.rvFavoritePlacePlace.apply {
+            adapter = placeAdapter
+            itemAnimator = null
+        }
 
         val itemTouchHelper =
             ItemTouchHelper(

--- a/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceViewModel.kt
+++ b/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceViewModel.kt
@@ -11,11 +11,11 @@ import com.on.turip.data.common.onFailure
 import com.on.turip.data.common.onSuccess
 import com.on.turip.di.RepositoryModule
 import com.on.turip.domain.ErrorEvent
+import com.on.turip.domain.favorite.FavoritePlace
 import com.on.turip.domain.favorite.repository.FavoritePlaceRepository
 import com.on.turip.domain.favorite.usecase.UpdateFavoritePlaceUseCase
 import com.on.turip.domain.folder.Folder
 import com.on.turip.domain.folder.repository.FolderRepository
-import com.on.turip.domain.trip.Place
 import com.on.turip.ui.common.mapper.toUiModel
 import com.on.turip.ui.main.favorite.model.FavoritePlaceFolderModel
 import com.on.turip.ui.main.favorite.model.FavoritePlaceModel
@@ -62,9 +62,14 @@ class FavoritePlaceViewModel(
     private suspend fun loadPlacesInSelectFolder() {
         favoritePlaceRepository
             .loadFavoritePlaces(selectedFolderId)
-            .onSuccess { places: List<Place> ->
+            .onSuccess { favoritePlaces: List<FavoritePlace> ->
                 _favoritePlaceUiState.value =
-                    favoritePlaceUiState.value?.copy(places = places.map { place: Place -> place.toUiModel() })
+                    favoritePlaceUiState.value?.copy(
+                        places =
+                            favoritePlaces.map { favoritePlace: FavoritePlace ->
+                                favoritePlace.toUiModel()
+                            },
+                    )
                 _favoritePlaceUiState.value =
                     favoritePlaceUiState.value?.copy(isServerError = false)
                 _favoritePlaceUiState.value =
@@ -126,10 +131,10 @@ class FavoritePlaceViewModel(
         viewModelScope.launch {
             favoritePlaceRepository
                 .loadFavoritePlaces(folderId)
-                .onSuccess { result: List<Place> ->
+                .onSuccess { favoritePlaces: List<FavoritePlace> ->
                     _favoritePlaceUiState.value =
                         favoritePlaceUiState.value?.copy(
-                            places = result.map { it.toUiModel() },
+                            places = favoritePlaces.map { it.toUiModel() },
                         )
                     _favoritePlaceUiState.value =
                         favoritePlaceUiState.value?.copy(isServerError = false)

--- a/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceViewModel.kt
+++ b/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceViewModel.kt
@@ -66,9 +66,10 @@ class FavoritePlaceViewModel(
                 _favoritePlaceUiState.value =
                     favoritePlaceUiState.value?.copy(
                         places =
-                            favoritePlaces.map { favoritePlace: FavoritePlace ->
-                                favoritePlace.toUiModel()
-                            },
+                            favoritePlaces
+                                .map { favoritePlace: FavoritePlace ->
+                                    favoritePlace.toUiModel()
+                                }.sortedBy { it.order },
                     )
                 _favoritePlaceUiState.value =
                     favoritePlaceUiState.value?.copy(isServerError = false)
@@ -134,7 +135,7 @@ class FavoritePlaceViewModel(
                 .onSuccess { favoritePlaces: List<FavoritePlace> ->
                     _favoritePlaceUiState.value =
                         favoritePlaceUiState.value?.copy(
-                            places = favoritePlaces.map { it.toUiModel() },
+                            places = favoritePlaces.map { it.toUiModel() }.sortedBy { it.order },
                         )
                     _favoritePlaceUiState.value =
                         favoritePlaceUiState.value?.copy(isServerError = false)

--- a/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceViewModel.kt
+++ b/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceViewModel.kt
@@ -173,12 +173,22 @@ class FavoritePlaceViewModel(
         }
     }
 
-    fun updateFavoritePlacesOrder(favoritePlaceIdsOrder: List<Long>) {
+    fun updateFavoritePlacesOrder(newFavoritePlaces: List<FavoritePlaceModel>) {
         viewModelScope.launch {
-            favoritePlaceRepository.updateFavoritePlacesOrder(
-                favoriteFolderId = selectedFolderId,
-                updatedOrder = favoritePlaceIdsOrder,
-            )
+            favoritePlaceRepository
+                .updateFavoritePlacesOrder(
+                    favoriteFolderId = selectedFolderId,
+                    updatedOrder = newFavoritePlaces.map { it.favoritePlaceId },
+                ).onSuccess {
+                    _favoritePlaceUiState.value =
+                        favoritePlaceUiState.value?.copy(
+                            places = newFavoritePlaces,
+                        )
+                    Timber.d("순서 변경 완료: $newFavoritePlaces")
+                }.onFailure { errorEvent: ErrorEvent ->
+                    checkError(errorEvent)
+                    Timber.e("장소 순서 변경 API 호출 실패")
+                }
         }
     }
 

--- a/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceViewModel.kt
+++ b/android/app/src/main/java/com/on/turip/ui/main/favorite/FavoritePlaceViewModel.kt
@@ -69,7 +69,7 @@ class FavoritePlaceViewModel(
                             favoritePlaces
                                 .map { favoritePlace: FavoritePlace ->
                                     favoritePlace.toUiModel()
-                                }.sortedBy { it.order },
+                                },
                     )
                 _favoritePlaceUiState.value =
                     favoritePlaceUiState.value?.copy(isServerError = false)
@@ -135,7 +135,7 @@ class FavoritePlaceViewModel(
                 .onSuccess { favoritePlaces: List<FavoritePlace> ->
                     _favoritePlaceUiState.value =
                         favoritePlaceUiState.value?.copy(
-                            places = favoritePlaces.map { it.toUiModel() }.sortedBy { it.order },
+                            places = favoritePlaces.map { it.toUiModel() },
                         )
                     _favoritePlaceUiState.value =
                         favoritePlaceUiState.value?.copy(isServerError = false)
@@ -170,6 +170,15 @@ class FavoritePlaceViewModel(
                 _favoritePlaceUiState.value =
                     favoritePlaceUiState.value?.copy(isServerError = true)
             }
+        }
+    }
+
+    fun updateFavoritePlacesOrder(favoritePlaceIdsOrder: List<Long>) {
+        viewModelScope.launch {
+            favoritePlaceRepository.updateFavoritePlacesOrder(
+                favoriteFolderId = selectedFolderId,
+                updatedOrder = favoritePlaceIdsOrder,
+            )
         }
     }
 

--- a/android/app/src/main/java/com/on/turip/ui/main/favorite/model/FavoritePlaceModel.kt
+++ b/android/app/src/main/java/com/on/turip/ui/main/favorite/model/FavoritePlaceModel.kt
@@ -4,7 +4,7 @@ import android.net.Uri
 
 data class FavoritePlaceModel(
     val favoritePlaceId: Long,
-    val order: Int,
+    val order: Long,
     val placeId: Long,
     val name: String,
     val uri: Uri,

--- a/android/app/src/main/java/com/on/turip/ui/main/favorite/model/FavoritePlaceModel.kt
+++ b/android/app/src/main/java/com/on/turip/ui/main/favorite/model/FavoritePlaceModel.kt
@@ -3,6 +3,8 @@ package com.on.turip.ui.main.favorite.model
 import android.net.Uri
 
 data class FavoritePlaceModel(
+    val favoritePlaceId: Long,
+    val order: Int,
     val placeId: Long,
     val name: String,
     val uri: Uri,


### PR DESCRIPTION
## Issues
- closed #353

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
- 장소 찜 순서 변경 api 연결했습니다.
- 드래그 앤 드랍 ux 좀 수정했습니다.
- 폴더로 찜한 장소에 순서오는 response dto 필드 추가했습니다.

## 📷 Screenshot  

[ 드래그로 순서 변경 ]

https://github.com/user-attachments/assets/2a73a5e2-190d-4da0-8359-6eb2670b5991

[ 드래그로 순서 변경 + 찜 삭제 ]

https://github.com/user-attachments/assets/0c32e428-5fa4-43f8-95f1-7b5b776460f6


## 📚 Reference
