### PR TITLE
[feat] 공용 debug keystore 설정

### DIFF
--- a/.github/workflows/android-cd.yml
+++ b/.github/workflows/android-cd.yml
@@ -44,10 +44,9 @@ jobs:
 
       - name: Create local.properties
         run: |
-          echo "base_url=${{ secrets.BASE_URL }}" > local.properties
-          echo "keyAlias=${{ secrets.KEY_ALIAS }}" >> local.properties
-          echo "keyPassword=${{ secrets.KEY_PASSWORD }}" >> local.properties
-          echo "storePassword=${{ secrets.STORE_PASSWORD }}" >> local.properties
+          echo "debug_base_url=${{ secrets.DEBUG_BASE_URL }}" > ./local.properties
+          echo "release_base_url=${{ secrets.RELEASE_BASE_URL }}" >> ./local.properties
+          echo "client_id=${{ secrets.GOOGLE_CLIENT_ID }}" >> ./local.properties
           echo "google_maps_api_key=${{ secrets.GOOGLE_MAPS_API_KEY }}" >> ./local.properties
 
       - name: Write google-services.json for release
@@ -55,8 +54,21 @@ jobs:
           mkdir -p ./app
           echo '${{ secrets.GOOGLE_SERVICES_JSON_RELEASE }}' > ./app/google-services.json
 
-      - name: Generate Keystore
-        run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > ./app/release-keystore.jks
+      - name: Generate Keystores
+        run: |
+          echo "${{ secrets.DEBUG_KEYSTORE_BASE64 }}" | base64 -d > ./app/debug-keystore.jks
+          echo "${{ secrets.RELEASE_KEYSTORE_BASE64 }}" | base64 -d > ./app/release-keystore.jks
+
+      - name: Create keystore.properties
+        run: |
+          echo "debug_store_file=./app/debug-keystore.jks" > ./keystore.properties
+          echo "debug_store_password=${{ secrets.DEBUG_STORE_PASSWORD }}" >> ./keystore.properties
+          echo "debug_key_alias=${{ secrets.DEBUG_KEY_ALIAS }}" >> ./keystore.properties
+          echo "debug_key_password=${{ secrets.DEBUG_KEY_PASSWORD }}" >> ./keystore.properties
+          echo "release_store_file=./app/release-keystore.jks" >> ./keystore.properties
+          echo "release_store_password=${{ secrets.RELEASE_STORE_PASSWORD }}" >> ./keystore.properties
+          echo "release_key_alias=${{ secrets.RELEASE_KEY_ALIAS }}" >> ./keystore.properties
+          echo "release_key_password=${{ secrets.RELEASE_KEY_PASSWORD }}" >> ./keystore.properties
 
       - name: Build Release AAB
         run: ./gradlew bundleRelease --stacktrace
@@ -94,4 +106,3 @@ jobs:
           curl -H "Content-Type: application/json" \
             -d '{"username": "Turip Android", "content": "❌ Turip Android PR Check Failure - Please Check!"}' \
             ${{ secrets.DISCORD_WEBHOOK_URL }}
-

--- a/.github/workflows/android-cd.yml
+++ b/.github/workflows/android-cd.yml
@@ -44,10 +44,12 @@ jobs:
 
       - name: Create local.properties
         run: |
-          echo "debug_base_url=${{ secrets.DEBUG_BASE_URL }}" > ./local.properties
-          echo "release_base_url=${{ secrets.RELEASE_BASE_URL }}" >> ./local.properties
-          echo "client_id=${{ secrets.GOOGLE_CLIENT_ID }}" >> ./local.properties
-          echo "google_maps_api_key=${{ secrets.GOOGLE_MAPS_API_KEY }}" >> ./local.properties
+          cat > ./local.properties <<'EOF'
+          debug_base_url=${{ secrets.DEBUG_BASE_URL }}
+          release_base_url=${{ secrets.RELEASE_BASE_URL }}
+          client_id=${{ secrets.GOOGLE_CLIENT_ID }}
+          google_maps_api_key=${{ secrets.GOOGLE_MAPS_API_KEY }}
+          EOF
 
       - name: Write google-services.json for release
         run: |
