### PR TITLE
[feat] 마이그레이션을 취소할 시에 게스트 데이터를 모두 지우는 기능 추가

### DIFF
--- a/android/app/src/main/java/com/on/turip/data/login/datasource/MemberDataSource.kt
+++ b/android/app/src/main/java/com/on/turip/data/login/datasource/MemberDataSource.kt
@@ -8,4 +8,6 @@ interface MemberDataSource {
     suspend fun postLogout(): TuripCustomResult<Unit>
 
     suspend fun postWithdraw(): TuripCustomResult<Unit>
+
+    suspend fun deleteGuestData(): TuripCustomResult<Unit>
 }

--- a/android/app/src/main/java/com/on/turip/data/login/datasource/MemberDataSource.kt
+++ b/android/app/src/main/java/com/on/turip/data/login/datasource/MemberDataSource.kt
@@ -7,7 +7,7 @@ interface MemberDataSource {
 
     suspend fun postLogout(): TuripCustomResult<Unit>
 
-    suspend fun deleteMemberData(): TuripCustomResult<Unit>
+    suspend fun deleteMember(): TuripCustomResult<Unit>
 
-    suspend fun deleteGuestData(): TuripCustomResult<Unit>
+    suspend fun deleteGuest(): TuripCustomResult<Unit>
 }

--- a/android/app/src/main/java/com/on/turip/data/login/datasource/MemberDataSource.kt
+++ b/android/app/src/main/java/com/on/turip/data/login/datasource/MemberDataSource.kt
@@ -7,7 +7,7 @@ interface MemberDataSource {
 
     suspend fun postLogout(): TuripCustomResult<Unit>
 
-    suspend fun postWithdraw(): TuripCustomResult<Unit>
+    suspend fun deleteMemberData(): TuripCustomResult<Unit>
 
     suspend fun deleteGuestData(): TuripCustomResult<Unit>
 }

--- a/android/app/src/main/java/com/on/turip/data/login/datasource/MemberRemoteDataSource.kt
+++ b/android/app/src/main/java/com/on/turip/data/login/datasource/MemberRemoteDataSource.kt
@@ -18,13 +18,13 @@ class MemberRemoteDataSource @Inject constructor(
             memberService.postLogout()
         }
 
-    override suspend fun deleteMemberData(): TuripCustomResult<Unit> =
+    override suspend fun deleteMember(): TuripCustomResult<Unit> =
         safeApiCall {
-            memberService.deleteMemberData()
+            memberService.deleteMember()
         }
 
-    override suspend fun deleteGuestData(): TuripCustomResult<Unit> =
+    override suspend fun deleteGuest(): TuripCustomResult<Unit> =
         safeApiCall {
-            memberService.deleteGuestData()
+            memberService.deleteGuest()
         }
 }

--- a/android/app/src/main/java/com/on/turip/data/login/datasource/MemberRemoteDataSource.kt
+++ b/android/app/src/main/java/com/on/turip/data/login/datasource/MemberRemoteDataSource.kt
@@ -22,4 +22,9 @@ class MemberRemoteDataSource @Inject constructor(
         safeApiCall {
             memberService.postWithdraw()
         }
+
+    override suspend fun deleteGuestData(): TuripCustomResult<Unit> =
+        safeApiCall {
+            memberService.deleteGuestData()
+        }
 }

--- a/android/app/src/main/java/com/on/turip/data/login/datasource/MemberRemoteDataSource.kt
+++ b/android/app/src/main/java/com/on/turip/data/login/datasource/MemberRemoteDataSource.kt
@@ -18,9 +18,9 @@ class MemberRemoteDataSource @Inject constructor(
             memberService.postLogout()
         }
 
-    override suspend fun postWithdraw(): TuripCustomResult<Unit> =
+    override suspend fun deleteMemberData(): TuripCustomResult<Unit> =
         safeApiCall {
-            memberService.postWithdraw()
+            memberService.deleteMemberData()
         }
 
     override suspend fun deleteGuestData(): TuripCustomResult<Unit> =

