### PR TITLE
[feat] 초대 토큰 API 구현

### DIFF
--- a/.github/workflows/backend-dev-admin-deploy.yml
+++ b/.github/workflows/backend-dev-admin-deploy.yml
@@ -126,6 +126,7 @@ jobs:
           KAKAO_API_KEY: ${{ secrets.KAKAO_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
+          INVITATION_JWT_SECRET_KEY: ${{ secrets.INVITATION_JWT_SECRET_KEY }}
         run: |
           cd backend
           IMAGE_TAG="${{ github.event.inputs.image_tag || needs.build_and_test.outputs.image_tag }}"
@@ -152,6 +153,7 @@ jobs:
           KAKAO_API_KEY=${KAKAO_API_KEY}
           GOOGLE_API_KEY=${GOOGLE_API_KEY}
           YOUTUBE_API_KEY=${YOUTUBE_API_KEY}
+          INVITATION_JWT_SECRET_KEY=${INVITATION_JWT_SECRET_KEY}
           EOF
           
           if [ -f .env ]; then

--- a/.github/workflows/backend-dev-app-deploy.yml
+++ b/.github/workflows/backend-dev-app-deploy.yml
@@ -126,6 +126,7 @@ jobs:
           KAKAO_API_KEY: ${{ secrets.KAKAO_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
+          INVITATION_JWT_SECRET_KEY: ${{ secrets.INVITATION_JWT_SECRET_KEY }}
         run: |
           cd backend
           IMAGE_TAG="${{ github.event.inputs.image_tag || needs.build_and_test.outputs.image_tag }}"
@@ -152,6 +153,7 @@ jobs:
           KAKAO_API_KEY=${KAKAO_API_KEY}
           GOOGLE_API_KEY=${GOOGLE_API_KEY}
           YOUTUBE_API_KEY=${YOUTUBE_API_KEY}
+          INVITATION_JWT_SECRET_KEY=${INVITATION_JWT_SECRET_KEY}
           EOF
           
           if [ -f .env ]; then

--- a/.github/workflows/backend-prod-admin-deploy.yml
+++ b/.github/workflows/backend-prod-admin-deploy.yml
@@ -120,6 +120,7 @@ jobs:
           KAKAO_API_KEY: ${{ secrets.KAKAO_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
+          INVITATION_JWT_SECRET_KEY: ${{ secrets.INVITATION_JWT_SECRET_KEY }}
         run: |
           cd backend
           IMAGE_TAG="${{ needs.build_and_test.outputs.image_tag }}"
@@ -146,6 +147,7 @@ jobs:
           KAKAO_API_KEY=${KAKAO_API_KEY}
           GOOGLE_API_KEY=${GOOGLE_API_KEY}
           YOUTUBE_API_KEY=${YOUTUBE_API_KEY}
+          INVITATION_JWT_SECRET_KEY=${INVITATION_JWT_SECRET_KEY}
           EOF
           
           if [ -f .env ]; then

--- a/.github/workflows/backend-prod-app-deploy.yml
+++ b/.github/workflows/backend-prod-app-deploy.yml
@@ -120,6 +120,7 @@ jobs:
           KAKAO_API_KEY: ${{ secrets.KAKAO_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
+          INVITATION_JWT_SECRET_KEY: ${{ secrets.INVITATION_JWT_SECRET_KEY }}
         run: |
           cd backend
           IMAGE_TAG="${{ needs.build_and_test.outputs.image_tag }}"
@@ -146,6 +147,7 @@ jobs:
           KAKAO_API_KEY=${KAKAO_API_KEY}
           GOOGLE_API_KEY=${GOOGLE_API_KEY}
           YOUTUBE_API_KEY=${YOUTUBE_API_KEY}
+          INVITATION_JWT_SECRET_KEY=${INVITATION_JWT_SECRET_KEY}
           EOF
           
           if [ -f .env ]; then

--- a/backend/turip-app/src/main/java/turip/common/exception/ErrorTag.java
+++ b/backend/turip-app/src/main/java/turip/common/exception/ErrorTag.java
@@ -11,10 +11,11 @@ public enum ErrorTag {
     DEVICE_FID_REQUIRED("요청 헤더에 device_fid가 존재하지 않습니다."),
     FAVORITE_PLACE_FOLDER_MISMATCH("장소 찜이 해당 폴더에 존재하지 않습니다."),
     SHARED_FAVORITE_FOLDER_OPERATION_NOT_ALLOWED("공유 찜폴더에는 이 작업을 수행할 수 없습니다."),
-
     EMAIL_INVALID("이메일 형식이 올바르지 않습니다."),
     LOGIN_ID_INVALID("아이디 형식이 올바르지 않습니다."),
     LOGIN_PASSWORD_INVALID("비밀번호 형식이 올바르지 않습니다."),
+    INVITATION_TOKEN_EXPIRED("초대 토큰이 만료됐습니다."),
+    INVALID_INVITATION_TOKEN("유효하지 않은 초대 토큰입니다."),
 
     // 401 Unauthorized
     UNAUTHORIZED("토큰 기반 인증에 실패했습니다."),

--- a/backend/turip-app/src/main/java/turip/favorite/controller/FavoriteFolderController.java
+++ b/backend/turip-app/src/main/java/turip/favorite/controller/FavoriteFolderController.java
@@ -28,6 +28,7 @@ import turip.favorite.controller.dto.request.FavoriteFolderRequest;
 import turip.favorite.controller.dto.response.FavoriteFolderResponse;
 import turip.favorite.controller.dto.response.FavoriteFoldersWithFavoriteStatusResponse;
 import turip.favorite.controller.dto.response.FavoriteFoldersWithPlaceCountResponse;
+import turip.favorite.controller.dto.response.FolderInvitationCodeResponse;
 import turip.favorite.service.FavoriteFolderService;
 
 @RestController
@@ -161,6 +162,115 @@ public class FavoriteFolderController {
         FavoriteFolderResponse response = favoriteFolderService.createCustomFavoriteFolder(request, account);
         return ResponseEntity.created(URI.create("/api/v1/turips/" + response.id()))
                 .body(response);
+    }
+
+    @Operation(
+            summary = "튜립 초대코드 생성 api",
+            description = "튜립을 공유하기 위한 초대코드를 생성한다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = FolderInvitationCodeResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    summary = "초대코드 생성 성공",
+                                    value = """
+                                            {
+                                                "invitationCode": "aZbC1dasda13"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "실패 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "access token expired",
+                                            summary = "만료된 access token",
+                                            value = """
+                                                    {
+                                                    	"tag": "ACCESS_TOKEN_EXPIRED",
+                                                    	"message": "access token이 만료됐습니다."
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "invalid signature access token",
+                                            summary = "서명값이 올바르지 않은 access token",
+                                            value = """
+                                                    {
+                                                    	"tag": "ACCESS_TOKEN_SIGNATURE_INVALID",
+                                                    	"message": "access token이 위조됐습니다."
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "unauthorized",
+                                            summary = "알 수 없는 이유로 인증 실패",
+                                            value = """
+                                                    {
+                                                    	"tag": "UNAUTHORIZED",
+                                                    	"message": "토큰 기반 인증에 실패했습니다."
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "실패 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "not_turip_member",
+                                            summary = "튜립(폴더) 멤버가 아닌 경우",
+                                            value = """
+                                                    {
+                                                        "tag": "FORBIDDEN",
+                                                        "message": "접근 권한이 없습니다."
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "실패 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "turip_not_found",
+                                    summary = "id에 대한 튜립을 찾을 수 없는 경우",
+                                    value = """
+                                            {
+                                                "tag": "FAVORITE_FOLDER_NOT_FOUND",
+                                                "message": "찜폴더를 찾을 수 없습니다."
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    @PostMapping("/{turipId}/invitation-codes")
+    public ResponseEntity<FolderInvitationCodeResponse> createInvitationCode(
+            @PathVariable("turipId") Long favoriteFolderId,
+            @Parameter(hidden = true) @AuthAccount Account account) {
+        FolderInvitationCodeResponse response = favoriteFolderService.createInvitationCode(account, favoriteFolderId);
+        return ResponseEntity.ok(response);
     }
 
     @Operation(

--- a/backend/turip-app/src/main/java/turip/favorite/controller/FavoriteFolderController.java
+++ b/backend/turip-app/src/main/java/turip/favorite/controller/FavoriteFolderController.java
@@ -290,9 +290,7 @@ public class FavoriteFolderController {
                                     summary = "초대 토큰 검증 성공",
                                     value = """
                                             {
-                                                "turipId": 1,
-                                                "turipName": "내 튜립",
-                                                "isMember": true
+                                                "turipId": 1
                                             }
                                             """
                             )

--- a/backend/turip-app/src/main/java/turip/favorite/controller/FavoriteFolderController.java
+++ b/backend/turip-app/src/main/java/turip/favorite/controller/FavoriteFolderController.java
@@ -28,8 +28,8 @@ import turip.favorite.controller.dto.request.FavoriteFolderRequest;
 import turip.favorite.controller.dto.response.FavoriteFolderResponse;
 import turip.favorite.controller.dto.response.FavoriteFoldersWithFavoriteStatusResponse;
 import turip.favorite.controller.dto.response.FavoriteFoldersWithPlaceCountResponse;
-import turip.favorite.controller.dto.response.FolderInvitationCodeResponse;
 import turip.favorite.controller.dto.response.FolderInvitationDetailResponse;
+import turip.favorite.controller.dto.response.FolderInvitationTokenResponse;
 import turip.favorite.service.FavoriteFolderService;
 
 @RestController
@@ -167,7 +167,7 @@ public class FavoriteFolderController {
 
     @Operation(
             summary = "튜립 초대 토큰 생성 api",
-            description = "튜립을 공유하기 위한 초대 토큰를 생성한다."
+            description = "튜립을 공유하기 위한 초대 토큰을 생성한다."
     )
     @ApiResponses(value = {
             @ApiResponse(
@@ -175,7 +175,7 @@ public class FavoriteFolderController {
                     description = "성공 예시",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = FolderInvitationCodeResponse.class),
+                            schema = @Schema(implementation = FolderInvitationTokenResponse.class),
                             examples = @ExampleObject(
                                     name = "success",
                                     summary = "초대 토큰 생성 성공",
@@ -266,17 +266,17 @@ public class FavoriteFolderController {
                     )
             )
     })
-    @PostMapping("/{turipId}/invitation-codes")
-    public ResponseEntity<FolderInvitationCodeResponse> createInvitationCode(
+    @PostMapping("/{turipId}/invitation-tokens")
+    public ResponseEntity<FolderInvitationTokenResponse> createInvitationToken(
             @PathVariable("turipId") Long favoriteFolderId,
             @Parameter(hidden = true) @AuthAccount Account account) {
-        FolderInvitationCodeResponse response = favoriteFolderService.createInvitationCode(account, favoriteFolderId);
+        FolderInvitationTokenResponse response = favoriteFolderService.createInvitationToken(account, favoriteFolderId);
         return ResponseEntity.ok(response);
     }
 
     @Operation(
             summary = "튜립 초대 토큰 검증 api",
-            description = "튜립 초대 토큰를 검증한다."
+            description = "튜립 초대 토큰을 검증한다."
     )
     @ApiResponses(value = {
             @ApiResponse(

--- a/backend/turip-app/src/main/java/turip/favorite/controller/FavoriteFolderController.java
+++ b/backend/turip-app/src/main/java/turip/favorite/controller/FavoriteFolderController.java
@@ -21,7 +21,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import turip.account.domain.Account;
+import turip.account.domain.Member;
 import turip.auth.resolver.AuthAccount;
+import turip.auth.resolver.AuthMember;
 import turip.common.exception.ErrorResponse;
 import turip.favorite.controller.dto.request.FavoriteFolderNameRequest;
 import turip.favorite.controller.dto.request.FavoriteFolderRequest;
@@ -269,8 +271,8 @@ public class FavoriteFolderController {
     @PostMapping("/{turipId}/invitation-tokens")
     public ResponseEntity<FolderInvitationTokenResponse> createInvitationToken(
             @PathVariable("turipId") Long favoriteFolderId,
-            @Parameter(hidden = true) @AuthAccount Account account) {
-        FolderInvitationTokenResponse response = favoriteFolderService.createInvitationToken(account, favoriteFolderId);
+            @Parameter(hidden = true) @AuthMember Member member) {
+        FolderInvitationTokenResponse response = favoriteFolderService.createInvitationToken(member, favoriteFolderId);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/turip-app/src/main/java/turip/favorite/controller/FavoriteFolderController.java
+++ b/backend/turip-app/src/main/java/turip/favorite/controller/FavoriteFolderController.java
@@ -29,6 +29,7 @@ import turip.favorite.controller.dto.response.FavoriteFolderResponse;
 import turip.favorite.controller.dto.response.FavoriteFoldersWithFavoriteStatusResponse;
 import turip.favorite.controller.dto.response.FavoriteFoldersWithPlaceCountResponse;
 import turip.favorite.controller.dto.response.FolderInvitationCodeResponse;
+import turip.favorite.controller.dto.response.FolderInvitationDetailResponse;
 import turip.favorite.service.FavoriteFolderService;
 
 @RestController
@@ -165,8 +166,8 @@ public class FavoriteFolderController {
     }
 
     @Operation(
-            summary = "튜립 초대코드 생성 api",
-            description = "튜립을 공유하기 위한 초대코드를 생성한다."
+            summary = "튜립 초대 토큰 생성 api",
+            description = "튜립을 공유하기 위한 초대 토큰를 생성한다."
     )
     @ApiResponses(value = {
             @ApiResponse(
@@ -177,7 +178,7 @@ public class FavoriteFolderController {
                             schema = @Schema(implementation = FolderInvitationCodeResponse.class),
                             examples = @ExampleObject(
                                     name = "success",
-                                    summary = "초대코드 생성 성공",
+                                    summary = "초대 토큰 생성 성공",
                                     value = """
                                             {
                                                 "invitationCode": "aZbC1dasda13"
@@ -270,6 +271,100 @@ public class FavoriteFolderController {
             @PathVariable("turipId") Long favoriteFolderId,
             @Parameter(hidden = true) @AuthAccount Account account) {
         FolderInvitationCodeResponse response = favoriteFolderService.createInvitationCode(account, favoriteFolderId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+            summary = "튜립 초대 토큰 검증 api",
+            description = "튜립 초대 토큰를 검증한다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = FolderInvitationDetailResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    summary = "초대 토큰 검증 성공",
+                                    value = """
+                                            {
+                                                "turipId": 1,
+                                                "turipName": "내 튜립",
+                                                "isMember": true
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "실패 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "invalid_invitation_token",
+                                            summary = "유효하지 않은 초대 토큰",
+                                            value = """
+                                                    {
+                                                        "tag": "INVALID_INVITATION_TOKEN",
+                                                        "message": "유효하지 않은 초대 토큰입니다."
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "실패 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "access token expired",
+                                            summary = "만료된 access token",
+                                            value = """
+                                                    {
+                                                    	"tag": "ACCESS_TOKEN_EXPIRED",
+                                                    	"message": "access token이 만료됐습니다."
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "invalid signature access token",
+                                            summary = "서명값이 올바르지 않은 access token",
+                                            value = """
+                                                    {
+                                                    	"tag": "ACCESS_TOKEN_SIGNATURE_INVALID",
+                                                    	"message": "access token이 위조됐습니다."
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "unauthorized",
+                                            summary = "알 수 없는 이유로 인증 실패",
+                                            value = """
+                                                    {
+                                                    	"tag": "UNAUTHORIZED",
+                                                    	"message": "토큰 기반 인증에 실패했습니다."
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            )
+    })
+    @GetMapping("/invitation-tokens")
+    public ResponseEntity<FolderInvitationDetailResponse> verifyInvitation(
+            @RequestParam("token") String token,
+            @Parameter(hidden = true) @AuthAccount Account account
+    ) {
+        FolderInvitationDetailResponse response = favoriteFolderService.getInvitationDetails(token);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/turip-app/src/main/java/turip/favorite/controller/FavoriteFolderController.java
+++ b/backend/turip-app/src/main/java/turip/favorite/controller/FavoriteFolderController.java
@@ -290,7 +290,8 @@ public class FavoriteFolderController {
                                     summary = "초대 토큰 검증 성공",
                                     value = """
                                             {
-                                                "turipId": 1
+                                                "turipId": 1,
+                                                "alreadyJoined": false
                                             }
                                             """
                             )
@@ -362,7 +363,7 @@ public class FavoriteFolderController {
             @RequestParam("token") String token,
             @Parameter(hidden = true) @AuthAccount Account account
     ) {
-        FolderInvitationDetailResponse response = favoriteFolderService.getInvitationDetails(token);
+        FolderInvitationDetailResponse response = favoriteFolderService.getInvitationDetails(token, account);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/turip-app/src/main/java/turip/favorite/controller/dto/response/FolderInvitationCodeResponse.java
+++ b/backend/turip-app/src/main/java/turip/favorite/controller/dto/response/FolderInvitationCodeResponse.java
@@ -1,0 +1,8 @@
+package turip.favorite.controller.dto.response;
+
+public record FolderInvitationCodeResponse(String invitationCode) {
+
+    public static FolderInvitationCodeResponse from(String invitationCode) {
+        return new FolderInvitationCodeResponse(invitationCode);
+    }
+}

--- a/backend/turip-app/src/main/java/turip/favorite/controller/dto/response/FolderInvitationCodeResponse.java
+++ b/backend/turip-app/src/main/java/turip/favorite/controller/dto/response/FolderInvitationCodeResponse.java
@@ -1,8 +1,0 @@
-package turip.favorite.controller.dto.response;
-
-public record FolderInvitationCodeResponse(String invitationCode) {
-
-    public static FolderInvitationCodeResponse from(String invitationCode) {
-        return new FolderInvitationCodeResponse(invitationCode);
-    }
-}

--- a/backend/turip-app/src/main/java/turip/favorite/controller/dto/response/FolderInvitationDetailResponse.java
+++ b/backend/turip-app/src/main/java/turip/favorite/controller/dto/response/FolderInvitationDetailResponse.java
@@ -2,7 +2,7 @@ package turip.favorite.controller.dto.response;
 
 public record FolderInvitationDetailResponse(Long turipId, boolean alreadyJoined) {
 
-    public static FolderInvitationDetailResponse from(Long turipId, boolean alreadyJoined) {
+    public static FolderInvitationDetailResponse of(Long turipId, boolean alreadyJoined) {
         return new FolderInvitationDetailResponse(turipId, alreadyJoined);
     }
 }

--- a/backend/turip-app/src/main/java/turip/favorite/controller/dto/response/FolderInvitationDetailResponse.java
+++ b/backend/turip-app/src/main/java/turip/favorite/controller/dto/response/FolderInvitationDetailResponse.java
@@ -1,0 +1,8 @@
+package turip.favorite.controller.dto.response;
+
+public record FolderInvitationDetailResponse(Long turipId) {
+
+    public static FolderInvitationDetailResponse from(Long turipId) {
+        return new FolderInvitationDetailResponse(turipId);
+    }
+}

--- a/backend/turip-app/src/main/java/turip/favorite/controller/dto/response/FolderInvitationDetailResponse.java
+++ b/backend/turip-app/src/main/java/turip/favorite/controller/dto/response/FolderInvitationDetailResponse.java
@@ -1,8 +1,8 @@
 package turip.favorite.controller.dto.response;
 
-public record FolderInvitationDetailResponse(Long turipId) {
+public record FolderInvitationDetailResponse(Long turipId, boolean alreadyJoined) {
 
-    public static FolderInvitationDetailResponse from(Long turipId) {
-        return new FolderInvitationDetailResponse(turipId);
+    public static FolderInvitationDetailResponse from(Long turipId, boolean alreadyJoined) {
+        return new FolderInvitationDetailResponse(turipId, alreadyJoined);
     }
 }

--- a/backend/turip-app/src/main/java/turip/favorite/controller/dto/response/FolderInvitationTokenResponse.java
+++ b/backend/turip-app/src/main/java/turip/favorite/controller/dto/response/FolderInvitationTokenResponse.java
@@ -1,0 +1,8 @@
+package turip.favorite.controller.dto.response;
+
+public record FolderInvitationTokenResponse(String invitationCode) {
+
+    public static FolderInvitationTokenResponse from(String invitationCode) {
+        return new FolderInvitationTokenResponse(invitationCode);
+    }
+}

--- a/backend/turip-app/src/main/java/turip/favorite/domain/FavoriteFolder.java
+++ b/backend/turip-app/src/main/java/turip/favorite/domain/FavoriteFolder.java
@@ -54,15 +54,6 @@ public class FavoriteFolder {
         return unformattedName.trim();
     }
 
-    public void rename(String newName) {
-        validateName(newName);
-        this.name = newName;
-    }
-
-    public void shareFolder() {
-        this.isShared = true;
-    }
-
     private static void validateName(String name) {
         if (name.isBlank()) {
             throw new IllegalArgumentException(ErrorTag.FAVORITE_FOLDER_NAME_BLANK);
@@ -70,6 +61,15 @@ public class FavoriteFolder {
         if (name.length() > 20) {
             throw new IllegalArgumentException(ErrorTag.FAVORITE_FOLDER_NAME_TOO_LONG);
         }
+    }
+
+    public void rename(String newName) {
+        validateName(newName);
+        this.name = newName;
+    }
+
+    public void convertToSharedFolder() {
+        this.isShared = true;
     }
 
     public boolean isSameFolderName(String folderName) {

--- a/backend/turip-app/src/main/java/turip/favorite/service/FavoriteFolderAccountService.java
+++ b/backend/turip-app/src/main/java/turip/favorite/service/FavoriteFolderAccountService.java
@@ -34,10 +34,12 @@ public class FavoriteFolderAccountService {
     }
 
     public void validateMembership(Account account, FavoriteFolder favoriteFolder) {
-        boolean isMember = favoriteFolderAccountRepository.existsByFavoriteFolderAndAccount(favoriteFolder, account);
-
-        if (!isMember) {
+        if (!isFolderMember(account, favoriteFolder)) {
             throw new ForbiddenException(ErrorTag.FORBIDDEN);
         }
+    }
+
+    public boolean isFolderMember(Account account, FavoriteFolder favoriteFolder) {
+        return favoriteFolderAccountRepository.existsByFavoriteFolderAndAccount(favoriteFolder, account);
     }
 }

--- a/backend/turip-app/src/main/java/turip/favorite/service/FavoriteFolderService.java
+++ b/backend/turip-app/src/main/java/turip/favorite/service/FavoriteFolderService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import turip.account.domain.Account;
+import turip.account.domain.Member;
 import turip.common.exception.ErrorTag;
 import turip.common.exception.custom.BadRequestException;
 import turip.common.exception.custom.ConflictException;
@@ -56,17 +57,17 @@ public class FavoriteFolderService {
     }
 
     @Transactional
-    public FolderInvitationTokenResponse createInvitationToken(Account account, Long favoriteFolderId) {
+    public FolderInvitationTokenResponse createInvitationToken(Member member, Long favoriteFolderId) {
         FavoriteFolder favoriteFolder = favoriteFolderRepository.findById(favoriteFolderId)
                 .orElseThrow(() -> new NotFoundException(ErrorTag.FAVORITE_FOLDER_NOT_FOUND));
 
-        favoriteFolderAccountService.validateMembership(account, favoriteFolder);
+        favoriteFolderAccountService.validateMembership(member.getAccount(), favoriteFolder);
 
         if (!favoriteFolder.isShared()) {
             favoriteFolder.convertToSharedFolder();
         }
 
-        String invitationToken = invitationTokenProvider.generateToken(account.getId(), favoriteFolderId);
+        String invitationToken = invitationTokenProvider.generateToken(member.getAccount().getId(), favoriteFolderId);
 
         return FolderInvitationTokenResponse.from(invitationToken);
     }

--- a/backend/turip-app/src/main/java/turip/favorite/service/FavoriteFolderService.java
+++ b/backend/turip-app/src/main/java/turip/favorite/service/FavoriteFolderService.java
@@ -82,6 +82,11 @@ public class FavoriteFolderService {
         return FolderInvitationDetailResponse.of(favoriteFolderId, alreadyJoined);
     }
 
+    public FavoriteFolder getById(Long favoriteFolderId) {
+        return favoriteFolderRepository.findById(favoriteFolderId)
+                .orElseThrow(() -> new NotFoundException(ErrorTag.FAVORITE_FOLDER_NOT_FOUND));
+    }
+
     public FavoriteFoldersWithPlaceCountResponse findAllByAccount(Account account) {
         List<FavoriteFolderWithPlaceCountResponse> favoriteFoldersWithPlaceCount = favoriteFolderRepository.findAllByAccountOrderByFavoriteFolderAccountIdAsc(
                         account).stream()
@@ -161,10 +166,5 @@ public class FavoriteFolderService {
     private Place getPlaceById(Long id) {
         return placeRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException(ErrorTag.PLACE_NOT_FOUND));
-    }
-
-    private FavoriteFolder getById(Long favoriteFolderId) {
-        return favoriteFolderRepository.findById(favoriteFolderId)
-                .orElseThrow(() -> new NotFoundException(ErrorTag.FAVORITE_FOLDER_NOT_FOUND));
     }
 }

--- a/backend/turip-app/src/main/java/turip/favorite/service/FavoriteFolderService.java
+++ b/backend/turip-app/src/main/java/turip/favorite/service/FavoriteFolderService.java
@@ -74,12 +74,11 @@ public class FavoriteFolderService {
     public FolderInvitationDetailResponse getInvitationDetails(String token, Account account) {
         Long favoriteFolderId = invitationTokenProvider.getClaimOfName(token, "fid", Long.class);
 
-        FavoriteFolder favoriteFolder = favoriteFolderRepository.findById(favoriteFolderId)
-                .orElseThrow(() -> new NotFoundException(ErrorTag.FAVORITE_FOLDER_NOT_FOUND));
+        FavoriteFolder favoriteFolder = getById(favoriteFolderId);
 
         boolean alreadyJoined = favoriteFolderAccountService.isFolderMember(account, favoriteFolder);
 
-        return FolderInvitationDetailResponse.from(favoriteFolderId, alreadyJoined);
+        return FolderInvitationDetailResponse.of(favoriteFolderId, alreadyJoined);
     }
 
     public FavoriteFoldersWithPlaceCountResponse findAllByAccount(Account account) {

--- a/backend/turip-app/src/main/java/turip/favorite/service/FavoriteFolderService.java
+++ b/backend/turip-app/src/main/java/turip/favorite/service/FavoriteFolderService.java
@@ -71,15 +71,15 @@ public class FavoriteFolderService {
         return FolderInvitationTokenResponse.from(invitationToken);
     }
 
-    public FolderInvitationDetailResponse getInvitationDetails(String token) {
+    public FolderInvitationDetailResponse getInvitationDetails(String token, Account account) {
         Long favoriteFolderId = invitationTokenProvider.getClaimOfName(token, "fid", Long.class);
 
-        boolean exists = favoriteFolderRepository.existsById(favoriteFolderId);
-        if (!exists) {
-            throw new NotFoundException(ErrorTag.FAVORITE_FOLDER_NOT_FOUND);
-        }
+        FavoriteFolder favoriteFolder = favoriteFolderRepository.findById(favoriteFolderId)
+                .orElseThrow(() -> new NotFoundException(ErrorTag.FAVORITE_FOLDER_NOT_FOUND));
 
-        return FolderInvitationDetailResponse.from(favoriteFolderId);
+        boolean alreadyJoined = favoriteFolderAccountService.isFolderMember(account, favoriteFolder);
+
+        return FolderInvitationDetailResponse.from(favoriteFolderId, alreadyJoined);
     }
 
     public FavoriteFoldersWithPlaceCountResponse findAllByAccount(Account account) {

--- a/backend/turip-app/src/main/java/turip/favorite/service/FavoriteFolderService.java
+++ b/backend/turip-app/src/main/java/turip/favorite/service/FavoriteFolderService.java
@@ -17,8 +17,8 @@ import turip.favorite.controller.dto.response.FavoriteFolderWithFavoriteStatusRe
 import turip.favorite.controller.dto.response.FavoriteFolderWithPlaceCountResponse;
 import turip.favorite.controller.dto.response.FavoriteFoldersWithFavoriteStatusResponse;
 import turip.favorite.controller.dto.response.FavoriteFoldersWithPlaceCountResponse;
-import turip.favorite.controller.dto.response.FolderInvitationCodeResponse;
 import turip.favorite.controller.dto.response.FolderInvitationDetailResponse;
+import turip.favorite.controller.dto.response.FolderInvitationTokenResponse;
 import turip.favorite.domain.AccountRole;
 import turip.favorite.domain.FavoriteFolder;
 import turip.favorite.repository.FavoriteFolderRepository;
@@ -56,7 +56,7 @@ public class FavoriteFolderService {
     }
 
     @Transactional
-    public FolderInvitationCodeResponse createInvitationCode(Account account, Long favoriteFolderId) {
+    public FolderInvitationTokenResponse createInvitationToken(Account account, Long favoriteFolderId) {
         FavoriteFolder favoriteFolder = favoriteFolderRepository.findById(favoriteFolderId)
                 .orElseThrow(() -> new NotFoundException(ErrorTag.FAVORITE_FOLDER_NOT_FOUND));
 
@@ -66,9 +66,9 @@ public class FavoriteFolderService {
             favoriteFolder.convertToSharedFolder();
         }
 
-        String invitationCode = invitationTokenProvider.generateToken(account.getId(), favoriteFolderId);
+        String invitationToken = invitationTokenProvider.generateToken(account.getId(), favoriteFolderId);
 
-        return FolderInvitationCodeResponse.from(invitationCode);
+        return FolderInvitationTokenResponse.from(invitationToken);
     }
 
     public FolderInvitationDetailResponse getInvitationDetails(String token) {

--- a/backend/turip-app/src/main/java/turip/favorite/service/FavoriteFolderService.java
+++ b/backend/turip-app/src/main/java/turip/favorite/service/FavoriteFolderService.java
@@ -17,10 +17,12 @@ import turip.favorite.controller.dto.response.FavoriteFolderWithFavoriteStatusRe
 import turip.favorite.controller.dto.response.FavoriteFolderWithPlaceCountResponse;
 import turip.favorite.controller.dto.response.FavoriteFoldersWithFavoriteStatusResponse;
 import turip.favorite.controller.dto.response.FavoriteFoldersWithPlaceCountResponse;
+import turip.favorite.controller.dto.response.FolderInvitationCodeResponse;
 import turip.favorite.domain.AccountRole;
 import turip.favorite.domain.FavoriteFolder;
 import turip.favorite.repository.FavoriteFolderRepository;
 import turip.favorite.repository.FavoritePlaceRepository;
+import turip.favorite.token.InvitationTokenProvider;
 import turip.place.domain.Place;
 import turip.place.repository.PlaceRepository;
 
@@ -32,6 +34,7 @@ public class FavoriteFolderService {
     private final FavoritePlaceRepository favoritePlaceRepository;
     private final PlaceRepository placeRepository;
     private final FavoriteFolderAccountService favoriteFolderAccountService;
+    private final InvitationTokenProvider invitationTokenProvider;
 
     @Transactional
     public void createDefaultFavoriteFolder(Account account) {
@@ -49,6 +52,22 @@ public class FavoriteFolderService {
         favoriteFolderAccountService.save(savedFavoriteFolder, account, AccountRole.OWNER);
 
         return FavoriteFolderResponse.of(savedFavoriteFolder, account);
+    }
+
+    @Transactional
+    public FolderInvitationCodeResponse createInvitationCode(Account account, Long favoriteFolderId) {
+        FavoriteFolder favoriteFolder = favoriteFolderRepository.findById(favoriteFolderId)
+                .orElseThrow(() -> new NotFoundException(ErrorTag.FAVORITE_FOLDER_NOT_FOUND));
+
+        favoriteFolderAccountService.validateMembership(account, favoriteFolder);
+
+        if (!favoriteFolder.isShared()) {
+            favoriteFolder.convertToSharedFolder();
+        }
+
+        String invitationCode = invitationTokenProvider.generateToken(account.getId(), favoriteFolderId);
+
+        return FolderInvitationCodeResponse.from(invitationCode);
     }
 
     public FavoriteFoldersWithPlaceCountResponse findAllByAccount(Account account) {

--- a/backend/turip-app/src/main/java/turip/favorite/service/FavoriteFolderService.java
+++ b/backend/turip-app/src/main/java/turip/favorite/service/FavoriteFolderService.java
@@ -18,6 +18,7 @@ import turip.favorite.controller.dto.response.FavoriteFolderWithPlaceCountRespon
 import turip.favorite.controller.dto.response.FavoriteFoldersWithFavoriteStatusResponse;
 import turip.favorite.controller.dto.response.FavoriteFoldersWithPlaceCountResponse;
 import turip.favorite.controller.dto.response.FolderInvitationCodeResponse;
+import turip.favorite.controller.dto.response.FolderInvitationDetailResponse;
 import turip.favorite.domain.AccountRole;
 import turip.favorite.domain.FavoriteFolder;
 import turip.favorite.repository.FavoriteFolderRepository;
@@ -68,6 +69,17 @@ public class FavoriteFolderService {
         String invitationCode = invitationTokenProvider.generateToken(account.getId(), favoriteFolderId);
 
         return FolderInvitationCodeResponse.from(invitationCode);
+    }
+
+    public FolderInvitationDetailResponse getInvitationDetails(String token) {
+        Long favoriteFolderId = invitationTokenProvider.getClaimOfName(token, "fid", Long.class);
+
+        boolean exists = favoriteFolderRepository.existsById(favoriteFolderId);
+        if (!exists) {
+            throw new NotFoundException(ErrorTag.FAVORITE_FOLDER_NOT_FOUND);
+        }
+
+        return FolderInvitationDetailResponse.from(favoriteFolderId);
     }
 
     public FavoriteFoldersWithPlaceCountResponse findAllByAccount(Account account) {

--- a/backend/turip-app/src/main/java/turip/favorite/service/FavoriteFolderService.java
+++ b/backend/turip-app/src/main/java/turip/favorite/service/FavoriteFolderService.java
@@ -162,4 +162,9 @@ public class FavoriteFolderService {
         return placeRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException(ErrorTag.PLACE_NOT_FOUND));
     }
+
+    private FavoriteFolder getById(Long favoriteFolderId) {
+        return favoriteFolderRepository.findById(favoriteFolderId)
+                .orElseThrow(() -> new NotFoundException(ErrorTag.FAVORITE_FOLDER_NOT_FOUND));
+    }
 }

--- a/backend/turip-app/src/main/java/turip/favorite/token/InvitationTokenProvider.java
+++ b/backend/turip-app/src/main/java/turip/favorite/token/InvitationTokenProvider.java
@@ -3,6 +3,7 @@ package turip.favorite.token;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SignatureException;
 import java.nio.charset.StandardCharsets;
@@ -57,7 +58,7 @@ public class InvitationTokenProvider {
                     .getPayload();
         } catch (ExpiredJwtException e) {
             throw new BadRequestException(ErrorTag.INVITATION_TOKEN_EXPIRED);
-        } catch (Exception e) {
+        } catch (SignatureException | MalformedJwtException | IllegalArgumentException e) {
             throw new BadRequestException(ErrorTag.INVALID_INVITATION_TOKEN);
         }
     }

--- a/backend/turip-app/src/main/java/turip/favorite/token/InvitationTokenProvider.java
+++ b/backend/turip-app/src/main/java/turip/favorite/token/InvitationTokenProvider.java
@@ -1,0 +1,40 @@
+package turip.favorite.token;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Date;
+import java.util.Map;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InvitationTokenProvider {
+
+    private final SecretKey signingKey;
+    private final Duration tokenExpiration;
+
+    public InvitationTokenProvider(
+            @Value("${invitation.jwt.secret-key}") String secretKey,
+            @Value("${invitation.jwt.token-expiration}") Duration tokenExpiration) {
+        this.signingKey = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+        this.tokenExpiration = tokenExpiration;
+    }
+
+    public String generateToken(Long createdAccountId, Long favoriteFolderId) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + tokenExpiration.toMillis());
+
+        return Jwts.builder()
+                .header()
+                .type("JWT")
+                .and()
+                .issuedAt(now)
+                .expiration(expiry)
+                .claims(Map.of("cid", createdAccountId, "fid", favoriteFolderId))
+                .signWith(signingKey, Jwts.SIG.HS256)
+                .compact();
+    }
+}

--- a/backend/turip-app/src/main/java/turip/favorite/token/InvitationTokenProvider.java
+++ b/backend/turip-app/src/main/java/turip/favorite/token/InvitationTokenProvider.java
@@ -1,7 +1,10 @@
 package turip.favorite.token;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Date;
@@ -9,6 +12,8 @@ import java.util.Map;
 import javax.crypto.SecretKey;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import turip.common.exception.ErrorTag;
+import turip.common.exception.custom.BadRequestException;
 
 @Component
 public class InvitationTokenProvider {
@@ -36,5 +41,24 @@ public class InvitationTokenProvider {
                 .claims(Map.of("cid", createdAccountId, "fid", favoriteFolderId))
                 .signWith(signingKey, Jwts.SIG.HS256)
                 .compact();
+    }
+
+    public <T> T getClaimOfName(String token, String claimName, Class<T> requiredType) {
+        Claims claims = parseToken(token);
+        return claims.get(claimName, requiredType);
+    }
+
+    private Claims parseToken(String token) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(signingKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (ExpiredJwtException e) {
+            throw new BadRequestException(ErrorTag.INVITATION_TOKEN_EXPIRED);
+        } catch (Exception e) {
+            throw new BadRequestException(ErrorTag.INVALID_INVITATION_TOKEN);
+        }
     }
 }

--- a/backend/turip-app/src/main/resources/application.yml
+++ b/backend/turip-app/src/main/resources/application.yml
@@ -52,3 +52,8 @@ youtube:
   api:
     key: ${YOUTUBE_API_KEY}
     url: https://www.googleapis.com/youtube/v3/videos
+
+invitation:
+  jwt:
+    secret-key: ${INVITATION_JWT_SECRET_KEY}
+    token-expiration: 7d # 604800000 # 7일

--- a/backend/turip-app/src/test/java/turip/favorite/api/FavoriteFolderApiTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/api/FavoriteFolderApiTest.java
@@ -470,4 +470,47 @@ class FavoriteFolderApiTest {
                     .statusCode(400);
         }
     }
+
+    @DisplayName("/api/v1/turips/invitation-tokens GET 튜립 초대 토큰 검증 테스트")
+    @Nested
+    class VerifyInvitation {
+
+        @DisplayName("유효한 초대 토큰를 검증하고 200 OK와 튜립 정보를 응답한다")
+        @Test
+        void verifyInvitation1() {
+            // given
+            Long accountId = testDataHelper.insertAccount();
+            String accessToken = testDataHelper.createAccessToken(accountId);
+
+            Long folderId = testDataHelper.insertFavoriteFolder("내 튜립");
+            testDataHelper.insertFavoriteFolderAccount(accountId, folderId, AccountRole.OWNER);
+
+            String invitationToken = testDataHelper.createInvitationToken(accountId, folderId);
+
+            // when & then
+            RestAssured.given().port(port)
+                    .header("Authorization", "Bearer " + accessToken)
+                    .queryParam("token", invitationToken)
+                    .when().get("/api/v1/turips/invitation-tokens")
+                    .then()
+                    .statusCode(200)
+                    .body("turipId", is(folderId.intValue()));
+        }
+
+        @DisplayName("유효하지 않은 초대 토큰를 검증하고 400 BAD REQUEST를 응답한다")
+        @Test
+        void verifyInvitation2() {
+            // given
+            Long accountId = testDataHelper.insertAccount();
+            String accessToken = testDataHelper.createAccessToken(accountId);
+
+            // when & then
+            RestAssured.given().port(port)
+                    .header("Authorization", "Bearer " + accessToken)
+                    .queryParam("token", "invalid-token")
+                    .when().get("/api/v1/turips/invitation-tokens")
+                    .then()
+                    .statusCode(400);
+        }
+    }
 }

--- a/backend/turip-app/src/test/java/turip/favorite/api/FavoriteFolderApiTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/api/FavoriteFolderApiTest.java
@@ -475,7 +475,7 @@ class FavoriteFolderApiTest {
     @Nested
     class VerifyInvitation {
 
-        @DisplayName("유효한 초대 토큰를 검증하고 200 OK와 튜립 정보를 응답한다")
+        @DisplayName("유효한 초대 토큰을 검증하고 200 OK와 튜립 정보를 응답한다")
         @Test
         void verifyInvitation1() {
             // given

--- a/backend/turip-app/src/test/java/turip/favorite/api/FavoriteFolderApiTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/api/FavoriteFolderApiTest.java
@@ -494,7 +494,8 @@ class FavoriteFolderApiTest {
                     .when().get("/api/v1/turips/invitation-tokens")
                     .then()
                     .statusCode(200)
-                    .body("turipId", is(folderId.intValue()));
+                    .body("turipId", is(folderId.intValue()))
+                    .body("alreadyJoined", is(true));
         }
 
         @DisplayName("유효하지 않은 초대 토큰를 검증하고 400 BAD REQUEST를 응답한다")

--- a/backend/turip-app/src/test/java/turip/favorite/repository/FavoriteFolderRepositoryTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/repository/FavoriteFolderRepositoryTest.java
@@ -132,7 +132,7 @@ class FavoriteFolderRepositoryTest {
 
         // Shared folder (isShared = true)
         FavoriteFolder sharedFolder = favoriteFolderRepository.save(FavoriteFolderFixture.createCustomFolder("공유 폴더"));
-        sharedFolder.shareFolder();
+        sharedFolder.convertToSharedFolder();
         favoriteFolderRepository.save(sharedFolder);
 
         // 폴더와 계정 연결

--- a/backend/turip-app/src/test/java/turip/favorite/service/FavoriteFolderServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/service/FavoriteFolderServiceTest.java
@@ -20,6 +20,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import turip.account.domain.Account;
+import turip.account.domain.Member;
 import turip.account.domain.Role;
 import turip.common.exception.ErrorTag;
 import turip.common.exception.custom.BadRequestException;
@@ -490,15 +491,16 @@ class FavoriteFolderServiceTest {
             Long accountId = 1L;
             Long folderId = 1L;
             Account account = AccountFixture.createCustomAccount(accountId, Role.USER);
+            Member member = new Member(account, "test@naver.com", true);
             FavoriteFolder favoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(folderId, "폴더");
 
             given(favoriteFolderRepository.findById(folderId))
                     .willReturn(Optional.of(favoriteFolder));
-            given(invitationTokenProvider.generateToken(account.getId(), folderId))
+            given(invitationTokenProvider.generateToken(member.getAccount().getId(), folderId))
                     .willReturn("test_token");
 
             // when
-            FolderInvitationTokenResponse actual = favoriteFolderService.createInvitationToken(account, folderId);
+            FolderInvitationTokenResponse actual = favoriteFolderService.createInvitationToken(member, folderId);
 
             // then
             assertThat(actual.invitationCode()).isEqualTo("test_token");
@@ -511,6 +513,7 @@ class FavoriteFolderServiceTest {
             Long accountId = 1L;
             Long folderId = 1L;
             Account account = AccountFixture.createCustomAccount(accountId, Role.USER);
+            Member member = new Member(account, "test@naver.com", true);
             FavoriteFolder favoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(folderId, "폴더");
             boolean before = favoriteFolder.isShared();
 
@@ -518,7 +521,7 @@ class FavoriteFolderServiceTest {
                     .willReturn(Optional.of(favoriteFolder));
 
             // when
-            favoriteFolderService.createInvitationToken(account, folderId);
+            favoriteFolderService.createInvitationToken(member, folderId);
             boolean after = favoriteFolder.isShared();
 
             // then
@@ -533,15 +536,16 @@ class FavoriteFolderServiceTest {
             Long accountId = 1L;
             Long folderId = 1L;
             Account account = AccountFixture.createCustomAccount(accountId, Role.USER);
+            Member member = new Member(account, "test@naver.com", true);
             FavoriteFolder favoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(folderId, "폴더");
 
             given(favoriteFolderRepository.findById(folderId))
                     .willReturn(Optional.of(favoriteFolder));
             willThrow(new ForbiddenException(ErrorTag.FORBIDDEN))
-                    .given(favoriteFolderAccountService).validateMembership(account, favoriteFolder);
+                    .given(favoriteFolderAccountService).validateMembership(member.getAccount(), favoriteFolder);
 
             // when & then
-            assertThatThrownBy(() -> favoriteFolderService.createInvitationToken(account, folderId))
+            assertThatThrownBy(() -> favoriteFolderService.createInvitationToken(member, folderId))
                     .isInstanceOf(ForbiddenException.class)
                     .hasMessage(ErrorTag.FORBIDDEN.getMessage());
 

--- a/backend/turip-app/src/test/java/turip/favorite/service/FavoriteFolderServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/service/FavoriteFolderServiceTest.java
@@ -479,11 +479,11 @@ class FavoriteFolderServiceTest {
         }
     }
 
-    @DisplayName("공유 폴더 초대 코드 생성 테스트")
+    @DisplayName("공유 폴더 초대 토큰 생성 테스트")
     @Nested
     class CreateInvitationCode {
 
-        @DisplayName("초대 코드를 생성할 수 있다")
+        @DisplayName("초대 토큰를 생성할 수 있다")
         @Test
         void createInvitationCode() {
             // given
@@ -504,7 +504,7 @@ class FavoriteFolderServiceTest {
             assertThat(actual.invitationCode()).isEqualTo("test_token");
         }
 
-        @DisplayName("초대 코드 최초 생성 시 공유 폴더로 변경된다")
+        @DisplayName("초대 토큰 최초 생성 시 공유 폴더로 변경된다")
         @Test
         void createInvitationCode_convertsToShared() {
             // given
@@ -527,7 +527,7 @@ class FavoriteFolderServiceTest {
         }
 
         @Test
-        @DisplayName("공유 폴더에 참여하지 않은 멤버가 초대 코드 생성 시 예외가 발생한다")
+        @DisplayName("공유 폴더에 참여하지 않은 멤버가 초대 토큰 생성 시 예외가 발생한다")
         void createInvitationCode_Forbidden() {
             // given
             Long accountId = 1L;
@@ -542,7 +542,81 @@ class FavoriteFolderServiceTest {
 
             // when & then
             assertThatThrownBy(() -> favoriteFolderService.createInvitationCode(account, folderId))
-                    .isInstanceOf(ForbiddenException.class);
+                    .isInstanceOf(ForbiddenException.class)
+                    .hasMessage(ErrorTag.FORBIDDEN.getMessage());
+
+        }
+    }
+
+    @DisplayName("공유 폴더 초대 토큰 검증 테스트")
+    @Nested
+    class VerifyInvitation {
+
+        @DisplayName("유효한 토큰을 검증하고 폴더 id를 응답한다")
+        @Test
+        void verifyInvitation_success() {
+            // given
+            String token = "valid_token";
+            Long folderId = 1L;
+
+            given(invitationTokenProvider.getClaimOfName(token, "fid", Long.class))
+                    .willReturn(folderId);
+            given(favoriteFolderRepository.existsById(folderId))
+                    .willReturn(true);
+
+            // when
+            var response = favoriteFolderService.getInvitationDetails(token);
+
+            // then
+            assertThat(response.turipId()).isEqualTo(folderId);
+        }
+
+        @DisplayName("토큰에 해당하는 폴더가 존재하지 않으면 NotFoundException을 발생시킨다")
+        @Test
+        void verifyInvitation_folderNotFound() {
+            // given
+            String token = "valid_token";
+            Long folderId = 1L;
+
+            given(invitationTokenProvider.getClaimOfName(token, "fid", Long.class))
+                    .willReturn(folderId);
+            given(favoriteFolderRepository.existsById(folderId))
+                    .willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> favoriteFolderService.getInvitationDetails(token))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage(ErrorTag.FAVORITE_FOLDER_NOT_FOUND.getMessage());
+        }
+
+        @DisplayName("토큰이 만료되었으면 BadRequestException을 발생시킨다")
+        @Test
+        void verifyInvitation_expiredToken() {
+            // given
+            String token = "expired_token";
+
+            given(invitationTokenProvider.getClaimOfName(token, "fid", Long.class))
+                    .willThrow(new BadRequestException(ErrorTag.INVITATION_TOKEN_EXPIRED));
+
+            // when & then
+            assertThatThrownBy(() -> favoriteFolderService.getInvitationDetails(token))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage(ErrorTag.INVITATION_TOKEN_EXPIRED.getMessage());
+        }
+
+        @DisplayName("토큰이 유효하지 않으면 BadRequestException을 발생시킨다")
+        @Test
+        void verifyInvitation_invalidToken() {
+            // given
+            String token = "invalid_token";
+
+            given(invitationTokenProvider.getClaimOfName(token, "fid", Long.class))
+                    .willThrow(new BadRequestException(ErrorTag.INVALID_INVITATION_TOKEN));
+
+            // when & then
+            assertThatThrownBy(() -> favoriteFolderService.getInvitationDetails(token))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage(ErrorTag.INVALID_INVITATION_TOKEN.getMessage());
         }
     }
 }

--- a/backend/turip-app/src/test/java/turip/favorite/service/FavoriteFolderServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/service/FavoriteFolderServiceTest.java
@@ -32,9 +32,11 @@ import turip.favorite.controller.dto.request.FavoriteFolderRequest;
 import turip.favorite.controller.dto.response.FavoriteFolderResponse;
 import turip.favorite.controller.dto.response.FavoriteFoldersWithFavoriteStatusResponse;
 import turip.favorite.controller.dto.response.FavoriteFoldersWithPlaceCountResponse;
+import turip.favorite.controller.dto.response.FolderInvitationCodeResponse;
 import turip.favorite.domain.FavoriteFolder;
 import turip.favorite.repository.FavoriteFolderRepository;
 import turip.favorite.repository.FavoritePlaceRepository;
+import turip.favorite.token.InvitationTokenProvider;
 import turip.place.domain.Place;
 import turip.place.repository.PlaceRepository;
 import turip.util.fixture.AccountFixture;
@@ -57,6 +59,9 @@ class FavoriteFolderServiceTest {
 
     @Mock
     private PlaceRepository placeRepository;
+
+    @Mock
+    private InvitationTokenProvider invitationTokenProvider;
 
     @DisplayName("기본 장소 찜 폴더 생성 테스트")
     @Nested
@@ -471,6 +476,73 @@ class FavoriteFolderServiceTest {
             assertThatThrownBy(() -> favoriteFolderService.remove(member, folderId))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage(ErrorTag.SHARED_FAVORITE_FOLDER_OPERATION_NOT_ALLOWED.getMessage());
+        }
+    }
+
+    @DisplayName("공유 폴더 초대 코드 생성 테스트")
+    @Nested
+    class CreateInvitationCode {
+
+        @DisplayName("초대 코드를 생성할 수 있다")
+        @Test
+        void createInvitationCode() {
+            // given
+            Long accountId = 1L;
+            Long folderId = 1L;
+            Account account = AccountFixture.createCustomAccount(accountId, Role.USER);
+            FavoriteFolder favoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(folderId, "폴더");
+
+            given(favoriteFolderRepository.findById(folderId))
+                    .willReturn(Optional.of(favoriteFolder));
+            given(invitationTokenProvider.generateToken(account.getId(), folderId))
+                    .willReturn("test_token");
+
+            // when
+            FolderInvitationCodeResponse actual = favoriteFolderService.createInvitationCode(account, folderId);
+
+            // then
+            assertThat(actual.invitationCode()).isEqualTo("test_token");
+        }
+
+        @DisplayName("초대 코드 최초 생성 시 공유 폴더로 변경된다")
+        @Test
+        void createInvitationCode_convertsToShared() {
+            // given
+            Long accountId = 1L;
+            Long folderId = 1L;
+            Account account = AccountFixture.createCustomAccount(accountId, Role.USER);
+            FavoriteFolder favoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(folderId, "폴더");
+            boolean before = favoriteFolder.isShared();
+
+            given(favoriteFolderRepository.findById(folderId))
+                    .willReturn(Optional.of(favoriteFolder));
+
+            // when
+            favoriteFolderService.createInvitationCode(account, folderId);
+            boolean after = favoriteFolder.isShared();
+
+            // then
+            assertThat(before).isFalse();
+            assertThat(after).isTrue();
+        }
+
+        @Test
+        @DisplayName("공유 폴더에 참여하지 않은 멤버가 초대 코드 생성 시 예외가 발생한다")
+        void createInvitationCode_Forbidden() {
+            // given
+            Long accountId = 1L;
+            Long folderId = 1L;
+            Account account = AccountFixture.createCustomAccount(accountId, Role.USER);
+            FavoriteFolder favoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(folderId, "폴더");
+
+            given(favoriteFolderRepository.findById(folderId))
+                    .willReturn(Optional.of(favoriteFolder));
+            willThrow(new ForbiddenException(ErrorTag.FORBIDDEN))
+                    .given(favoriteFolderAccountService).validateMembership(account, favoriteFolder);
+
+            // when & then
+            assertThatThrownBy(() -> favoriteFolderService.createInvitationCode(account, folderId))
+                    .isInstanceOf(ForbiddenException.class);
         }
     }
 }

--- a/backend/turip-app/src/test/java/turip/favorite/service/FavoriteFolderServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/service/FavoriteFolderServiceTest.java
@@ -32,7 +32,7 @@ import turip.favorite.controller.dto.request.FavoriteFolderRequest;
 import turip.favorite.controller.dto.response.FavoriteFolderResponse;
 import turip.favorite.controller.dto.response.FavoriteFoldersWithFavoriteStatusResponse;
 import turip.favorite.controller.dto.response.FavoriteFoldersWithPlaceCountResponse;
-import turip.favorite.controller.dto.response.FolderInvitationCodeResponse;
+import turip.favorite.controller.dto.response.FolderInvitationTokenResponse;
 import turip.favorite.domain.FavoriteFolder;
 import turip.favorite.repository.FavoriteFolderRepository;
 import turip.favorite.repository.FavoritePlaceRepository;
@@ -498,7 +498,7 @@ class FavoriteFolderServiceTest {
                     .willReturn("test_token");
 
             // when
-            FolderInvitationCodeResponse actual = favoriteFolderService.createInvitationCode(account, folderId);
+            FolderInvitationTokenResponse actual = favoriteFolderService.createInvitationToken(account, folderId);
 
             // then
             assertThat(actual.invitationCode()).isEqualTo("test_token");
@@ -518,7 +518,7 @@ class FavoriteFolderServiceTest {
                     .willReturn(Optional.of(favoriteFolder));
 
             // when
-            favoriteFolderService.createInvitationCode(account, folderId);
+            favoriteFolderService.createInvitationToken(account, folderId);
             boolean after = favoriteFolder.isShared();
 
             // then
@@ -541,7 +541,7 @@ class FavoriteFolderServiceTest {
                     .given(favoriteFolderAccountService).validateMembership(account, favoriteFolder);
 
             // when & then
-            assertThatThrownBy(() -> favoriteFolderService.createInvitationCode(account, folderId))
+            assertThatThrownBy(() -> favoriteFolderService.createInvitationToken(account, folderId))
                     .isInstanceOf(ForbiddenException.class)
                     .hasMessage(ErrorTag.FORBIDDEN.getMessage());
 

--- a/backend/turip-app/src/test/java/turip/favorite/service/FavoriteFolderServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/service/FavoriteFolderServiceTest.java
@@ -565,12 +565,17 @@ class FavoriteFolderServiceTest {
                     .willReturn(folderId);
             given(favoriteFolderRepository.findById(folderId))
                     .willReturn(Optional.of(favoriteFolder));
+            given(favoriteFolderAccountService.isFolderMember(user, favoriteFolder))
+                    .willReturn(true);
 
             // when
             var response = favoriteFolderService.getInvitationDetails(token, user);
 
             // then
-            assertThat(response.turipId()).isEqualTo(folderId);
+            assertAll(
+                    () -> assertThat(response.turipId()).isEqualTo(folderId),
+                    () -> assertThat(response.alreadyJoined()).isTrue()
+            );
         }
 
         @DisplayName("토큰에 해당하는 폴더가 존재하지 않으면 NotFoundException을 발생시킨다")

--- a/backend/turip-app/src/test/java/turip/favorite/service/FavoriteFolderServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/service/FavoriteFolderServiceTest.java
@@ -558,14 +558,16 @@ class FavoriteFolderServiceTest {
             // given
             String token = "valid_token";
             Long folderId = 1L;
+            FavoriteFolder favoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(folderId, "폴더");
+            Account user = AccountFixture.createUser();
 
             given(invitationTokenProvider.getClaimOfName(token, "fid", Long.class))
                     .willReturn(folderId);
-            given(favoriteFolderRepository.existsById(folderId))
-                    .willReturn(true);
+            given(favoriteFolderRepository.findById(folderId))
+                    .willReturn(Optional.of(favoriteFolder));
 
             // when
-            var response = favoriteFolderService.getInvitationDetails(token);
+            var response = favoriteFolderService.getInvitationDetails(token, user);
 
             // then
             assertThat(response.turipId()).isEqualTo(folderId);
@@ -577,14 +579,15 @@ class FavoriteFolderServiceTest {
             // given
             String token = "valid_token";
             Long folderId = 1L;
+            Account user = AccountFixture.createUser();
 
             given(invitationTokenProvider.getClaimOfName(token, "fid", Long.class))
                     .willReturn(folderId);
-            given(favoriteFolderRepository.existsById(folderId))
-                    .willReturn(false);
+            given(favoriteFolderRepository.findById(folderId))
+                    .willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> favoriteFolderService.getInvitationDetails(token))
+            assertThatThrownBy(() -> favoriteFolderService.getInvitationDetails(token, user))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage(ErrorTag.FAVORITE_FOLDER_NOT_FOUND.getMessage());
         }
@@ -594,12 +597,13 @@ class FavoriteFolderServiceTest {
         void verifyInvitation_expiredToken() {
             // given
             String token = "expired_token";
+            Account user = AccountFixture.createUser();
 
             given(invitationTokenProvider.getClaimOfName(token, "fid", Long.class))
                     .willThrow(new BadRequestException(ErrorTag.INVITATION_TOKEN_EXPIRED));
 
             // when & then
-            assertThatThrownBy(() -> favoriteFolderService.getInvitationDetails(token))
+            assertThatThrownBy(() -> favoriteFolderService.getInvitationDetails(token, user))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage(ErrorTag.INVITATION_TOKEN_EXPIRED.getMessage());
         }
@@ -609,12 +613,13 @@ class FavoriteFolderServiceTest {
         void verifyInvitation_invalidToken() {
             // given
             String token = "invalid_token";
+            Account user = AccountFixture.createUser();
 
             given(invitationTokenProvider.getClaimOfName(token, "fid", Long.class))
                     .willThrow(new BadRequestException(ErrorTag.INVALID_INVITATION_TOKEN));
 
             // when & then
-            assertThatThrownBy(() -> favoriteFolderService.getInvitationDetails(token))
+            assertThatThrownBy(() -> favoriteFolderService.getInvitationDetails(token, user))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage(ErrorTag.INVALID_INVITATION_TOKEN.getMessage());
         }

--- a/backend/turip-app/src/test/java/turip/favorite/token/InvitationTokenProviderTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/token/InvitationTokenProviderTest.java
@@ -1,0 +1,53 @@
+package turip.favorite.token;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class InvitationTokenProviderTest {
+
+    private static final String TEST_SECRET_KEY = "a-test-secret-key-that-is-long-enough-to-be-secure";
+    private static final Duration TEST_TOKEN_EXPIRATION = Duration.ofHours(1);
+
+    private InvitationTokenProvider invitationTokenProvider;
+    private SecretKey signingKey;
+
+    @BeforeEach
+    void setUp() {
+        invitationTokenProvider = new InvitationTokenProvider(TEST_SECRET_KEY, TEST_TOKEN_EXPIRATION);
+        signingKey = Keys.hmacShaKeyFor(TEST_SECRET_KEY.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @DisplayName("초대 토큰 생성 테스트")
+    @Test
+    void generateToken() {
+        // given
+        Long createdAccountId = 1L;
+        Long favoriteFolderId = 2L;
+
+        // when
+        String token = invitationTokenProvider.generateToken(createdAccountId, favoriteFolderId);
+
+        // then
+        Claims claims = Jwts.parser()
+                .verifyWith(signingKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        Date now = new Date();
+        assertThat(claims.get("cid", Long.class)).isEqualTo(createdAccountId);
+        assertThat(claims.get("fid", Long.class)).isEqualTo(favoriteFolderId);
+        assertThat(claims.getIssuedAt()).isCloseTo(now, 1000);
+        assertThat(claims.getExpiration()).isCloseTo(new Date(now.getTime() + TEST_TOKEN_EXPIRATION.toMillis()), 1000);
+    }
+}

--- a/backend/turip-app/src/test/java/turip/util/fixture/FavoriteFolderFixture.java
+++ b/backend/turip-app/src/test/java/turip/util/fixture/FavoriteFolderFixture.java
@@ -27,7 +27,7 @@ public class FavoriteFolderFixture {
 
     public static FavoriteFolder createSharedFolder(String name) {
         FavoriteFolder customFolder = createCustomFolder(name);
-        customFolder.shareFolder();
+        customFolder.convertToSharedFolder();
         return customFolder;
     }
 

--- a/backend/turip-app/src/test/java/turip/util/helper/TestDataHelper.java
+++ b/backend/turip-app/src/test/java/turip/util/helper/TestDataHelper.java
@@ -11,13 +11,29 @@ import org.springframework.stereotype.Component;
 import turip.account.domain.Provider;
 import turip.account.domain.Role;
 import turip.account.domain.TuripMember;
+import turip.auth.token.JwtProvider;
 import turip.favorite.domain.AccountRole;
+import turip.favorite.token.InvitationTokenProvider;
 
 @Component
 public class TestDataHelper {
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private InvitationTokenProvider invitationTokenProvider;
+
+    public String createAccessToken(Long accountId) {
+        return jwtProvider.generateAccessToken(accountId, Role.USER);
+    }
+
+    public String createInvitationToken(Long accountId, Long folderId) {
+        return invitationTokenProvider.generateToken(accountId, folderId);
+    }
 
     public Long insertAccount() {
         return insertAccount(Role.USER);

--- a/backend/turip-app/src/test/resources/application-test.yml
+++ b/backend/turip-app/src/test/resources/application-test.yml
@@ -62,3 +62,9 @@ region:
       etc:
         image-url: https://test.example.com/overseas-etc.jpg
 
+invitation:
+  base-url: https://invite.turip.kro.kr/
+  jwt:
+    secret-key: turip-test-invitation-jwt-secret-key-for-testing-purposes
+    token-expiration: 1h
+

--- a/backend/turip-app/src/test/resources/application-test.yml
+++ b/backend/turip-app/src/test/resources/application-test.yml
@@ -63,7 +63,6 @@ region:
         image-url: https://test.example.com/overseas-etc.jpg
 
 invitation:
-  base-url: https://invite.turip.kro.kr/
   jwt:
     secret-key: turip-test-invitation-jwt-secret-key-for-testing-purposes
     token-expiration: 1h


### PR DESCRIPTION
## Issues
- closed #572

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
- [x]  초대 링크 생성 API
- [x]  토큰에 대한 폴더 정보 확인 API

- 초대 링크에 토큰이 사용되기 때문에 길이를 최대한 단축하고자 했습니다.
    - 인코딩 시 Jwts.SIG.HS256 알고리즘 사용
    - 필드명 단축
    
    ```java
    cid -> createdAccountId (초대 링크를 생성한 계정 id)
    fid -> favoriteFolderId
    ```

## 📷 Screenshot

## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 폴더 초대 토큰 생성 API 추가 — 폴더 공유용 초대 코드를 발급합니다
  * 초대 토큰 검증 API 추가 — 토큰 유효성과 사용자의 참여 여부를 조회합니다

* **개선 사항**
  * 토큰 생성 시 폴더를 공유 상태로 자동 전환
  * 초대 JWT 설정(비밀키·만료) 추가로 초대 링크 보안 강화
  * 만료/무효 토큰에 대한 명확한 사용자용 오류 메시지 추가

* **테스트**
  * 초대 토큰 생성·검증 관련 단위 및 통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->