@@ -61,14 +63,16 @@ jobs:
 
       - name: Create keystore.properties
         run: |
-          echo "debug_store_file=./debug-keystore.jks" > ./keystore.properties
-          echo "debug_store_password=${{ secrets.DEBUG_STORE_PASSWORD }}" >> ./keystore.properties
-          echo "debug_key_alias=${{ secrets.DEBUG_KEY_ALIAS }}" >> ./keystore.properties
-          echo "debug_key_password=${{ secrets.DEBUG_KEY_PASSWORD }}" >> ./keystore.properties
-          echo "release_store_file=./release-keystore.jks" >> ./keystore.properties
-          echo "release_store_password=${{ secrets.RELEASE_STORE_PASSWORD }}" >> ./keystore.properties
-          echo "release_key_alias=${{ secrets.RELEASE_KEY_ALIAS }}" >> ./keystore.properties
-          echo "release_key_password=${{ secrets.RELEASE_KEY_PASSWORD }}" >> ./keystore.properties
+          cat > ./keystore.properties <<'EOF'
+          debug_store_file=./debug-keystore.jks
+          debug_store_password=${{ secrets.DEBUG_STORE_PASSWORD }}
+          debug_key_alias=${{ secrets.DEBUG_KEY_ALIAS }}
+          debug_key_password=${{ secrets.DEBUG_KEY_PASSWORD }}
+          release_store_file=./release-keystore.jks
+          release_store_password=${{ secrets.RELEASE_STORE_PASSWORD }}
+          release_key_alias=${{ secrets.RELEASE_KEY_ALIAS }}
+          release_key_password=${{ secrets.RELEASE_KEY_PASSWORD }}
+          EOF
 
       - name: Build Release AAB
         run: ./gradlew bundleRelease --stacktrace

--- a/.github/workflows/android-cd.yml
+++ b/.github/workflows/android-cd.yml
@@ -61,11 +61,11 @@ jobs:
 
       - name: Create keystore.properties
         run: |
-          echo "debug_store_file=./app/debug-keystore.jks" > ./keystore.properties
+          echo "debug_store_file=./debug-keystore.jks" > ./keystore.properties
           echo "debug_store_password=${{ secrets.DEBUG_STORE_PASSWORD }}" >> ./keystore.properties
           echo "debug_key_alias=${{ secrets.DEBUG_KEY_ALIAS }}" >> ./keystore.properties
           echo "debug_key_password=${{ secrets.DEBUG_KEY_PASSWORD }}" >> ./keystore.properties
-          echo "release_store_file=./app/release-keystore.jks" >> ./keystore.properties
+          echo "release_store_file=./release-keystore.jks" >> ./keystore.properties
           echo "release_store_password=${{ secrets.RELEASE_STORE_PASSWORD }}" >> ./keystore.properties
           echo "release_key_alias=${{ secrets.RELEASE_KEY_ALIAS }}" >> ./keystore.properties
           echo "release_key_password=${{ secrets.RELEASE_KEY_PASSWORD }}" >> ./keystore.properties

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -48,7 +48,24 @@ jobs:
         run: |
           echo "debug_base_url=${{ secrets.DEBUG_BASE_URL }}" > ./local.properties
           echo "release_base_url=${{ secrets.RELEASE_BASE_URL }}" >> ./local.properties
+          echo "client_id=${{ secrets.GOOGLE_CLIENT_ID }}" >> ./local.properties
           echo "google_maps_api_key=${{ secrets.GOOGLE_MAPS_API_KEY }}" >> ./local.properties
