### PR TITLE
[fix] 찜폴더 마이그레이션 로직 수정

### DIFF
--- a/backend/turip-app/src/main/java/turip/account/service/MemberService.java
+++ b/backend/turip-app/src/main/java/turip/account/service/MemberService.java
@@ -64,7 +64,7 @@ public class MemberService {
     }
 
     private void migrateFavoriteFolders(Member member, Guest guest) {
-        favoriteFolderRepository.deletePersonalFoldersByAccount(guest.getAccount());
+        favoriteFolderRepository.deleteDefaultFolderByAccount(member.getAccount());
         favoriteFolderAccountRepository.updateAccount(guest.getAccount(), member.getAccount());
     }
 }

--- a/backend/turip-app/src/main/java/turip/favorite/repository/FavoriteFolderRepository.java
+++ b/backend/turip-app/src/main/java/turip/favorite/repository/FavoriteFolderRepository.java
@@ -42,4 +42,14 @@ public interface FavoriteFolderRepository extends JpaRepository<FavoriteFolder, 
             ") " +
             "AND ff.isShared = false")
     void deletePersonalFoldersByAccount(@Param("account") Account account);
+
+    @Modifying
+    @Query("DELETE FROM FavoriteFolder ff " +
+            "WHERE ff.id IN (" +
+            "   SELECT ffa.favoriteFolder.id " +
+            "   FROM FavoriteFolderAccount ffa " +
+            "   WHERE ffa.account = :account " +
+            ") " +
+            "AND ff.isDefault = true")
+    void deleteDefaultFolderByAccount(@Param("account") Account account);
 }

--- a/backend/turip-app/src/main/java/turip/favorite/repository/FavoriteFolderRepository.java
+++ b/backend/turip-app/src/main/java/turip/favorite/repository/FavoriteFolderRepository.java
@@ -45,11 +45,11 @@ public interface FavoriteFolderRepository extends JpaRepository<FavoriteFolder, 
 
     @Modifying
     @Query("DELETE FROM FavoriteFolder ff " +
-            "WHERE ff.id IN (" +
+            "WHERE ff.id = (" +
             "   SELECT ffa.favoriteFolder.id " +
             "   FROM FavoriteFolderAccount ffa " +
             "   WHERE ffa.account = :account " +
-            ") " +
-            "AND ff.isDefault = true")
+            "   AND ffa.favoriteFolder.isDefault = true" +
+            ")")
     void deleteDefaultFolderByAccount(@Param("account") Account account);
 }

--- a/backend/turip-app/src/test/java/turip/account/api/MemberApiTest.java
+++ b/backend/turip-app/src/test/java/turip/account/api/MemberApiTest.java
@@ -1,13 +1,8 @@
 package turip.account.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.mockito.Mockito.when;
 
 import io.restassured.RestAssured;
