### PR TITLE
[feat] 다중 키워드 검색 기능 구현, ngram size 수정

### DIFF
--- a/backend/mysql/docker-compose.yml
+++ b/backend/mysql/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  mysql:
+    image: mysql:8.0.42
+    container_name: turip-mysql-dev
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: root_pw
+      MYSQL_DATABASE: turip_dev
+      MYSQL_USER: turip
+      MYSQL_PASSWORD: turip_pw
+      TZ: Asia/Seoul
+    ports:
+      - "3306:3306"
+    command:
+      [ "--ngram_token_size=1" ]

--- a/backend/src/main/java/turip/content/repository/ContentRepository.java
+++ b/backend/src/main/java/turip/content/repository/ContentRepository.java
@@ -140,7 +140,9 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
         String[] words = keyword.trim().split("\\s+");
         return String.join(" ",
                 Arrays.stream(words)
+                        .map(word -> word.replaceAll("[+\\-*~<>()\"@]", ""))
                         .map(word -> "+" + word)
+                        .filter(word -> word.length() > 1)
                         .toArray(String[]::new)
         );
     }

--- a/backend/src/main/java/turip/content/repository/ContentRepository.java
+++ b/backend/src/main/java/turip/content/repository/ContentRepository.java
@@ -1,5 +1,6 @@
 package turip.content.repository;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
@@ -131,4 +132,16 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
             @Param("lastId") Long lastId,
             Pageable pageable
     );
+
+    default String createBooleanModeKeyword(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return "";
+        }
+        String[] words = keyword.trim().split("\\s+");
+        return String.join(" ",
+                Arrays.stream(words)
+                        .map(word -> "+" + word)
+                        .toArray(String[]::new)
+        );
+    }
 }

--- a/backend/src/main/java/turip/content/service/ContentService.java
+++ b/backend/src/main/java/turip/content/service/ContentService.java
@@ -64,7 +64,8 @@ public class ContentService {
         if (lastContentId == 0) {
             lastContentId = Long.MAX_VALUE;
         }
-        Slice<Content> contentSlice = contentRepository.findByKeywordContaining(keyword, lastContentId,
+        String booleanModeKeyword = contentRepository.createBooleanModeKeyword(keyword);
+        Slice<Content> contentSlice = contentRepository.findByKeywordContaining(booleanModeKeyword, lastContentId,
                 PageRequest.of(0, pageSize));
         return convertToContentsDetailWithLoadableResponse(member, contentSlice);
     }
@@ -110,7 +111,8 @@ public class ContentService {
     }
 
     public ContentCountResponse countByKeyword(String keyword) {
-        int count = contentRepository.countByKeywordContaining(keyword);
+        String booleanModeKeyword = contentRepository.createBooleanModeKeyword(keyword);
+        int count = contentRepository.countByKeywordContaining(booleanModeKeyword);
         return ContentCountResponse.from(count);
     }
 

--- a/backend/src/main/resources/db/migration/V7__alter_tables.mysql.sql
+++ b/backend/src/main/resources/db/migration/V7__alter_tables.mysql.sql
@@ -1,0 +1,14 @@
+-- 기존 Fulltext Index 제거
+ALTER TABLE content DROP INDEX idx_title;
+ALTER TABLE creator DROP INDEX idx_channel_name;
+ALTER TABLE place DROP INDEX idx_name;
+
+-- ngram_token_size=1 설정 후, 새 인덱스 생성
+ALTER TABLE content
+    ADD FULLTEXT INDEX idx_title (title) WITH PARSER ngram;
+
+ALTER TABLE creator
+    ADD FULLTEXT INDEX idx_channel_name (channel_name) WITH PARSER ngram;
+
+ALTER TABLE place
+    ADD FULLTEXT INDEX idx_name (name) WITH PARSER ngram;

--- a/backend/src/test/java/turip/content/service/ContentServiceTest.java
+++ b/backend/src/test/java/turip/content/service/ContentServiceTest.java
@@ -76,7 +76,11 @@ class ContentServiceTest {
             Content content1 = new Content(1L, creator, city, "메이의 속초 브이로그 1편", "url1", LocalDate.of(2025, 7, 8));
             Content content2 = new Content(2L, creator, city, "메이의 속초 브이로그 2편", "url2", LocalDate.of(2025, 7, 8));
             List<Content> contents = List.of(content1, content2);
-            given(contentRepository.findByKeywordContaining(keyword, maxId, PageRequest.of(0, pageSize)))
+
+            String booleanModeKeyword = "+메이";
+            given(contentRepository.createBooleanModeKeyword(keyword))
+                    .willReturn(booleanModeKeyword);
+            given(contentRepository.findByKeywordContaining(booleanModeKeyword, maxId, PageRequest.of(0, pageSize)))
                     .willReturn(new SliceImpl<>(contents));
 
             Map<Long, TripDurationResponse> durations = Map.of(


### PR DESCRIPTION
## Issues
- closed #469 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
1. 다중 키워드 검색
이전에 "부산 맛집"이라는 키워드로 검색하면, 아래와 같은 전문검색 쿼리가 사용됐습니다.

```sql
SELECT *
FROM content
WHERE MATCH(title) AGAINST('+부산 맛집' IN BOOLEAN MODE);
```

이 경우 "부산" 혹은 "맛집" 둘 중 하나라도 포함되면(OR 연산) 결과에 포함됩니다. 그래서 데모데이에서 사용자가 "~ 본점" 이라는 키워드로 검색했을 때, 본점이라는 키워드가 포함된 모든 컨텐츠가 나오게 됐습니다.
하지만 사용자가 기대하는 결과는 "부산"과 "맛집"이라는 키워드가 동시에 존재하는 콘텐츠라고 생각했습니다. 따라서 다중 키워드가 존재한다면 공백을 기준으로 split한 뒤 boolean mode의 '+' 연산을 사용하도록 변경했습니다.
```sql
SELECT *
FROM content
WHERE MATCH(title) AGAINST('+부산 +맛집' IN BOOLEAN MODE);
```

이로 인해 다중 키워드에 대한 AND 검색을 지원할 수 있게 되었습니다.

2. ngram
이전에 설정된 ngram token size는 2 였습니다. 이로 인해 "빵"과 같이 1글자 키워드 검색이 불가능했습니다. 추후 "빵 여행", "봄 여행"과 같은 태그를 만들 예정이기 때문에 해당 키워드에 대한 검색 결과도 지원하고자 합니다.
이를 위해 ngram size를 1로 변경했습니다.

아래 작업을 수행했습니다.
- mysql 설정 파일에서 size 수정 
- 기존에 존재하는  Index를 drop했다가 다시 생성하기 위해. Flyway migration 파일 추가


## 📷 Screenshot

## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **기능 개선**
  * 검색어를 불린 모드로 전처리해 보다 정확하고 의도에 맞는 키워드 검색 결과를 제공합니다.
* **인프라(Chores)**
  * 개발용 MySQL 서비스 구성 추가 및 전체 텍스트 색인을 n-gram 기반으로 재구성해 검색 품질과 개발환경 안정성을 향상했습니다.
* **테스트**
  * 변경된 검색 흐름을 반영해 단위 테스트를 추가/수정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->