+
+      - name: Generate Keystores
+        run: |
+          echo "${{ secrets.DEBUG_KEYSTORE_BASE64 }}" | base64 -d > ./app/debug-keystore.jks
+          echo "${{ secrets.RELEASE_KEYSTORE_BASE64 }}" | base64 -d > ./app/release-keystore.jks
+
+      - name: Create keystore.properties
+        run: |
+          echo "debug_store_file=./app/debug-keystore.jks" > ./keystore.properties
+          echo "debug_store_password=${{ secrets.DEBUG_STORE_PASSWORD }}" >> ./keystore.properties
+          echo "debug_key_alias=${{ secrets.DEBUG_KEY_ALIAS }}" >> ./keystore.properties
+          echo "debug_key_password=${{ secrets.DEBUG_KEY_PASSWORD }}" >> ./keystore.properties
+          echo "release_store_file=./app/release-keystore.jks" >> ./keystore.properties
+          echo "release_store_password=${{ secrets.RELEASE_STORE_PASSWORD }}" >> ./keystore.properties
+          echo "release_key_alias=${{ secrets.RELEASE_KEY_ALIAS }}" >> ./keystore.properties
+          echo "release_key_password=${{ secrets.RELEASE_KEY_PASSWORD }}" >> ./keystore.properties
 
       - name: Write google-services.json for debug
         run: |
@@ -90,7 +107,27 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Create local.properties
-        run: echo "base_url=${{ secrets.BASE_URL }}" > local.properties
+        run: |
+          echo "debug_base_url=${{ secrets.DEBUG_BASE_URL }}" > ./local.properties
+          echo "release_base_url=${{ secrets.RELEASE_BASE_URL }}" >> ./local.properties
+          echo "client_id=${{ secrets.CLIENT_ID }}" >> ./local.properties
+          echo "google_maps_api_key=${{ secrets.GOOGLE_MAPS_API_KEY }}" >> ./local.properties
+
+      - name: Generate Keystores
+        run: |
+          echo "${{ secrets.DEBUG_KEYSTORE_BASE64 }}" | base64 -d > ./app/debug-keystore.jks
+          echo "${{ secrets.RELEASE_KEYSTORE_BASE64 }}" | base64 -d > ./app/release-keystore.jks
+
+      - name: Create keystore.properties
+        run: |
+          echo "debug_store_file=./app/debug-keystore.jks" > ./keystore.properties
+          echo "debug_store_password=${{ secrets.DEBUG_STORE_PASSWORD }}" >> ./keystore.properties
+          echo "debug_key_alias=${{ secrets.DEBUG_KEY_ALIAS }}" >> ./keystore.properties
+          echo "debug_key_password=${{ secrets.DEBUG_KEY_PASSWORD }}" >> ./keystore.properties
+          echo "release_store_file=./app/release-keystore.jks" >> ./keystore.properties
+          echo "release_store_password=${{ secrets.RELEASE_STORE_PASSWORD }}" >> ./keystore.properties
+          echo "release_key_alias=${{ secrets.RELEASE_KEY_ALIAS }}" >> ./keystore.properties
+          echo "release_key_password=${{ secrets.RELEASE_KEY_PASSWORD }}" >> ./keystore.properties
 
       - name: Run ktlintCheck
         run: ./gradlew ktlintCheck --stacktrace
@@ -122,9 +159,27 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Create local.properties
-        run: | 
-          echo "base_url=${{ secrets.BASE_URL }}" > local.properties
+        run: |
+          echo "debug_base_url=${{ secrets.DEBUG_BASE_URL }}" > ./local.properties
+          echo "release_base_url=${{ secrets.RELEASE_BASE_URL }}" >> ./local.properties
+          echo "client_id=${{ secrets.CLIENT_ID }}" >> ./local.properties
           echo "google_maps_api_key=${{ secrets.GOOGLE_MAPS_API_KEY }}" >> ./local.properties
