### PR TITLE
[fix] Set-Cookie의 Secure 설정 환경 분리

### DIFF
--- a/backend/src/main/java/turip/auth/util/TokenCookieUtil.java
+++ b/backend/src/main/java/turip/auth/util/TokenCookieUtil.java
@@ -9,19 +9,22 @@ public class TokenCookieUtil {
 
     private final long accessTokenMaxAge;
     private final long refreshTokenMaxAge;
+    private final boolean secureCookie;
 
     public TokenCookieUtil(
             @Value("${jwt.access-token-expiration-ms}") long accessTokenExpirationMs,
-            @Value("${jwt.refresh-token-expiration-ms}") long refreshTokenExpirationMs
+            @Value("${jwt.refresh-token-expiration-ms}") long refreshTokenExpirationMs,
+            @Value("${cookie.secure:true}") boolean secureCookie
     ) {
         this.accessTokenMaxAge = accessTokenExpirationMs / 1000;
         this.refreshTokenMaxAge = refreshTokenExpirationMs / 1000;
+        this.secureCookie = secureCookie;
     }
 
     public ResponseCookie createAccessTokenCookie(String accessToken) {
         return ResponseCookie.from("accessToken", accessToken)
                 .httpOnly(true)
-                .secure(true)
+                .secure(secureCookie)
                 .path("/")
                 .maxAge(accessTokenMaxAge)
                 .sameSite("Strict")
@@ -31,7 +34,7 @@ public class TokenCookieUtil {
     public ResponseCookie createRefreshTokenCookie(String refreshToken) {
         return ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true)
-                .secure(true)
+                .secure(secureCookie)
                 .path("/")
                 .maxAge(refreshTokenMaxAge)
                 .sameSite("Strict")
@@ -41,7 +44,7 @@ public class TokenCookieUtil {
     public ResponseCookie createExpiredAccessTokenCookie() {
         return ResponseCookie.from("accessToken", "")
                 .httpOnly(true)
-                .secure(true)
+                .secure(secureCookie)
                 .path("/")
                 .maxAge(0)
                 .sameSite("Strict")
@@ -51,7 +54,7 @@ public class TokenCookieUtil {
     public ResponseCookie createExpiredRefreshTokenCookie() {
         return ResponseCookie.from("refreshToken", "")
                 .httpOnly(true)
-                .secure(true)
+                .secure(secureCookie)
                 .path("/")
                 .maxAge(0)
                 .sameSite("Strict")

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -27,6 +27,9 @@ spring:
 jwt:
   access-token-expiration-ms: 10800000  # 3시간
 
+cookie:
+  secure: false  # HTTP 환경에서 쿠키 전송 허용
+
 management:
   endpoint:
     health:


### PR DESCRIPTION
## Issues
- closed #543

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description

개발 서버에서, 어드민 로그인 응답으로 Set-Cookie 헤더를 받았으나 브라우저에 쿠키를 저장하지 않는 것을 확인했습니다. 쿠키에 Secure 플래그가 켜져있는데 개발 서버는 HTTP 환경이어서, 쿠키 저장을 하지 않는 것으로 파악했습니다. 따라서 dev Profile에서는 `Secure = false`로 설정하도록 수정했습니다!

#### Set-Cookie의 Secure 플래그
- "HTTPS에서만 쿠키 저장/사용"을 의미
- HTTPS가 아닌 HTTP 환경에서는 요청/응답이 암호화되지 않기에, 요청 헤더의 Cookie 혹은 응답 헤더의 Set-Cookie에 들어있는 토큰 유출 가능성이 존재. 따라서 HTTPS 환경에서만 쿠키에 민감 정보를 담을 수 있게끔 Secure 플래그를 사용
(참고로 localhost는 W3C 스펙에서 잠재적으로 안전하다고 판단, HTTP이어도 Secure 쿠키 허용)


## 📷 Screenshot

## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 쿠키 보안 설정이 이제 환경별로 동적으로 구성 가능합니다. 개발 환경에서는 설정 파일을 통해 HTTP를 통한 쿠키 전송을 허용할 수 있으며, 프로덕션 환경에서는 HTTPS 보안 전송이 기본으로 적용됩니다. 액세스 토큰 및 리프레시 토큰을 포함한 모든 인증 관련 쿠키에 이 보안 설정이 동적으로 적용됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->