-import io.restassured.http.ContentType;
-import java.util.HashMap;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -98,8 +93,10 @@ class MemberApiTest {
             testDataHelper.insertSocialMember(memberId, provider, providerId);
 
             // 3. Guest의 FavoriteFolder와 FavoriteContent 생성
+            Long folderId0 = testDataHelper.insertFavoriteFolder("기본 폴더", true, false);
             Long folderId1 = testDataHelper.insertFavoriteFolder("기본 폴더", true, false);
             Long folderId2 = testDataHelper.insertFavoriteFolder("커스텀 폴더");
+            testDataHelper.insertFavoriteFolderAccount(memberAccountId, folderId0, AccountRole.OWNER);
             testDataHelper.insertFavoriteFolderAccount(guestAccountId, folderId1, AccountRole.OWNER);
             testDataHelper.insertFavoriteFolderAccount(guestAccountId, folderId2, AccountRole.OWNER);
 
@@ -140,11 +137,20 @@ class MemberApiTest {
             );
             assertThat(favoriteContentCount).isEqualTo(1);
 
+            // 검증: 게스트에 존재하던 폴더가 모두 제거됐는지 확인
             Integer favoriteFolderAccountCount = jdbcTemplate.queryForObject(
-                    "SELECT COUNT(*) FROM favorite_folder_account WHERE account_id = 2",
-                    Integer.class
+                    "SELECT COUNT(*) FROM favorite_folder_account WHERE account_id = ?",
+                    Integer.class,
+                    guestAccountId
             );
-            assertThat(favoriteFolderAccountCount).isEqualTo(0); // Guest의 개인 폴더는 모두 삭제됨
+            assertThat(favoriteFolderAccountCount).isEqualTo(0);
+
+            // 검증: 기존에 member에 존재하던 폴더는 제거되고, 마이그레이션 된 폴더만 존재하는지 확인
+            Integer migratedFolderCount = jdbcTemplate.queryForObject(
+                    "SELECT COUNT(*) FROM favorite_folder_account WHERE account_id = ?",
+                    Integer.class,
+                    memberAccountId);
+            assertThat(migratedFolderCount).isEqualTo(2);
 
             // 검증: Guest가 삭제되었는지 확인
             Integer guestCount = jdbcTemplate.queryForObject(

--- a/backend/turip-app/src/test/java/turip/account/service/MemberServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/account/service/MemberServiceTest.java
@@ -2,7 +2,6 @@ package turip.account.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -24,15 +23,11 @@ import turip.account.repository.MemberRepository;
 import turip.auth.service.RefreshTokenService;
 import turip.common.exception.ErrorTag;
 import turip.common.exception.custom.BadRequestException;
-import turip.favorite.domain.AccountRole;
 import turip.favorite.domain.FavoriteContent;
-import turip.favorite.domain.FavoriteFolder;
-import turip.favorite.domain.FavoriteFolderAccount;
 import turip.favorite.repository.FavoriteContentRepository;
 import turip.favorite.repository.FavoriteFolderAccountRepository;
 import turip.favorite.repository.FavoriteFolderRepository;
 import turip.util.fixture.AccountFixture;
-import turip.util.fixture.FavoriteFolderFixture;
 import turip.util.fixture.GuestFixture;
 import turip.util.fixture.MemberFixture;
 
@@ -125,7 +120,7 @@ class MemberServiceTest {
             memberService.migrate(member, guest);
 
             // then
-            verify(favoriteFolderRepository).deletePersonalFoldersByAccount(guestAccount);
+            verify(favoriteFolderRepository).deleteDefaultFolderByAccount(memberAccount);
             verify(favoriteFolderAccountRepository).updateAccount(guestAccount, memberAccount);
         }
 

--- a/backend/turip-app/src/test/java/turip/favorite/repository/FavoriteFolderRepositoryTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/repository/FavoriteFolderRepositoryTest.java
@@ -153,4 +153,26 @@ class FavoriteFolderRepositoryTest {
         assertThat(favoriteFolderRepository.findById(personalFolder2.getId())).isEmpty();
         assertThat(favoriteFolderRepository.findById(sharedFolder.getId())).isPresent();
     }
+
+    @Test
+    @DisplayName("특정 계정의 기본 폴더를 삭제할 수 있다")
+    void deleteDefaultFoldersByAccount() {
+        // given
+        Account account = accountRepository.save(AccountFixture.createEntity());
+
+        FavoriteFolder defaultFolder = favoriteFolderRepository.save(FavoriteFolderFixture.createDefaultFolder());
+
+        // 폴더와 계정 연결
+        favoriteFolderAccountRepository.save(
+                FavoriteFolderAccountFixture.createFavoriteFolderAccount(defaultFolder, account, AccountRole.OWNER));
+
+        // when
+        favoriteFolderRepository.deleteDefaultFolderByAccount(account);
+        entityManager.flush();
+        entityManager.clear();
+
+        // then
+        assertThat(favoriteFolderRepository.findById(defaultFolder.getId())).isEmpty();
+        assertThat(favoriteFolderAccountRepository.findByFavoriteFolderAndAccount(defaultFolder, account)).isEmpty();
+    }
 }


### PR DESCRIPTION
## Issues
- closed #622 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description

공유찜폴더 마이그레이션 동작:

1. member 계정 생성과 동시에 생겼던 member의 기존 기본 폴더 제거(마이그레이션은 회원가입 직후 진행 -> 그 사이에 생긴 찜폴더는 기본찜폴더밖에 없고, guest의 기본 찜폴더를 옮겨올 것이기 때문에 제거 필요)
2. guest의 모든 찜폴더에 대한 account_id를 member의 account_id로 변경


## 📷 Screenshot

## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 계정 마이그레이션 시 기본(디폴트) 즐겨찾기 폴더 삭제 로직으로 수정하여 마이그레이션된 계정의 폴더 정리 정확성 향상

* **테스트**
  * 기본 즐겨찾기 폴더 삭제 동작에 대한 단위/통합 테스트 추가
  * 계정 마이그레이션 관련 검증 로직 보강으로 이관된 폴더 수 확인 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->