+
+      - name: Generate Keystores
+        run: |
+          echo "${{ secrets.DEBUG_KEYSTORE_BASE64 }}" | base64 -d > ./app/debug-keystore.jks
+          echo "${{ secrets.RELEASE_KEYSTORE_BASE64 }}" | base64 -d > ./app/release-keystore.jks
+
+      - name: Create keystore.properties
+        run: |
+          echo "debug_store_file=./app/debug-keystore.jks" > ./keystore.properties
+          echo "debug_store_password=${{ secrets.DEBUG_STORE_PASSWORD }}" >> ./keystore.properties
+          echo "debug_key_alias=${{ secrets.DEBUG_KEY_ALIAS }}" >> ./keystore.properties
+          echo "debug_key_password=${{ secrets.DEBUG_KEY_PASSWORD }}" >> ./keystore.properties
+          echo "release_store_file=./app/release-keystore.jks" >> ./keystore.properties
+          echo "release_store_password=${{ secrets.RELEASE_STORE_PASSWORD }}" >> ./keystore.properties
+          echo "release_key_alias=${{ secrets.RELEASE_KEY_ALIAS }}" >> ./keystore.properties
+          echo "release_key_password=${{ secrets.RELEASE_KEY_PASSWORD }}" >> ./keystore.properties
 
       - name: Write google-services.json for debug
         run: |

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -46,10 +46,12 @@ jobs:
 
       - name: Create local.properties
         run: |
-          echo "debug_base_url=${{ secrets.DEBUG_BASE_URL }}" > ./local.properties
-          echo "release_base_url=${{ secrets.RELEASE_BASE_URL }}" >> ./local.properties
-          echo "client_id=${{ secrets.GOOGLE_CLIENT_ID }}" >> ./local.properties
-          echo "google_maps_api_key=${{ secrets.GOOGLE_MAPS_API_KEY }}" >> ./local.properties
+          cat > ./local.properties <<'EOF'
+          debug_base_url=${{ secrets.DEBUG_BASE_URL }}
+          release_base_url=${{ secrets.RELEASE_BASE_URL }}
+          client_id=${{ secrets.GOOGLE_CLIENT_ID }}
+          google_maps_api_key=${{ secrets.GOOGLE_MAPS_API_KEY }}
+          EOF
 
       - name: Generate Keystores
         run: |
@@ -58,14 +60,16 @@ jobs:
 
       - name: Create keystore.properties
         run: |
-          echo "debug_store_file=./debug-keystore.jks" > ./keystore.properties
-          echo "debug_store_password=${{ secrets.DEBUG_STORE_PASSWORD }}" >> ./keystore.properties
-          echo "debug_key_alias=${{ secrets.DEBUG_KEY_ALIAS }}" >> ./keystore.properties
-          echo "debug_key_password=${{ secrets.DEBUG_KEY_PASSWORD }}" >> ./keystore.properties
-          echo "release_store_file=./release-keystore.jks" >> ./keystore.properties
-          echo "release_store_password=${{ secrets.RELEASE_STORE_PASSWORD }}" >> ./keystore.properties
-          echo "release_key_alias=${{ secrets.RELEASE_KEY_ALIAS }}" >> ./keystore.properties
-          echo "release_key_password=${{ secrets.RELEASE_KEY_PASSWORD }}" >> ./keystore.properties
+          cat > ./keystore.properties <<'EOF'
+          debug_store_file=./debug-keystore.jks
+          debug_store_password=${{ secrets.DEBUG_STORE_PASSWORD }}
+          debug_key_alias=${{ secrets.DEBUG_KEY_ALIAS }}
+          debug_key_password=${{ secrets.DEBUG_KEY_PASSWORD }}
+          release_store_file=./release-keystore.jks
+          release_store_password=${{ secrets.RELEASE_STORE_PASSWORD }}
+          release_key_alias=${{ secrets.RELEASE_KEY_ALIAS }}
+          release_key_password=${{ secrets.RELEASE_KEY_PASSWORD }}
+          EOF
 
       - name: Write google-services.json for debug
         run: |
@@ -108,10 +112,12 @@ jobs:
 
       - name: Create local.properties
         run: |
