### PR TITLE
[fix] splash화면에서 간헐적으로 넘어가지 않는 오류 수정

### DIFF
--- a/android/app/src/main/java/com/on/turip/di/NetworkModule.kt
+++ b/android/app/src/main/java/com/on/turip/di/NetworkModule.kt
@@ -4,6 +4,7 @@ import com.on.turip.BuildConfig
 import com.on.turip.common.AuthState
 import com.on.turip.common.FidProvider
 import com.on.turip.common.UserType
+import com.on.turip.core.result.ErrorType
 import com.on.turip.core.result.fold
 import com.on.turip.di.NetworkModule.LOG_PREFIX
 import com.on.turip.domain.login.AuthRepository
@@ -125,9 +126,11 @@ object NetworkModule {
                                     refreshToken = newTokens.refreshToken,
                                 )
                             },
-                            onFailure = {
-                                userStorageRepository.clearTokens()
-                                AuthState.change(UserType.GUEST)
+                            onFailure = { error ->
+                                if (error is ErrorType.Auth) {
+                                    userStorageRepository.clearTokens()
+                                    AuthState.change(UserType.GUEST)
+                                }
                                 null
                             },
                         )

--- a/android/app/src/main/java/com/on/turip/di/NetworkModule.kt
+++ b/android/app/src/main/java/com/on/turip/di/NetworkModule.kt
@@ -126,6 +126,8 @@ object NetworkModule {
                                 )
                             },
                             onFailure = {
+                                userStorageRepository.clearTokens()
+                                AuthState.change(UserType.GUEST)
                                 null
                             },
                         )