--- a/android/app/src/main/java/com/on/turip/data/login/repository/DefaultMemberRepository.kt
+++ b/android/app/src/main/java/com/on/turip/data/login/repository/DefaultMemberRepository.kt
@@ -12,7 +12,7 @@ class DefaultMemberRepository @Inject constructor(
 
     override suspend fun logout(): TuripCustomResult<Unit> = memberDataSource.postLogout()
 
-    override suspend fun withdraw(): TuripCustomResult<Unit> = memberDataSource.deleteMemberData()
+    override suspend fun deleteMember(): TuripCustomResult<Unit> = memberDataSource.deleteMember()
 
-    override suspend fun deleteGuestData(): TuripCustomResult<Unit> = memberDataSource.deleteGuestData()
+    override suspend fun deleteGuest(): TuripCustomResult<Unit> = memberDataSource.deleteGuest()
 }

--- a/android/app/src/main/java/com/on/turip/data/login/repository/DefaultMemberRepository.kt
+++ b/android/app/src/main/java/com/on/turip/data/login/repository/DefaultMemberRepository.kt
@@ -13,4 +13,6 @@ class DefaultMemberRepository @Inject constructor(
     override suspend fun logout(): TuripCustomResult<Unit> = memberDataSource.postLogout()
 
     override suspend fun withdraw(): TuripCustomResult<Unit> = memberDataSource.postWithdraw()
+
+    override suspend fun deleteGuestData(): TuripCustomResult<Unit> = memberDataSource.deleteGuestData()
 }

--- a/android/app/src/main/java/com/on/turip/data/login/repository/DefaultMemberRepository.kt
+++ b/android/app/src/main/java/com/on/turip/data/login/repository/DefaultMemberRepository.kt
@@ -12,7 +12,7 @@ class DefaultMemberRepository @Inject constructor(
 
     override suspend fun logout(): TuripCustomResult<Unit> = memberDataSource.postLogout()
 
-    override suspend fun withdraw(): TuripCustomResult<Unit> = memberDataSource.postWithdraw()
+    override suspend fun withdraw(): TuripCustomResult<Unit> = memberDataSource.deleteMemberData()
 
     override suspend fun deleteGuestData(): TuripCustomResult<Unit> = memberDataSource.deleteGuestData()
 }

--- a/android/app/src/main/java/com/on/turip/data/login/service/MemberService.kt
+++ b/android/app/src/main/java/com/on/turip/data/login/service/MemberService.kt
@@ -12,7 +12,7 @@ interface MemberService {
     suspend fun postLogout(): Response<Unit>
 
     @DELETE("members/me")
-    suspend fun postWithdraw(): Response<Unit>
+    suspend fun deleteMemberData(): Response<Unit>
 
     @DELETE("guests/me")
     suspend fun deleteGuestData(): Response<Unit>

--- a/android/app/src/main/java/com/on/turip/data/login/service/MemberService.kt
+++ b/android/app/src/main/java/com/on/turip/data/login/service/MemberService.kt
@@ -12,8 +12,8 @@ interface MemberService {
     suspend fun postLogout(): Response<Unit>
 
     @DELETE("members/me")
-    suspend fun deleteMemberData(): Response<Unit>
+    suspend fun deleteMember(): Response<Unit>
 
     @DELETE("guests/me")
-    suspend fun deleteGuestData(): Response<Unit>
+    suspend fun deleteGuest(): Response<Unit>
 }

--- a/android/app/src/main/java/com/on/turip/data/login/service/MemberService.kt
+++ b/android/app/src/main/java/com/on/turip/data/login/service/MemberService.kt
@@ -13,4 +13,7 @@ interface MemberService {
 
     @DELETE("members/me")
     suspend fun postWithdraw(): Response<Unit>
+
+    @DELETE("guests/me")
+    suspend fun deleteGuestData(): Response<Unit>
 }

--- a/android/app/src/main/java/com/on/turip/domain/login/MemberRepository.kt
+++ b/android/app/src/main/java/com/on/turip/domain/login/MemberRepository.kt
@@ -8,4 +8,6 @@ interface MemberRepository {
     suspend fun logout(): TuripCustomResult<Unit>
 
     suspend fun withdraw(): TuripCustomResult<Unit>
+
+    suspend fun deleteGuestData(): TuripCustomResult<Unit>
 }

--- a/android/app/src/main/java/com/on/turip/domain/login/MemberRepository.kt
+++ b/android/app/src/main/java/com/on/turip/domain/login/MemberRepository.kt
@@ -7,7 +7,7 @@ interface MemberRepository {
 
     suspend fun logout(): TuripCustomResult<Unit>
 
-    suspend fun withdraw(): TuripCustomResult<Unit>
+    suspend fun deleteMember(): TuripCustomResult<Unit>
 
-    suspend fun deleteGuestData(): TuripCustomResult<Unit>
+    suspend fun deleteGuest(): TuripCustomResult<Unit>
 }

--- a/android/app/src/main/java/com/on/turip/ui/compose/login/LoginScreen.kt
+++ b/android/app/src/main/java/com/on/turip/ui/compose/login/LoginScreen.kt
@@ -60,10 +60,8 @@ fun LoginScreen(
             dismissText = stringResource(R.string.setting_logout_dialog_dismiss),
             confirmButtonColor = colorResource(R.color.turip_blue_11aebf_70),
             dismissButtonColor = colorResource(R.color.turip_gray_b4b4b4),
-            onConfirmation = {
-                viewmodel.migration()
-            },
-            onDismissRequest = navigateToMain,
+            onConfirmation = viewmodel::migration,
+            onDismissRequest = viewmodel::clearGuestData,
         )
     }
 