-          echo "debug_base_url=${{ secrets.DEBUG_BASE_URL }}" > ./local.properties
-          echo "release_base_url=${{ secrets.RELEASE_BASE_URL }}" >> ./local.properties
-          echo "client_id=${{ secrets.GOOGLE_CLIENT_ID }}" >> ./local.properties
-          echo "google_maps_api_key=${{ secrets.GOOGLE_MAPS_API_KEY }}" >> ./local.properties
+          cat > ./local.properties <<'EOF'
+          debug_base_url=${{ secrets.DEBUG_BASE_URL }}
+          release_base_url=${{ secrets.RELEASE_BASE_URL }}
+          client_id=${{ secrets.GOOGLE_CLIENT_ID }}
+          google_maps_api_key=${{ secrets.GOOGLE_MAPS_API_KEY }}
+          EOF
 
       - name: Generate Keystores
         run: |
@@ -120,14 +126,16 @@ jobs:
 
       - name: Create keystore.properties
         run: |
-          echo "debug_store_file=./debug-keystore.jks" > ./keystore.properties
-          echo "debug_store_password=${{ secrets.DEBUG_STORE_PASSWORD }}" >> ./keystore.properties
-          echo "debug_key_alias=${{ secrets.DEBUG_KEY_ALIAS }}" >> ./keystore.properties
-          echo "debug_key_password=${{ secrets.DEBUG_KEY_PASSWORD }}" >> ./keystore.properties
-          echo "release_store_file=./release-keystore.jks" >> ./keystore.properties
-          echo "release_store_password=${{ secrets.RELEASE_STORE_PASSWORD }}" >> ./keystore.properties
-          echo "release_key_alias=${{ secrets.RELEASE_KEY_ALIAS }}" >> ./keystore.properties
-          echo "release_key_password=${{ secrets.RELEASE_KEY_PASSWORD }}" >> ./keystore.properties
+          cat > ./keystore.properties <<'EOF'
+          debug_store_file=./debug-keystore.jks
+          debug_store_password=${{ secrets.DEBUG_STORE_PASSWORD }}
+          debug_key_alias=${{ secrets.DEBUG_KEY_ALIAS }}
+          debug_key_password=${{ secrets.DEBUG_KEY_PASSWORD }}
+          release_store_file=./release-keystore.jks
+          release_store_password=${{ secrets.RELEASE_STORE_PASSWORD }}
+          release_key_alias=${{ secrets.RELEASE_KEY_ALIAS }}
+          release_key_password=${{ secrets.RELEASE_KEY_PASSWORD }}
+          EOF
 
       - name: Run ktlintCheck
         run: ./gradlew ktlintCheck --stacktrace
@@ -160,10 +168,12 @@ jobs:
 
       - name: Create local.properties
         run: |
-          echo "debug_base_url=${{ secrets.DEBUG_BASE_URL }}" > ./local.properties
-          echo "release_base_url=${{ secrets.RELEASE_BASE_URL }}" >> ./local.properties
-          echo "client_id=${{ secrets.GOOGLE_CLIENT_ID }}" >> ./local.properties
-          echo "google_maps_api_key=${{ secrets.GOOGLE_MAPS_API_KEY }}" >> ./local.properties
+          cat > ./local.properties <<'EOF'
+          debug_base_url=${{ secrets.DEBUG_BASE_URL }}
+          release_base_url=${{ secrets.RELEASE_BASE_URL }}
+          client_id=${{ secrets.GOOGLE_CLIENT_ID }}
+          google_maps_api_key=${{ secrets.GOOGLE_MAPS_API_KEY }}
+          EOF
 
       - name: Generate Keystores
         run: |
@@ -172,14 +182,16 @@ jobs:
 
       - name: Create keystore.properties
         run: |
