### PR TITLE
[fix] Dockerfile에서 사용하는 jdk 이미지 수정

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21-jdk
+FROM eclipse-temurin:21-jdk
 COPY otel/opentelemetry-javaagent.jar /opentelemetry-javaagent.jar
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} /app.jar


### PR DESCRIPTION
## Issues
- closed #465

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
베이스 이미지를 deprecated된 `openjdk:21-jdk` 대신 `eclipse-temurin`을 사용하도록 변경

## 📷 Screenshot

## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chore**
  * 서비스 배포 인프라 환경을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->