@@ -158,10 +156,12 @@ private fun LoginScreenContent(
                                         colorResource(R.color.gray_200_c1c1c1),
                                     ),
                                 shape = RoundedCornerShape(10.dp),
-                            ).background(
+                            )
+                            .background(
                                 color = colorResource(R.color.gray_300_5b5b5b),
                                 shape = RoundedCornerShape(10.dp),
-                            ).fillMaxWidth()
+                            )
+                            .fillMaxWidth()
                             .padding(vertical = 20.dp),
                     textAlign = TextAlign.Center,
                 )

--- a/android/app/src/main/java/com/on/turip/ui/compose/login/LoginViewmodel.kt
+++ b/android/app/src/main/java/com/on/turip/ui/compose/login/LoginViewmodel.kt
@@ -74,6 +74,18 @@ class LoginViewmodel @Inject constructor(
         }
     }
 
+    fun clearGuestData() {
+        viewModelScope.launch {
+            memberRepository
+                .deleteGuestData()
+                .onSuccess {
+                    _uiEvent.send(LoginUiEvent.NavigateToMain)
+                }.onFailure {
+                    Timber.e("게스트 데이터 삭제 실패")
+                }
+        }
+    }
+
     fun onGuestLogin() {
         viewModelScope.launch {
             AuthState.change(UserType.GUEST)

--- a/android/app/src/main/java/com/on/turip/ui/compose/login/LoginViewmodel.kt
+++ b/android/app/src/main/java/com/on/turip/ui/compose/login/LoginViewmodel.kt
@@ -77,7 +77,7 @@ class LoginViewmodel @Inject constructor(
     fun clearGuestData() {
         viewModelScope.launch {
             memberRepository
-                .deleteGuestData()
+                .deleteGuest()
                 .onSuccess {
                     _uiEvent.send(LoginUiEvent.NavigateToMain)
                 }.onFailure {

--- a/android/app/src/main/java/com/on/turip/ui/main/favorite/SettingViewModel.kt
+++ b/android/app/src/main/java/com/on/turip/ui/main/favorite/SettingViewModel.kt
@@ -96,7 +96,7 @@ class SettingViewModel @Inject constructor(
             _uiState.update { it.copy(showWithdrawDialog = false) }
 
             memberRepository
-                .withdraw()
+                .deleteMember()
                 .onSuccess {
                     userStorageRepository
                         .clearTokens()


### PR DESCRIPTION
## Issues
- closed #487 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
- 취소 버튼을 누르게 되면 게스트 데이터가 다 삭제되도록 변경했습니당
- 추가로 witdraw가 DELETE임에 따라 메서드명도 변경했어요~

## 📷 Screenshot

## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선사항**
  * 회원 계정 삭제와 게스트 계정 삭제 프로세스가 분리되어 명확하게 처리됩니다.
  * 게스트 삭제 시 앱 내 게스트 데이터 정리 후 메인 화면으로 복귀됩니다.
  * 회원 탈퇴(삭제) 확인 흐름이 갱신되어 일관된 성공/실패 처리가 적용됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->