-          echo "debug_store_file=./debug-keystore.jks" > ./keystore.properties
-          echo "debug_store_password=${{ secrets.DEBUG_STORE_PASSWORD }}" >> ./keystore.properties
-          echo "debug_key_alias=${{ secrets.DEBUG_KEY_ALIAS }}" >> ./keystore.properties
-          echo "debug_key_password=${{ secrets.DEBUG_KEY_PASSWORD }}" >> ./keystore.properties
-          echo "release_store_file=./release-keystore.jks" >> ./keystore.properties
-          echo "release_store_password=${{ secrets.RELEASE_STORE_PASSWORD }}" >> ./keystore.properties
-          echo "release_key_alias=${{ secrets.RELEASE_KEY_ALIAS }}" >> ./keystore.properties
-          echo "release_key_password=${{ secrets.RELEASE_KEY_PASSWORD }}" >> ./keystore.properties
+          cat > ./keystore.properties <<'EOF'
+          debug_store_file=./debug-keystore.jks
+          debug_store_password=${{ secrets.DEBUG_STORE_PASSWORD }}
+          debug_key_alias=${{ secrets.DEBUG_KEY_ALIAS }}
+          debug_key_password=${{ secrets.DEBUG_KEY_PASSWORD }}
+          release_store_file=./release-keystore.jks
+          release_store_password=${{ secrets.RELEASE_STORE_PASSWORD }}
+          release_key_alias=${{ secrets.RELEASE_KEY_ALIAS }}
+          release_key_password=${{ secrets.RELEASE_KEY_PASSWORD }}
+          EOF
 
       - name: Write google-services.json for debug
         run: |

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -58,11 +58,11 @@ jobs:
 
       - name: Create keystore.properties
         run: |
-          echo "debug_store_file=./app/debug-keystore.jks" > ./keystore.properties
+          echo "debug_store_file=./debug-keystore.jks" > ./keystore.properties
           echo "debug_store_password=${{ secrets.DEBUG_STORE_PASSWORD }}" >> ./keystore.properties
           echo "debug_key_alias=${{ secrets.DEBUG_KEY_ALIAS }}" >> ./keystore.properties
           echo "debug_key_password=${{ secrets.DEBUG_KEY_PASSWORD }}" >> ./keystore.properties
-          echo "release_store_file=./app/release-keystore.jks" >> ./keystore.properties
+          echo "release_store_file=./release-keystore.jks" >> ./keystore.properties
           echo "release_store_password=${{ secrets.RELEASE_STORE_PASSWORD }}" >> ./keystore.properties
           echo "release_key_alias=${{ secrets.RELEASE_KEY_ALIAS }}" >> ./keystore.properties
           echo "release_key_password=${{ secrets.RELEASE_KEY_PASSWORD }}" >> ./keystore.properties
@@ -110,7 +110,7 @@ jobs:
         run: |
           echo "debug_base_url=${{ secrets.DEBUG_BASE_URL }}" > ./local.properties
           echo "release_base_url=${{ secrets.RELEASE_BASE_URL }}" >> ./local.properties
-          echo "client_id=${{ secrets.CLIENT_ID }}" >> ./local.properties
+          echo "client_id=${{ secrets.GOOGLE_CLIENT_ID }}" >> ./local.properties
           echo "google_maps_api_key=${{ secrets.GOOGLE_MAPS_API_KEY }}" >> ./local.properties
 
       - name: Generate Keystores
@@ -120,11 +120,11 @@ jobs:
 
       - name: Create keystore.properties
         run: |
-          echo "debug_store_file=./app/debug-keystore.jks" > ./keystore.properties
+          echo "debug_store_file=./debug-keystore.jks" > ./keystore.properties
           echo "debug_store_password=${{ secrets.DEBUG_STORE_PASSWORD }}" >> ./keystore.properties
           echo "debug_key_alias=${{ secrets.DEBUG_KEY_ALIAS }}" >> ./keystore.properties
           echo "debug_key_password=${{ secrets.DEBUG_KEY_PASSWORD }}" >> ./keystore.properties
