### PR TITLE
[refactor] 디자인시스템 appbar 재정의

### DIFF
--- a/android/app/src/main/java/com/on/turip/ui/compose/designsystem/component/TuripAppBar.kt
+++ b/android/app/src/main/java/com/on/turip/ui/compose/designsystem/component/TuripAppBar.kt
@@ -91,7 +91,7 @@ fun TuripAppBar(
     }
 }
 
-sealed class AppBarPreviewCase {
+private sealed class AppBarPreviewCase {
     data object BackOnly : AppBarPreviewCase()
 
     data object LogoOnly : AppBarPreviewCase()
@@ -113,7 +113,7 @@ private class AppBarPreviewProvider : PreviewParameterProvider<AppBarPreviewCase
 
 @Preview(showBackground = true)
 @Composable
-fun TuripAppBarPreview(
+private fun TuripAppBarPreview(
     @PreviewParameter(AppBarPreviewProvider::class)
     case: AppBarPreviewCase,
 ) {

--- a/android/app/src/main/java/com/on/turip/ui/compose/designsystem/component/TuripAppBar.kt
+++ b/android/app/src/main/java/com/on/turip/ui/compose/designsystem/component/TuripAppBar.kt
@@ -1,65 +1,163 @@
 package com.on.turip.ui.compose.designsystem.component
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import com.on.turip.R
 import com.on.turip.ui.compose.designsystem.theme.TuripTheme
 
+/**
+ *
+ * containerColor : 앱 바 색상
+ *
+ * contentColor : 앱 바 내부의 요소들 색상 (LocalContentColor는 Image에는 적용 안되므로 주의)
+ *
+ * start : 앱 바 기준 시작점에서부터 Row 정렬하기 위한 컴포넌트들
+ *
+ * center : 시작, 끝 지점에 아이콘이 있더라도 중앙 정렬하기 위한 컴포넌트
+ *
+ * end : 앱 바 기준 끝지점에 Row 정렬하기 위한 컴포넌트들
+ */
 @Composable
 fun TuripAppBar(
-    canBack: Boolean,
     modifier: Modifier = Modifier,
-    onBackNavigate: () -> Unit = {},
+    containerColor: Color = TuripTheme.colors.white,
+    contentColor: Color = TuripTheme.colors.black,
+    start: (@Composable RowScope.() -> Unit)? = null,
+    center: (@Composable () -> Unit)? = null,
+    end: (@Composable RowScope.() -> Unit)? = null,
 ) {
-    Row(
+    Box(
         modifier =
-            modifier
+            Modifier
                 .fillMaxWidth()
-                .height(60.dp),
+                .height(58.dp) // xml과 로고 맞추기 위한 dp값, 나중에 피그마 기준인 62로 수정 필요
+                .background(containerColor)
+                .pointerInput(Unit) {}
+                .then(modifier),
     ) {
-        if (canBack) {
-            Image(
-                painter = painterResource(R.drawable.ic_back),
-                contentDescription = null,
-                modifier =
-                    Modifier
-                        .clickable(onClick = onBackNavigate)
-                        .padding(top = 12.dp, start = 14.dp),
-            )
+        CompositionLocalProvider(
+            LocalContentColor provides contentColor,
+        ) {
+            if (start != null) {
+                Row(
+                    modifier =
+                        Modifier
+                            .align(Alignment.CenterStart)
+                            .padding(start = 20.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    content = start,
+                )
+            }
+
+            if (center != null) {
+                Box(
+                    modifier = Modifier.align(Alignment.Center),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    center()
+                }
+            }
+
+            if (end != null) {
+                Row(
+                    modifier =
+                        Modifier
+                            .align(Alignment.CenterEnd)
+                            .padding(end = 20.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    content = end,
+                )
+            }
         }
-        Image(
-            painter = painterResource(R.drawable.ic_logo),
-            contentDescription = null,
-            modifier = Modifier.padding(top = 16.dp, start = 20.dp),
-        )
     }
 }
 
-@Preview(showBackground = true, name = "뒤로가기 버튼 O")
-@Composable
-private fun BackableTuripAppBarPreview() {
-    TuripTheme {
-        TuripAppBar(
-            canBack = true,
-        )
-    }
+sealed class AppBarPreviewCase {
+    data object BackOnly : AppBarPreviewCase()
+
+    data object LogoOnly : AppBarPreviewCase()
+
+    data object BackAndTitle : AppBarPreviewCase()
+
+    data object BackAndActions : AppBarPreviewCase()
 }
 
-@Preview(showBackground = true, name = "뒤로가기 버튼 X")
-@Composable
-private fun NotBackableTuripAppBarPreview() {
-    TuripTheme {
-        TuripAppBar(
-            canBack = false,
+private class AppBarPreviewProvider : PreviewParameterProvider<AppBarPreviewCase> {
+    override val values: Sequence<AppBarPreviewCase> =
+        sequenceOf(
+            AppBarPreviewCase.BackOnly,
+            AppBarPreviewCase.LogoOnly,
+            AppBarPreviewCase.BackAndTitle,
+            AppBarPreviewCase.BackAndActions,
         )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun TuripAppBarPreview(
+    @PreviewParameter(AppBarPreviewProvider::class)
+    case: AppBarPreviewCase,
+) {
+    TuripTheme {
+        when (case) {
+            AppBarPreviewCase.BackOnly -> {
+                TuripAppBar(
+                    start = {
+                        Icon(Icons.AutoMirrored.Default.ArrowBack, null)
+                    },
+                )
+            }
+
+            AppBarPreviewCase.LogoOnly -> {
+                TuripAppBar(
+                    start = {
+                        Image(painterResource(R.drawable.ic_logo), null)
+                    },
+                )
+            }
+
+            AppBarPreviewCase.BackAndTitle -> {
+                TuripAppBar(
+                    start = {
+                        Icon(Icons.AutoMirrored.Default.ArrowBack, null)
+                    },
+                    center = { Text("서울") },
+                )
+            }
+
+            AppBarPreviewCase.BackAndActions -> {
+                TuripAppBar(
+                    start = {
+                        Icon(Icons.AutoMirrored.Default.ArrowBack, null)
+                    },
+                    end = {
+                        Icon(Icons.Default.MoreVert, null)
+                    },
+                )
+            }
+        }
     }
 }

--- a/android/app/src/main/java/com/on/turip/ui/compose/designsystem/component/TuripAppBar.kt
+++ b/android/app/src/main/java/com/on/turip/ui/compose/designsystem/component/TuripAppBar.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
@@ -55,6 +56,7 @@ fun TuripAppBar(
                 .fillMaxWidth()
                 .height(58.dp) // xml과 로고 맞추기 위한 dp값, 나중에 피그마 기준인 62로 수정 필요
                 .background(containerColor)
+                .padding(horizontal = 20.dp)
                 .pointerInput(Unit) {}
                 .then(modifier),
     ) {
@@ -63,10 +65,7 @@ fun TuripAppBar(
         ) {
             if (start != null) {
                 Row(
-                    modifier =
-                        Modifier
-                            .align(Alignment.CenterStart)
-                            .padding(start = 20.dp),
+                    modifier = Modifier.align(Alignment.CenterStart),
                     verticalAlignment = Alignment.CenterVertically,
                     content = start,
                 )
@@ -83,10 +82,7 @@ fun TuripAppBar(
 
             if (end != null) {
                 Row(
-                    modifier =
-                        Modifier
-                            .align(Alignment.CenterEnd)
-                            .padding(end = 20.dp),
+                    modifier = Modifier.align(Alignment.CenterEnd),
                     verticalAlignment = Alignment.CenterVertically,
                     content = end,
                 )
@@ -140,11 +136,19 @@ fun TuripAppBarPreview(
             }
 
             AppBarPreviewCase.BackAndTitle -> {
+                val startAreaSize = 30.dp
                 TuripAppBar(
                     start = {
                         Icon(Icons.AutoMirrored.Default.ArrowBack, null)
                     },
-                    center = { Text("서울") },
+                    center = {
+                        Text(
+                            text = "text lenght is very Loooooooooooooooooooooooooooong ",
+                            overflow = TextOverflow.Ellipsis,
+                            maxLines = 1,
+                            modifier = Modifier.padding(start = startAreaSize),
+                        )
+                    },
                 )
             }
 

--- a/android/app/src/main/java/com/on/turip/ui/compose/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/on/turip/ui/compose/home/HomeScreen.kt
@@ -33,8 +33,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.on.turip.R
 import com.on.turip.ui.common.error.ErrorUiState
 import com.on.turip.ui.compose.designsystem.component.ErrorScreen
-import com.on.turip.ui.compose.designsystem.component.TuripAppBar
 import com.on.turip.ui.compose.designsystem.theme.TuripTheme
+import com.on.turip.ui.compose.home.component.HomeAppBar
 import com.on.turip.ui.compose.home.component.RegionList
 import com.on.turip.ui.compose.home.component.RegionTypeButtons
 import com.on.turip.ui.compose.home.component.SearchTextField
@@ -62,9 +62,7 @@ fun HomeScreen(
 
     Scaffold(
         contentWindowInsets = WindowInsets(),
-        topBar = {
-            TuripAppBar(canBack = false)
-        },
+        topBar = { HomeAppBar() },
     ) { innerPadding ->
         HomeScreenContent(
             uiState = uiState,
@@ -123,7 +121,8 @@ private fun HomeScreenContent(
                                 focusManager.clearFocus()
                                 keyboardController?.hide()
                             })
-                        }.padding(horizontal = 20.dp)
+                        }
+                        .padding(horizontal = 20.dp)
                         .verticalScroll(scrollState),
                 verticalArrangement = Arrangement.spacedBy(10.dp),
             ) {
@@ -178,11 +177,7 @@ private fun HomeScreenContent(
 private fun HomeLoadingPreview() {
     val uiState = HomeUiState.Idle
     TuripTheme {
-        Scaffold(
-            topBar = {
-                TuripAppBar(canBack = false)
-            },
-        ) { innerPadding ->
+        Scaffold(topBar = { HomeAppBar() }) { innerPadding ->
             HomeScreenContent(
                 uiState = uiState.copy(isLoading = true),
                 onSearchClick = {},
@@ -208,11 +203,7 @@ private fun HomeSuccessPreview() {
             errorUiState = ErrorUiState.None,
         )
     TuripTheme {
-        Scaffold(
-            topBar = {
-                TuripAppBar(canBack = false)
-            },
-        ) { innerPadding ->
+        Scaffold(topBar = { HomeAppBar() }) { innerPadding ->
             HomeScreenContent(
                 uiState = uiState,
                 onSearchClick = {},
@@ -231,11 +222,7 @@ private fun HomeSuccessPreview() {
 private fun HomeServerErrorPreview() {
     val uiState = HomeUiState.Idle
     TuripTheme {
-        Scaffold(
-            topBar = {
-                TuripAppBar(canBack = false)
-            },
-        ) { innerPadding ->
+        Scaffold(topBar = { HomeAppBar() }) { innerPadding ->
             HomeScreenContent(
                 uiState = uiState.copy(isLoading = false, errorUiState = ErrorUiState.Server),
                 onSearchClick = {},
@@ -254,11 +241,7 @@ private fun HomeServerErrorPreview() {
 private fun HomeNetworkErrorPreview() {
     val uiState = HomeUiState.Idle
     TuripTheme {
-        Scaffold(
-            topBar = {
-                TuripAppBar(canBack = false)
-            },
-        ) { innerPadding ->
+        Scaffold(topBar = { HomeAppBar() }) { innerPadding ->
             HomeScreenContent(
                 uiState = uiState.copy(isLoading = false, errorUiState = ErrorUiState.Network),
                 onSearchClick = {},

--- a/android/app/src/main/java/com/on/turip/ui/compose/home/component/HomeAppBar.kt
+++ b/android/app/src/main/java/com/on/turip/ui/compose/home/component/HomeAppBar.kt
@@ -1,0 +1,32 @@
+package com.on.turip.ui.compose.home.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.on.turip.R
+import com.on.turip.ui.compose.designsystem.component.TuripAppBar
+import com.on.turip.ui.compose.designsystem.theme.TuripTheme
+
+@Composable
+internal fun HomeAppBar(modifier: Modifier = Modifier) {
+    TuripAppBar(
+        start = {
+            Image(
+                painter = painterResource(R.drawable.ic_logo),
+                contentDescription = stringResource(R.string.app_name),
+            )
+        },
+        modifier = modifier,
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun HomeAppBarPreview() {
+    TuripTheme {
+        HomeAppBar()
+    }
+}

--- a/android/app/src/main/java/com/on/turip/ui/compose/setting/SettingAppBar.kt
+++ b/android/app/src/main/java/com/on/turip/ui/compose/setting/SettingAppBar.kt
@@ -1,0 +1,45 @@
+package com.on.turip.ui.compose.setting
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.on.turip.R
+import com.on.turip.ui.compose.designsystem.component.TuripAppBar
+import com.on.turip.ui.compose.designsystem.theme.TuripTheme
+
+@Composable
+internal fun SettingAppBar(
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    TuripAppBar(
+        start = {
+            Icon(
+                imageVector = Icons.AutoMirrored.Default.ArrowBack,
+                contentDescription = stringResource(R.string.all_back_description),
+                modifier =
+                    Modifier
+                        .size(24.dp)
+                        .clickable(onClick = onBackClick),
+            )
+        },
+        modifier = modifier,
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SettingAppBarPreview() {
+    TuripTheme {
+        SettingAppBar(
+            onBackClick = {},
+        )
+    }
+}

--- a/android/app/src/main/java/com/on/turip/ui/compose/setting/SettingScreen.kt
+++ b/android/app/src/main/java/com/on/turip/ui/compose/setting/SettingScreen.kt
@@ -31,6 +31,7 @@ import com.on.turip.ui.common.error.toUiModel
 import com.on.turip.ui.compose.designsystem.component.TuripDialog
 import com.on.turip.ui.compose.designsystem.component.TuripSnackbar
 import com.on.turip.ui.compose.designsystem.theme.TuripTheme
+import com.on.turip.ui.compose.setting.component.SettingAppBar
 import com.on.turip.ui.compose.setting.component.SettingItem
 import com.on.turip.ui.compose.setting.model.SettingUiEffect
 import com.on.turip.ui.compose.setting.model.SettingUiState

--- a/android/app/src/main/java/com/on/turip/ui/compose/setting/SettingScreen.kt
+++ b/android/app/src/main/java/com/on/turip/ui/compose/setting/SettingScreen.kt
@@ -28,7 +28,6 @@ import com.on.turip.common.AuthState
 import com.on.turip.common.UserType
 import com.on.turip.domain.setting.InquiryMail
 import com.on.turip.ui.common.error.toUiModel
-import com.on.turip.ui.compose.designsystem.component.TuripAppBar
 import com.on.turip.ui.compose.designsystem.component.TuripDialog
 import com.on.turip.ui.compose.designsystem.component.TuripSnackbar
 import com.on.turip.ui.compose.designsystem.theme.TuripTheme
@@ -104,12 +103,7 @@ fun SettingScreen(
                 .fillMaxSize()
                 .background(TuripTheme.colors.white)
                 .systemBarsPadding(),
-        topBar = {
-            TuripAppBar(
-                canBack = true,
-                onBackNavigate = navigateToBack,
-            )
-        },
+        topBar = { SettingAppBar(onBackClick = navigateToBack) },
         snackbarHost = { TuripSnackbar(snackbarHostState = snackbarHostState) },
     ) { innerPadding ->
         SettingScreenContent(
@@ -227,12 +221,22 @@ private fun SettingForMemberScreen(
 @Composable
 private fun GuestSettingScreenPreview() {
     TuripTheme {
-        SettingScreenContent(
-            onClickInquiry = {},
-            onClickPrivacyPolicy = {},
-            onClickLogin = {},
-            onClickLogout = {},
-            onClickWithdraw = {},
-        )
+        Scaffold(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .background(TuripTheme.colors.white)
+                    .systemBarsPadding(),
+            topBar = { SettingAppBar(onBackClick = { }) },
+        ) { innerPadding ->
+            SettingScreenContent(
+                onClickInquiry = {},
+                onClickPrivacyPolicy = {},
+                onClickLogin = {},
+                onClickLogout = {},
+                onClickWithdraw = {},
+                modifier = Modifier.padding(innerPadding),
+            )
+        }
     }
 }

--- a/android/app/src/main/java/com/on/turip/ui/compose/setting/component/SettingAppBar.kt
+++ b/android/app/src/main/java/com/on/turip/ui/compose/setting/component/SettingAppBar.kt
@@ -1,4 +1,4 @@
-package com.on.turip.ui.compose.setting
+package com.on.turip.ui.compose.setting.component
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.size

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="all_folder_name_error_out_of_bound">폴더명은 1 ~ 20 글자 범위 입니다.</string>
     <string name="all_folder_name_warning_max_length">폴더명은 최대 20글자 입니다.(현재 20 글자)</string>
     <string name="all_turip_description">직진만 남은 여행</string>
+    <string name="all_back_description">뒤로 가기</string>
 
     <!-- 바텀 네비게이션 -->
     <string name="bottom_navigation_home">홈</string>


### PR DESCRIPTION
## Issues
- closed #520

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
- 재사용하기 어려운 구조였던 AppBar를 개선했습니다.

디자인 시스템에 정의한 AppBar를 활용해서 화면마다 필요한 AppBar를 새롭게 구현하는 방식으로 진행하면 좋을 것 같습니다.
각 화면별 AppBar는 앞으로 분리될 모듈 내부에서만 사용할 수 있도록 internal 키워드로 가시성을 제한했습니다.

TuripAppBar 파일의 주석에서 확인할 수 있을텐데, contentColor(앱 바의 텍스트 및 아이콘 색상)로 넘겨준 색상은 Image 색상에는 적용되지 않고, Icon, Text 등은 색상을 정의하지 않으면 contentColor로 넘겨 준 색상을 따라가도록 구현할 수 있습니다.
TuripAppBar 파일의 주석을 확인하고 필요한 화면에 알맞게 구현을 진행해주시면 감사하겠습니다.

혹시 개선이 필요한 부분이 있다면 리뷰 남겨주시길 바랄게요, 감사합니다!

## 📷 Screenshot

## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 홈 화면 상단에 앱 로고 추가
  * 설정 화면에 뒤로 가기 버튼 추가
  * 앱 바의 유연한 레이아웃 시스템 도입으로 더 나은 UI 일관성 제공

* **UI/UX 개선**
  * 홈 및 설정 화면의 상단 바 시각적 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->