### PR TITLE
[fix] 장소 찜 다중 업데이트 기능에 대한 권한 변경

### DIFF
--- a/backend/turip-app/src/main/java/turip/favorite/service/FavoritePlaceService.java
+++ b/backend/turip-app/src/main/java/turip/favorite/service/FavoritePlaceService.java
@@ -212,7 +212,7 @@ public class FavoritePlaceService {
         if (requestedFavoriteFolders.size() != requestedFavoriteFolderIds.size()) {
             throw new NotFoundException(ErrorTag.FAVORITE_FOLDER_NOT_FOUND);
         }
-        requestedFavoriteFolders.forEach(folder -> favoriteFolderAccountService.validateOwnership(account, folder));
+        requestedFavoriteFolders.forEach(folder -> favoriteFolderAccountService.validateMembership(account, folder));
     }
 
     private void validateDuplicated(FavoriteFolder favoriteFolder, Place place) {

--- a/backend/turip-app/src/test/java/turip/favorite/service/FavoritePlaceServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/service/FavoritePlaceServiceTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 
 import java.util.List;
@@ -368,6 +369,30 @@ class FavoritePlaceServiceTest {
                     () -> verify(eventPublisher).publishEvent(
                             FavoriteFolderUpdateEvent.of(requestFolderId, ActionType.FOLDER_PLACE_CHANGED))
             );
+        }
+
+        @Test
+        @DisplayName("폴더 소유자가 아닌 참여자인 경우에도 업데이트 할 수 있다.")
+        void updateFavoriteFolders_validateMembership() {
+            // given
+            Account account = AccountFixture.createUser();
+            Long placeId = 1L;
+            Place place = new Place(placeId, "장소", "url", "주소", 1, 1);
+
+            Long folderId = 1L;
+            FavoriteFolder folder = FavoriteFolderFixture.createSharedFolderWithId(folderId, "공유 찜폴더");
+
+            given(placeRepository.findById(placeId)).willReturn(Optional.of(place));
+            given(favoriteFolderRepository.findAllById(any())).willReturn(List.of(folder));
+            given(favoritePlaceRepository.findAllByPlaceAndAccount(place, account)).willReturn(List.of());
+
+            lenient().doThrow(new ForbiddenException(ErrorTag.FORBIDDEN))
+                    .when(favoriteFolderAccountService)
+                    .validateOwnership(account, folder);
+
+            // when & then
+            assertDoesNotThrow(
+                    () -> favoritePlaceService.updateFavoriteFolders(account, List.of(folderId), placeId));
         }
     }
 


### PR DESCRIPTION
## Issues
- closed #634 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
- 폴더 소유자가 아닌 참여자도 장소 찜폴더 다중 업데이트를 통해 장소찜을 추가, 삭제할 수 있도록 수정했습니다!

## 📷 Screenshot

## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **새로운 기능**
  * 즐겨찾기 폴더 업데이트 시 폴더 소유자뿐만 아니라 폴더의 구성원도 장소를 추가하고 관리할 수 있도록 권한 범위가 확대되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->