### PR TITLE
[fix] SSE 통신을 위한 nginx 설정 변경

### DIFF
--- a/backend/nginx/conf.d/default.conf
+++ b/backend/nginx/conf.d/default.conf
@@ -11,6 +11,13 @@ server {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
             add_header X-Service-Version $service_version always;
+
+            # SSE(Server-Sent Events) 지원을 위한 설정
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_buffering off;
+            proxy_cache off;
+            chunked_transfer_encoding on;
         }
    }
 

--- a/backend/nginx/conf.d/default.conf
+++ b/backend/nginx/conf.d/default.conf
@@ -4,20 +4,25 @@ server {
         include /etc/nginx/conf.d/service-url.inc;
         resolver 127.0.0.11 valid=30s;
 
-        location / {
+        location ~* /stream$ {
             proxy_pass $service_url;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
-            add_header X-Service-Version $service_version always;
-
-            # SSE(Server-Sent Events) 지원을 위한 설정
-            proxy_http_version 1.1;
-            proxy_set_header Connection "";
             proxy_buffering off;
             proxy_cache off;
-            chunked_transfer_encoding on;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_read_timeout 300s;
+        }
+
+        location / {
+            proxy_pass $service_url;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            add_header X-Service-Version $service_version always;
         }
    }
 


### PR DESCRIPTION
## Issues
- closed #610 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description

dev-cd 브랜치에서 변경 내용을 테스트 배포해봤을 때, sse 연결이 되는 것 확인했습니다.

<img width="1069" height="242" alt="image" src="https://github.com/user-attachments/assets/f3aa067f-b4d6-4188-bb39-db7403217a8f" />

### proxy_buffering off;

버퍼링 설정을 해주면 Spring 서버에서 응답을 nginx의 응답 버퍼에 넣어주고 연결을 끊어버리지만, 버퍼링이 꺼지면 Spring Boot → Nginx → 클라이언트가 동기적으로 동작하기 때문에 Spring Boot 스레드가 그만큼 오래 잡혀 있다고 해요. 따라서 sse 연결을 위한 설정은 sse api에만 적용하기 위해, location 블럭을 분리했어요.

```nginx
location ~* /stream$ {
    proxy_pass $service_url;
    proxy_set_header Host $host;
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    
    proxy_buffering off;
    proxy_cache off;
    proxy_http_version 1.1;
    proxy_set_header Connection "";
    proxy_read_timeout 300s;
}

location / {
    proxy_pass $service_url;
    proxy_set_header Host $host;
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    add_header X-Service-Version $service_version always;
}
```


## 📷 Screenshot

## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 서버 전송 이벤트(SSE) 지원을 추가하여 실시간 데이터 스트리밍 기능을 활성화했습니다. 이를 통해 클라이언트가 서버로부터 연속적인 업데이트를 수신할 수 있게 되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->