-          echo "release_store_file=./app/release-keystore.jks" >> ./keystore.properties
+          echo "release_store_file=./release-keystore.jks" >> ./keystore.properties
           echo "release_store_password=${{ secrets.RELEASE_STORE_PASSWORD }}" >> ./keystore.properties
           echo "release_key_alias=${{ secrets.RELEASE_KEY_ALIAS }}" >> ./keystore.properties
           echo "release_key_password=${{ secrets.RELEASE_KEY_PASSWORD }}" >> ./keystore.properties
@@ -162,7 +162,7 @@ jobs:
         run: |
           echo "debug_base_url=${{ secrets.DEBUG_BASE_URL }}" > ./local.properties
           echo "release_base_url=${{ secrets.RELEASE_BASE_URL }}" >> ./local.properties
-          echo "client_id=${{ secrets.CLIENT_ID }}" >> ./local.properties
+          echo "client_id=${{ secrets.GOOGLE_CLIENT_ID }}" >> ./local.properties
           echo "google_maps_api_key=${{ secrets.GOOGLE_MAPS_API_KEY }}" >> ./local.properties
 
       - name: Generate Keystores
@@ -172,11 +172,11 @@ jobs:
 
       - name: Create keystore.properties
         run: |
-          echo "debug_store_file=./app/debug-keystore.jks" > ./keystore.properties
+          echo "debug_store_file=./debug-keystore.jks" > ./keystore.properties
           echo "debug_store_password=${{ secrets.DEBUG_STORE_PASSWORD }}" >> ./keystore.properties
           echo "debug_key_alias=${{ secrets.DEBUG_KEY_ALIAS }}" >> ./keystore.properties
           echo "debug_key_password=${{ secrets.DEBUG_KEY_PASSWORD }}" >> ./keystore.properties
-          echo "release_store_file=./app/release-keystore.jks" >> ./keystore.properties
+          echo "release_store_file=./release-keystore.jks" >> ./keystore.properties
           echo "release_store_password=${{ secrets.RELEASE_STORE_PASSWORD }}" >> ./keystore.properties
           echo "release_key_alias=${{ secrets.RELEASE_KEY_ALIAS }}" >> ./keystore.properties
           echo "release_key_password=${{ secrets.RELEASE_KEY_PASSWORD }}" >> ./keystore.properties

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -8,6 +8,7 @@ build/
 
 # Local configuration file (sdk path, etc)
 local.properties