--- a/android/app/src/main/java/com/on/turip/di/NetworkModule.kt
+++ b/android/app/src/main/java/com/on/turip/di/NetworkModule.kt
@@ -87,6 +87,10 @@ object NetworkModule {
     ) {
         install(plugin = Auth) {
             bearer {
+                sendWithoutRequest { request ->
+                    !request.url.pathSegments.contains("verification")
+                }
+
                 loadTokens {
                     when (AuthState.type) {
                         UserType.MEMBER -> {

--- a/android/app/src/main/java/com/on/turip/domain/login/usecase/CheckUserSignedInUseCase.kt
+++ b/android/app/src/main/java/com/on/turip/domain/login/usecase/CheckUserSignedInUseCase.kt
@@ -2,18 +2,24 @@ package com.on.turip.domain.login.usecase
 
 import com.on.turip.common.AuthState
 import com.on.turip.common.UserType
+import com.on.turip.core.result.TuripResult
+import com.on.turip.domain.login.AuthRepository
 import com.on.turip.domain.userstorage.repository.UserStorageRepository
 import javax.inject.Inject
 
 class CheckUserSignedInUseCase @Inject constructor(
     private val userStorageRepository: UserStorageRepository,
+    private val authRepository: AuthRepository,
 ) {
     suspend operator fun invoke(): Result<Unit> =
         userStorageRepository
             .loadAccessToken()
             .mapCatching { accessToken: String? ->
                 if (accessToken != null) {
-                    AuthState.change(UserType.MEMBER)
+                    when (authRepository.getTokenVerification(accessToken)) {
+                        is TuripResult.Success -> AuthState.change(UserType.MEMBER)
+                        is TuripResult.Failure -> AuthState.change(UserType.GUEST)
+                    }
                 } else {
                     AuthState.change(UserType.GUEST)
                 }

--- a/android/app/src/main/java/com/on/turip/domain/login/usecase/CheckUserSignedInUseCase.kt
+++ b/android/app/src/main/java/com/on/turip/domain/login/usecase/CheckUserSignedInUseCase.kt
@@ -2,20 +2,17 @@ package com.on.turip.domain.login.usecase
 
 import com.on.turip.common.AuthState
 import com.on.turip.common.UserType
-import com.on.turip.domain.login.AuthRepository
 import com.on.turip.domain.userstorage.repository.UserStorageRepository
 import javax.inject.Inject
 
 class CheckUserSignedInUseCase @Inject constructor(
     private val userStorageRepository: UserStorageRepository,
-    private val authRepository: AuthRepository,
 ) {
     suspend operator fun invoke(): Result<Unit> =
         userStorageRepository
             .loadAccessToken()
             .mapCatching { accessToken: String? ->
                 if (accessToken != null) {
-                    authRepository.getTokenVerification(accessToken)
                     AuthState.change(UserType.MEMBER)
                 } else {
                     AuthState.change(UserType.GUEST)

--- a/android/app/src/main/java/com/on/turip/ui/compose/login/LoginViewmodel.kt
+++ b/android/app/src/main/java/com/on/turip/ui/compose/login/LoginViewmodel.kt
@@ -73,9 +73,7 @@ class LoginViewmodel @Inject constructor(
                                 _uiEffect.send(LoginUiEffect.ShowError(ErrorUiState.Server))
                             }
 
-                            UiError.Global.TokenExpired -> {
-                                _uiEffect.send(LoginUiEffect.ShowError(ErrorUiState.Server))
-                            }
+                            UiError.Global.TokenExpired -> {}
                         }
                     }
                     Timber.e("IdToken불러오기 실패")

--- a/android/app/src/main/java/com/on/turip/ui/compose/login/LoginViewmodel.kt
+++ b/android/app/src/main/java/com/on/turip/ui/compose/login/LoginViewmodel.kt
@@ -44,6 +44,8 @@ class LoginViewmodel @Inject constructor(
 
     fun onGoogleLogin(googleCredentialManager: GoogleCredentialManager) {
         viewModelScope.launch {
+            AuthState.change(UserType.GUEST)
+
             googleCredentialManager
                 .getIdToken()
                 .onSuccess { result: GoogleIdTokenCredential ->
@@ -72,7 +74,7 @@ class LoginViewmodel @Inject constructor(
                             }
 
                             UiError.Global.TokenExpired -> {
-                                Unit
+                                _uiEffect.send(LoginUiEffect.ShowError(ErrorUiState.Server))
                             }
                         }
                     }

--- a/android/app/src/main/java/com/on/turip/ui/splash/SplashActivity.kt
+++ b/android/app/src/main/java/com/on/turip/ui/splash/SplashActivity.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
+import androidx.lifecycle.lifecycleScope
 import com.google.android.gms.tasks.Task
 import com.google.android.play.core.appupdate.AppUpdateInfo
 import com.google.android.play.core.appupdate.AppUpdateManager
@@ -18,9 +19,8 @@ import com.on.turip.ui.common.base.BaseActivity
 import com.on.turip.ui.login.LoginActivity
 import com.on.turip.ui.main.MainActivity
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
 import timber.log.Timber
 
 @SuppressLint("CustomSplashScreen")
@@ -46,10 +46,6 @@ class SplashActivity : BaseActivity<ActivitySplashBinding>() {
         super.onCreate(savedInstanceState)
 
         checkUpdateAndProceed()
-
-        CoroutineScope(Dispatchers.IO).launch {
-            viewModel.checkAutoLogin()
-        }
     }
 
     override fun onResume() {
@@ -83,7 +79,7 @@ class SplashActivity : BaseActivity<ActivitySplashBinding>() {
                                 AppUpdateOptions.newBuilder(UPDATE_TYPE).build(),
                             )
                         } else {
-                            navigateToLogin()
+                            autoLogin()
                         }
                     }
 
@@ -98,11 +94,11 @@ class SplashActivity : BaseActivity<ActivitySplashBinding>() {
                     }
 
                     else -> {
-                        navigateToLogin()
+                        autoLogin()
                     }
                 }
             }.addOnFailureListener {
-                navigateToLogin()
+                autoLogin()
             }
     }
 
@@ -117,6 +113,15 @@ class SplashActivity : BaseActivity<ActivitySplashBinding>() {
                 startActivity(LoginActivity.newIntent(this@SplashActivity))
                 finish()
             }
+        }
+    }
+
+    private fun autoLogin() {
+        lifecycleScope.launch {
+            runCatching {
+                withTimeout(2_000) { viewModel.checkAutoLogin() }
+            }
+            navigateToLogin()
         }
     }
 

--- a/android/app/src/main/java/com/on/turip/ui/splash/SplashActivity.kt
+++ b/android/app/src/main/java/com/on/turip/ui/splash/SplashActivity.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
-import androidx.lifecycle.lifecycleScope
 import com.google.android.gms.tasks.Task
 import com.google.android.play.core.appupdate.AppUpdateInfo
 import com.google.android.play.core.appupdate.AppUpdateManager
@@ -19,6 +18,8 @@ import com.on.turip.ui.common.base.BaseActivity
 import com.on.turip.ui.login.LoginActivity
 import com.on.turip.ui.main.MainActivity
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -44,9 +45,10 @@ class SplashActivity : BaseActivity<ActivitySplashBinding>() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        lifecycleScope.launch {
+        checkUpdateAndProceed()
+
+        CoroutineScope(Dispatchers.IO).launch {
             viewModel.checkAutoLogin()
-            checkUpdateAndProceed()
         }
     }
 

--- a/android/app/src/main/java/com/on/turip/ui/splash/SplashActivity.kt
+++ b/android/app/src/main/java/com/on/turip/ui/splash/SplashActivity.kt
@@ -4,7 +4,9 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.gms.tasks.Task
 import com.google.android.play.core.appupdate.AppUpdateInfo
 import com.google.android.play.core.appupdate.AppUpdateManager
@@ -20,7 +22,6 @@ import com.on.turip.ui.login.LoginActivity
 import com.on.turip.ui.main.MainActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withTimeout
 import timber.log.Timber
 
 @SuppressLint("CustomSplashScreen")
@@ -45,6 +46,7 @@ class SplashActivity : BaseActivity<ActivitySplashBinding>() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        observeUiEffect()
         checkUpdateAndProceed()
     }
 
@@ -79,7 +81,7 @@ class SplashActivity : BaseActivity<ActivitySplashBinding>() {
                                 AppUpdateOptions.newBuilder(UPDATE_TYPE).build(),
                             )
                         } else {
-                            autoLogin()
+                            viewModel.checkAutoLogin()
                         }
                     }
 
@@ -94,11 +96,11 @@ class SplashActivity : BaseActivity<ActivitySplashBinding>() {
                     }
 
                     else -> {
-                        autoLogin()
+                        viewModel.checkAutoLogin()
                     }
                 }
             }.addOnFailureListener {
-                autoLogin()
+                viewModel.checkAutoLogin()
             }
     }
 