+keystore.properties
 
 # Log/OS Files
 *.log

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
+import java.util.Properties
 
 plugins {
     alias(libs.plugins.android.application)
@@ -18,6 +19,18 @@ android {
     namespace = "com.on.turip"
     compileSdk = 36
 
+    val localProperties: Properties = gradleLocalProperties(rootDir, providers)
+    val keystorePropertiesFile: File = rootProject.file("keystore.properties")
+    val keystoreProperties: Properties =
+        Properties().apply {
+            if (!keystorePropertiesFile.exists()) error("keystore.properties 파일이 없습니다. android/keystore.properties를 생성해주세요.")
+            keystorePropertiesFile.reader(Charsets.UTF_8).use { reader -> load(reader) }
+        }
+
+    fun requireLocalProperty(key: String): String = localProperties.getProperty(key) ?: error("local.properties에 $key 를 설정해주세요.")
+
+    fun requireKeystoreProperty(key: String): String = keystoreProperties.getProperty(key) ?: error("keystore.properties에 $key 를 설정해주세요.")
+
     defaultConfig {
         applicationId = "com.on.turip"
         minSdk = 24
@@ -32,44 +45,46 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    signingConfigs {
+        create("debugTurip") {
+            storeFile = file(requireKeystoreProperty("debug_store_file"))
+            storePassword = requireKeystoreProperty("debug_store_password")
+            keyAlias = requireKeystoreProperty("debug_key_alias")
+            keyPassword = requireKeystoreProperty("debug_key_password")
+        }
+
+        create("releaseTurip") {
+            storeFile = file(requireKeystoreProperty("release_store_file"))
+            storePassword = requireKeystoreProperty("release_store_password")
+            keyAlias = requireKeystoreProperty("release_key_alias")
+            keyPassword = requireKeystoreProperty("release_key_password")
+        }
+    }
+
     buildTypes {
         debug {
+            signingConfig = signingConfigs.getByName("debugTurip")
+
             isMinifyEnabled = false
             isDebuggable = true
             applicationIdSuffix = ".debug"
             versionNameSuffix = ".debug"
             manifestPlaceholders["appName"] = "튜립.debug"
-            buildConfigField(
-                "String",
-                "BASE_URL",
-                "\"${gradleLocalProperties(rootDir, providers).getProperty("debug_base_url")}\"",
-            )
-            buildConfigField(
-                "String",
-                "CLIENT_ID",
-                "\"${gradleLocalProperties(rootDir, providers).getProperty("client_id")}\"",
-            )
+
+            buildConfigField("String", "BASE_URL", "\"${requireLocalProperty("debug_base_url")}\"")
+            buildConfigField("String", "CLIENT_ID", "\"${requireLocalProperty("client_id")}\"")
         }
 
         release {
+            signingConfig = signingConfigs.getByName("releaseTurip")
+
             isMinifyEnabled = true
             isShrinkResources = true
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro",
-            )
-            signingConfig = signingConfigs.getByName("debug")
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
             manifestPlaceholders["appName"] = "튜립"
-            buildConfigField(
-                "String",
-                "BASE_URL",
-                "\"${gradleLocalProperties(rootDir, providers).getProperty("release_base_url")}\"",
-            )
-            buildConfigField(
-                "String",
-                "CLIENT_ID",
-                "\"${gradleLocalProperties(rootDir, providers).getProperty("client_id")}\"",
-            )
+
+            buildConfigField("String", "BASE_URL", "\"${requireLocalProperty("release_base_url")}\"")
+            buildConfigField("String", "CLIENT_ID", "\"${requireLocalProperty("client_id")}\"")
         }
     }
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.util.Properties
 
 plugins {
@@ -92,12 +93,16 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = "17"
-    }
     buildFeatures {
+        buildConfig = true
         viewBinding = true
         compose = true
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -23,7 +23,6 @@ android {
         minSdk = 24
         //noinspection OldTargetApi
         targetSdk = 35
-        versionCode = 1
         versionName = libs.versions.versionName.get()
         versionCode =
             libs.versions.versionCode

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -21,4 +21,3 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-android.defaults.buildfeatures.buildconfig=true


### PR DESCRIPTION
## Issues
- closed #628

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description

공유 폴더 초대 기능을 구현하다보니 디버그 빌드 타입으로 테스트하기 위해 `SHA-256` key 등록이 필요했어요.

테스트하기 위해 각자 SHA 암호화키를 등록이 필요하기에 공용 Debug 키를 설정을 추가했습니다.
그 과정에서 release 빌드 타입에서 signingConfigs를 임시로 debug 사용하던 부분도 수정하며 빌드 타입별 signingConfig 설정 완료했습니다!

추가된 key 파일 설정은 프로젝트 노션에 기록 해뒀으니 각자 환경에 맞게 설정 부탁드립니다!

그 밖에 deprecated된 설정들 모두 수정 완료했습니다!

## 📷 Screenshot

## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 빌드 메타데이터 생성이 명시적으로 활성화되어 빌드 안정성이 향상되었습니다.
  * Kotlin JVM 대상 버전이 최신화되어 런타임 호환성이 개선되었습니다.
  * 버전 코드와 환경값이 외부 설정에서 읽히도록 변경되어 환경별 관리가 쉬워졌습니다.

* **서명/보안**
  * 개발·릴리스 서명 구성이 분리되어 서명 관리가 더 안전하고 일관되게 처리됩니다.
  * 키스토어 관련 설정이 별도 프로퍼티로 분리되었습니다.

* **CI/CD**
  * CI 파이프라인에서 로컬 설정 및 키스토어 생성/구성이 강화되어 빌드 일관성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->