@@ -116,12 +118,15 @@ class SplashActivity : BaseActivity<ActivitySplashBinding>() {
         }
     }
 
-    private fun autoLogin() {
+    private fun observeUiEffect() {
         lifecycleScope.launch {
-            runCatching {
-                withTimeout(2_000) { viewModel.checkAutoLogin() }
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiEffect.collect { effect ->
+                    when (effect) {
+                        SplashEffect.NavigateMain -> navigateToLogin()
+                    }
+                }
             }
-            navigateToLogin()
         }
     }
 

--- a/android/app/src/main/java/com/on/turip/ui/splash/SplashEffect.kt
+++ b/android/app/src/main/java/com/on/turip/ui/splash/SplashEffect.kt
@@ -1,0 +1,5 @@
+package com.on.turip.ui.splash
+
+sealed interface SplashEffect {
+    data object NavigateMain : SplashEffect
+}

--- a/android/app/src/main/java/com/on/turip/ui/splash/SplashViewmodel.kt
+++ b/android/app/src/main/java/com/on/turip/ui/splash/SplashViewmodel.kt
@@ -1,15 +1,26 @@
 package com.on.turip.ui.splash
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.on.turip.domain.login.usecase.CheckUserSignedInUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class SplashViewmodel @Inject constructor(
     private val checkUserSignedInUseCase: CheckUserSignedInUseCase,
 ) : ViewModel() {
-    suspend fun checkAutoLogin() {
-        checkUserSignedInUseCase()
+    private val _uiEffect = Channel<SplashEffect>(Channel.BUFFERED)
+    val uiEffect: Flow<SplashEffect> = _uiEffect.receiveAsFlow()
+
+    fun checkAutoLogin() {
+        viewModelScope.launch {
+            checkUserSignedInUseCase()
+            _uiEffect.send(SplashEffect.NavigateMain)
+        }
     }
 }


### PR DESCRIPTION
## Issues
- closed #591

---

## ✔️ Check-list
- [ ] Label을 지정해 주세요.
- [ ] Merge할 브랜치를 확인해 주세요.

---

## 🗒️ Work Description

### 🐞 SplashActivity 무한 대기 문제 원인 분석

SplashActivity에서 화면이 넘어가지 않는 문제가 발생했습니다.  
해당 이슈는 간헐적인 현상이 아닌, 특정 조건에서 재현 가능한 구조적 문제였습니다.

#### 🔎 원인
- `authLogin` 과정에서 **Refresh Token이 만료된 상태**
- 토큰 재발급 요청 중 에러 발생
- 해당 에러가 적절히 처리되지 않아 **코루틴이 정상 종료되지 않는 문제 발생**
- 결과적으로 Splash 화면에서 `navigate`가 호출되지 않음

---

### 🛠 개선 사항

#### 자동 로그인 타임아웃 적용
- 자동 로그인 로직에 **2초 타임아웃**을 적용
- 네트워크 지연 또는 비정상 응답 상황에서 무한 대기하지 않도록 처리
- 타임아웃 발생 시 코루틴을 취소하고 정상적으로 `navigate`가 호출되도록 보완

#### 에러 전파 구조 개선 검토
- 기존에는 ViewModel에서 UseCase의 에러를 명확히 처리하지 않음
- Activity 단에서 결과를 제어할 수 있도록  
  → ViewModel이 `Result`를 상위로 전파하는 구조로 테스트 예정
- 현재 Refresh 만료 상태 재현이 어려워  
  → 로컬 서버 환경에서 테스트 필요

#### 토큰 갱신 실패 처리 보강
- 토큰 갱신 실패 시:
  - 저장된 토큰 삭제
  - 사용자 상태를 `GUEST`로 전환하도록 명확히 처리

#### 구글 로그인 시작 시 상태 초기화
- 구글 로그인 시작 시 사용자 상태를 `GUEST`로 초기화하도록 변경

#### 실행 흐름 개선
- 스플래시 진입 시 자동 로그인 실행 시점을  
  → 인앱 업데이트 확인 이후로 조정

#### 기타 안정성 보완
- 예외 상황에서 코드가 보다 안전하게 종료될 수 있도록 일부 로직 정리


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 주요 변경사항

* **새로운 기능**
  * 스플래시 화면에서 UI 이벤트 기반 자동 로그인 및 네비게이션 흐름 추가(자동 이동 이벤트 제공)

* **버그 수정**
  * 토큰 갱신 실패 시 저장된 인증 정보 초기화 및 게스트 상태 전환으로 복구 강화
  * 인증 검증 경로에서는 인증 토큰이 전송되지 않도록 처리되어 검증 흐름 안정성 개선
  * Google 로그인 시작 시 인증 상태를 게스트로 초기화하여 예외 처리 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->