### PR TITLE
[feat] content_pending 테이블 및 엔티티 추가

### DIFF
--- a/backend/turip-app/src/main/java/turip/common/configuration/JpaAuditingConfiguration.java
+++ b/backend/turip-app/src/main/java/turip/common/configuration/JpaAuditingConfiguration.java
@@ -1,0 +1,9 @@
+package turip.common.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfiguration {
+}

--- a/backend/turip-app/src/main/java/turip/common/domain/BaseTimeEntity.java
+++ b/backend/turip-app/src/main/java/turip/common/domain/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package turip.common.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/backend/turip-app/src/main/java/turip/common/exception/ErrorTag.java
+++ b/backend/turip-app/src/main/java/turip/common/exception/ErrorTag.java
@@ -66,6 +66,7 @@ public enum ErrorTag {
     YOUTUBE_API_REQUEST_FAILED("유튜브 API 요청에 실패했습니다."),
     INVALID_YOUTUBE_URL("유효하지 않은 유튜브 URL입니다."),
     INVALID_TIMELINE_FORMAT("타임라인 형식이 올바르지 않습니다."),
+    IS_ALREADY_APPROVED("이미 승인된 콘텐츠입니다."),
 
     // 404 Not Found
     YOUTUBE_VIDEO_NOT_FOUND("유튜브 영상을 찾을 수 없습니다."),

--- a/backend/turip-app/src/main/java/turip/common/exception/GlobalExceptionHandler.java
+++ b/backend/turip-app/src/main/java/turip/common/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 import turip.common.exception.custom.HttpStatusException;
 import turip.common.exception.custom.IllegalArgumentException;
+import turip.common.exception.custom.IllegalStateException;
 
 @Slf4j
 @RestControllerAdvice
@@ -23,6 +24,13 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.warn(e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.from(e.getErrorTag()));
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalStateException(IllegalStateException e) {
         log.warn(e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ErrorResponse.from(e.getErrorTag()));

--- a/backend/turip-app/src/main/java/turip/common/exception/custom/IllegalStateException.java
+++ b/backend/turip-app/src/main/java/turip/common/exception/custom/IllegalStateException.java
@@ -1,0 +1,22 @@
+package turip.common.exception.custom;
+
+import turip.common.exception.ErrorTag;
+
+public class IllegalStateException extends RuntimeException {
+
+    private final ErrorTag errorTag;
+
+    public IllegalStateException(final ErrorTag errorTag) {
+        super(errorTag.getMessage());
+        this.errorTag = errorTag;
+    }
+
+    public IllegalStateException(final ErrorTag errorTag, final Throwable cause) {
+        super(errorTag.getMessage(), cause);
+        this.errorTag = errorTag;
+    }
+
+    public ErrorTag getErrorTag() {
+        return errorTag;
+    }
+}

--- a/backend/turip-app/src/main/java/turip/content/domain/ContentPending.java
+++ b/backend/turip-app/src/main/java/turip/content/domain/ContentPending.java
@@ -37,7 +37,7 @@ public class ContentPending {
 
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "content_data", nullable = false, columnDefinition = "JSON")
-    private String contentData;
+    private ContentPendingData contentData;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
@@ -65,8 +65,7 @@ public class ContentPending {
     private LocalDateTime updatedAt;
 
     public ContentPending(
-            String contentData,
-            ContentPendingStatus status,
+            ContentPendingData contentData,
             Account collectorAccount,
             Account validatorAccount,
             String rejectReason,

--- a/backend/turip-app/src/main/java/turip/content/domain/ContentPending.java
+++ b/backend/turip-app/src/main/java/turip/content/domain/ContentPending.java
@@ -20,6 +20,8 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 import turip.account.domain.Account;
+import turip.common.exception.ErrorTag;
+import turip.common.exception.custom.IllegalStateException;
 
 @Getter
 @Entity
@@ -81,6 +83,8 @@ public class ContentPending {
     }
 
     public void approve(Account validatorAccount, Content content) {
+        validateStatusNotApproved();
+
         this.status = ContentPendingStatus.APPROVED;
         this.validatorAccount = validatorAccount;
         this.rejectReason = "";
@@ -89,9 +93,17 @@ public class ContentPending {
     }
 
     public void reject(Account validatorAccount, String rejectReason) {
+        validateStatusNotApproved();
+
         this.status = ContentPendingStatus.REJECTED;
         this.validatorAccount = validatorAccount;
         this.rejectReason = rejectReason;
         this.updatedAt = LocalDateTime.now();
+    }
+
+    private void validateStatusNotApproved() {
+        if (this.status == ContentPendingStatus.APPROVED) {
+            throw new IllegalStateException(ErrorTag.IS_ALREADY_APPROVED);
+        }
     }
 }

--- a/backend/turip-app/src/main/java/turip/content/domain/ContentPending.java
+++ b/backend/turip-app/src/main/java/turip/content/domain/ContentPending.java
@@ -62,6 +62,24 @@ public class ContentPending {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
+    public ContentPending(
+            String contentData,
+            ContentPendingStatus status,
+            Account collectorAccount,
+            Account validatorAccount,
+            String rejectReason,
+            Content content
+    ) {
+        this.contentData = contentData;
+        this.status = status;
+        this.collectorAccount = collectorAccount;
+        this.validatorAccount = validatorAccount;
+        this.rejectReason = rejectReason;
+        this.content = content;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
     public void approve(Account validatorAccount, Content content) {
         this.status = ContentPendingStatus.APPROVED;
         this.validatorAccount = validatorAccount;

--- a/backend/turip-app/src/main/java/turip/content/domain/ContentPending.java
+++ b/backend/turip-app/src/main/java/turip/content/domain/ContentPending.java
@@ -72,7 +72,7 @@ public class ContentPending {
             Content content
     ) {
         this.contentData = contentData;
-        this.status = status;
+        this.status = ContentPendingStatus.PENDING;
         this.collectorAccount = collectorAccount;
         this.validatorAccount = validatorAccount;
         this.rejectReason = rejectReason;

--- a/backend/turip-app/src/main/java/turip/content/domain/ContentPending.java
+++ b/backend/turip-app/src/main/java/turip/content/domain/ContentPending.java
@@ -1,0 +1,78 @@
+package turip.content.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import turip.account.domain.Account;
+
+@Getter
+@Entity
+@Table(name = "content_pending")
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ContentPending {
+
+    @Id
+    @EqualsAndHashCode.Include
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "content_data", nullable = false, columnDefinition = "JSON")
+    private String contentData;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private ContentPendingStatus status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "collector_account_id", nullable = false, foreignKey = @ForeignKey(name = "fk_content_pending__collector_account"))
+    private Account collectorAccount;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "validator_account_id", foreignKey = @ForeignKey(name = "fk_content_pending__validator_account"))
+    private Account validatorAccount;
+
+    @Column(name = "reject_reason", columnDefinition = "TEXT")
+    private String rejectReason;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "content_id", foreignKey = @ForeignKey(name = "fk_content_pending__content"))
+    private Content content;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public void approve(Account validatorAccount, Content content) {
+        this.status = ContentPendingStatus.APPROVED;
+        this.validatorAccount = validatorAccount;
+        this.content = content;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void reject(Account validatorAccount, String rejectReason) {
+        this.status = ContentPendingStatus.REJECTED;
+        this.validatorAccount = validatorAccount;
+        this.rejectReason = rejectReason;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/backend/turip-app/src/main/java/turip/content/domain/ContentPending.java
+++ b/backend/turip-app/src/main/java/turip/content/domain/ContentPending.java
@@ -20,6 +20,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 import turip.account.domain.Account;
+import turip.common.domain.BaseTimeEntity;
 import turip.common.exception.ErrorTag;
 import turip.common.exception.custom.IllegalStateException;
 
@@ -28,7 +29,7 @@ import turip.common.exception.custom.IllegalStateException;
 @Table(name = "content_pending")
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ContentPending {
+public class ContentPending extends BaseTimeEntity {
 
     @Id
     @EqualsAndHashCode.Include
@@ -58,11 +59,8 @@ public class ContentPending {
     @JoinColumn(name = "content_id", foreignKey = @ForeignKey(name = "fk_content_pending__content"))
     private Content content;
 
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
+    @Column(name = "content_data_updated_at", nullable = false)
+    private LocalDateTime contentDataUpdatedAt;
 
     public ContentPending(
             ContentPendingData contentData,
@@ -77,8 +75,7 @@ public class ContentPending {
         this.validatorAccount = validatorAccount;
         this.rejectReason = rejectReason;
         this.content = content;
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
+        this.contentDataUpdatedAt = LocalDateTime.now();
     }
 
     public void approve(Account validatorAccount, Content content) {
@@ -88,7 +85,6 @@ public class ContentPending {
         this.validatorAccount = validatorAccount;
         this.rejectReason = "";
         this.content = content;
-        this.updatedAt = LocalDateTime.now();
     }
 
     public void reject(Account validatorAccount, String rejectReason) {
@@ -97,7 +93,6 @@ public class ContentPending {
         this.status = ContentPendingStatus.REJECTED;
         this.validatorAccount = validatorAccount;
         this.rejectReason = rejectReason;
-        this.updatedAt = LocalDateTime.now();
     }
 
     private void validateStatusNotApproved() {

--- a/backend/turip-app/src/main/java/turip/content/domain/ContentPending.java
+++ b/backend/turip-app/src/main/java/turip/content/domain/ContentPending.java
@@ -83,6 +83,7 @@ public class ContentPending {
     public void approve(Account validatorAccount, Content content) {
         this.status = ContentPendingStatus.APPROVED;
         this.validatorAccount = validatorAccount;
+        this.rejectReason = "";
         this.content = content;
         this.updatedAt = LocalDateTime.now();
     }

--- a/backend/turip-app/src/main/java/turip/content/domain/ContentPendingData.java
+++ b/backend/turip-app/src/main/java/turip/content/domain/ContentPendingData.java
@@ -1,0 +1,39 @@
+package turip.content.domain;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record ContentPendingData(
+        String cityName,
+        VideoData video,
+        List<ContentPlaceData> contentPlaces
+) {
+
+    public record VideoData(
+            String videoId,
+            String title,
+            String url,
+            String channelName,
+            String channelImage,
+            LocalDate uploadedDate
+    ) {
+    }
+
+    public record ContentPlaceData(
+            int visitDay,
+            int visitOrder,
+            String timeLine,
+            PlaceData place
+    ) {
+    }
+
+    public record PlaceData(
+            String name,
+            String url,
+            String address,
+            double latitude,
+            double longitude,
+            String categoryName
+    ) {
+    }
+}

--- a/backend/turip-app/src/main/java/turip/content/domain/ContentPendingStatus.java
+++ b/backend/turip-app/src/main/java/turip/content/domain/ContentPendingStatus.java
@@ -1,0 +1,7 @@
+package turip.content.domain;
+
+public enum ContentPendingStatus {
+    PENDING,
+    APPROVED,
+    REJECTED
+}

--- a/backend/turip-app/src/main/resources/db/migration/V14__update_guest_nickname_format.mysql.sql
+++ b/backend/turip-app/src/main/resources/db/migration/V14__update_guest_nickname_format.mysql.sql
@@ -3,4 +3,5 @@
 UPDATE account a
 INNER JOIN guest g ON a.id = g.account_id
 SET a.nickname = CONCAT('게스트_', 50000 + a.id)
-WHERE a.nickname IS NULL OR a.nickname NOT LIKE '게스트_%';
+WHERE a.nickname IS NULL
+   OR a.nickname NOT LIKE '게스트\_%';

--- a/backend/turip-app/src/main/resources/db/migration/V15__create_content_pending_table.mysql.sql
+++ b/backend/turip-app/src/main/resources/db/migration/V15__create_content_pending_table.mysql.sql
@@ -7,6 +7,7 @@ CREATE TABLE content_pending (
     validator_account_id BIGINT NULL,
     reject_reason TEXT NULL,
     content_id BIGINT NULL,
+    content_data_updated_at DATETIME NOT NULL,
     created_at DATETIME NOT NULL,
     updated_at DATETIME NOT NULL,
 

--- a/backend/turip-app/src/main/resources/db/migration/V15__create_content_pending_table.mysql.sql
+++ b/backend/turip-app/src/main/resources/db/migration/V15__create_content_pending_table.mysql.sql
@@ -1,0 +1,19 @@
+-- content_pending 테이블 생성
+CREATE TABLE content_pending (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    content_data JSON NOT NULL,
+    status VARCHAR(255) NOT NULL DEFAULT 'PENDING',
+    collector_account_id BIGINT NOT NULL,
+    validator_account_id BIGINT NULL,
+    reject_reason TEXT NULL,
+    content_id BIGINT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+
+    CONSTRAINT fk_content_pending__collector_account
+        FOREIGN KEY (collector_account_id) REFERENCES account (id),
+    CONSTRAINT fk_content_pending__validator_account
+        FOREIGN KEY (validator_account_id) REFERENCES account (id),
+    CONSTRAINT fk_content_pending__content
+        FOREIGN KEY (content_id) REFERENCES content (id)
+);

--- a/backend/turip-app/src/test/java/turip/content/domain/ContentPendingTest.java
+++ b/backend/turip-app/src/test/java/turip/content/domain/ContentPendingTest.java
@@ -1,0 +1,87 @@
+package turip.content.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import turip.account.domain.Account;
+import turip.util.fixture.AccountFixture;
+
+class ContentPendingTest {
+
+    @DisplayName("펜딩 콘텐츠 status 변경 테스트")
+    @Nested
+    class ContentPendingStatusTest {
+
+        @DisplayName("PENDING -> APPROVED 상태 변경 테스트")
+        @Test
+        void approve() {
+            // given
+            Account collector = AccountFixture.createAdmin();
+            Account validator = AccountFixture.createAdmin();
+            ContentPending pendingContent = new ContentPending(
+                    "{\"cityName\":\"서울\"}",
+                    ContentPendingStatus.PENDING,
+                    collector,
+                    null,
+                    null,
+                    null
+            );
+            Content content = null;
+
+            // when
+            pendingContent.approve(validator, content);
+
+            // then
+            assertThat(pendingContent.getStatus()).isEqualTo(ContentPendingStatus.APPROVED);
+            assertThat(pendingContent.getValidatorAccount()).isEqualTo(validator);
+        }
+
+        @DisplayName("PENDING -> REJECTED 상태 변경 테스트")
+        @Test
+        void reject() {
+            // given
+            Account collector = AccountFixture.createAdmin();
+            Account validator = AccountFixture.createAdmin();
+            ContentPending pendingContent = new ContentPending(
+                    "{\"cityName\":\"서울\"}",
+                    ContentPendingStatus.PENDING,
+                    collector,
+                    null,
+                    null,
+                    null
+            );
+            String rejectReason = "장소 하나가 빠졌어요";
+
+            // when
+            pendingContent.reject(validator, rejectReason);
+
+            // then
+            assertThat(pendingContent.getStatus()).isEqualTo(ContentPendingStatus.REJECTED);
+            assertThat(pendingContent.getValidatorAccount()).isEqualTo(validator);
+            assertThat(pendingContent.getRejectReason()).isEqualTo(rejectReason);
+        }
+
+        @DisplayName("ContentPending 생성 시 PENDING 상태로 초기화")
+        @Test
+        void createWithPendingStatus() {
+            // given
+            Account collector = AccountFixture.createUser();
+            String contentData = "{\"cityName\":\"부산\",\"video\":{\"videoId\":\"abc123\"}}";
+
+            // when
+            ContentPending pendingContent = new ContentPending(
+                    contentData,
+                    ContentPendingStatus.PENDING,
+                    collector,
+                    null,
+                    null,
+                    null
+            );
+
+            // then
+            assertThat(pendingContent.getStatus()).isEqualTo(ContentPendingStatus.PENDING);
+        }
+    }
+}

--- a/backend/turip-app/src/test/java/turip/content/domain/ContentPendingTest.java
+++ b/backend/turip-app/src/test/java/turip/content/domain/ContentPendingTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import turip.account.domain.Account;
 import turip.common.exception.custom.IllegalStateException;
 import turip.util.fixture.AccountFixture;
+import turip.util.fixture.ContentPendingFixture;
 
 class ContentPendingTest {
 
@@ -26,14 +27,7 @@ class ContentPendingTest {
                 // given
                 Account collector = AccountFixture.createAdmin();
                 Account validator = AccountFixture.createAdmin();
-                ContentPending pendingContent = new ContentPending(
-                        "{\"cityName\":\"서울\"}",
-                        ContentPendingStatus.PENDING,
-                        collector,
-                        null,
-                        "거절 사유",
-                        null
-                );
+                ContentPending pendingContent = ContentPendingFixture.createPending(collector);
                 Content content = null;
 
                 // when
@@ -51,14 +45,7 @@ class ContentPendingTest {
                 // given
                 Account collector = AccountFixture.createAdmin();
                 Account validator = AccountFixture.createAdmin();
-                ContentPending pendingContent = new ContentPending(
-                        "{\"cityName\":\"서울\"}",
-                        ContentPendingStatus.APPROVED,
-                        collector,
-                        null,
-                        "거절 사유",
-                        null
-                );
+                ContentPending pendingContent = ContentPendingFixture.createApproved(collector, validator, null);
                 Content content = null;
 
                 // when & then
@@ -78,14 +65,7 @@ class ContentPendingTest {
                 // given
                 Account collector = AccountFixture.createAdmin();
                 Account validator = AccountFixture.createAdmin();
-                ContentPending pendingContent = new ContentPending(
-                        "{\"cityName\":\"서울\"}",
-                        ContentPendingStatus.PENDING,
-                        collector,
-                        null,
-                        null,
-                        null
-                );
+                ContentPending pendingContent = ContentPendingFixture.createPending(collector);
                 String rejectReason = "장소 하나가 빠졌어요";
 
                 // when
@@ -103,14 +83,7 @@ class ContentPendingTest {
                 // given
                 Account collector = AccountFixture.createAdmin();
                 Account validator = AccountFixture.createAdmin();
-                ContentPending pendingContent = new ContentPending(
-                        "{\"cityName\":\"서울\"}",
-                        ContentPendingStatus.APPROVED,
-                        collector,
-                        null,
-                        null,
-                        null
-                );
+                ContentPending pendingContent = ContentPendingFixture.createApproved(collector, validator, null);
                 String rejectReason = "장소 하나가 빠졌어요";
 
                 // when
@@ -124,20 +97,13 @@ class ContentPendingTest {
         void createWithPendingStatus() {
             // given
             Account collector = AccountFixture.createUser();
-            String contentData = "{\"cityName\":\"부산\",\"video\":{\"videoId\":\"abc123\"}}";
 
             // when
-            ContentPending pendingContent = new ContentPending(
-                    contentData,
-                    ContentPendingStatus.PENDING,
-                    collector,
-                    null,
-                    null,
-                    null
-            );
+            ContentPending pendingContent = ContentPendingFixture.createPending(collector);
 
             // then
             assertThat(pendingContent.getStatus()).isEqualTo(ContentPendingStatus.PENDING);
+            assertThat(pendingContent.getContentData().cityName()).isEqualTo("부산");
         }
     }
 }

--- a/backend/turip-app/src/test/java/turip/content/domain/ContentPendingTest.java
+++ b/backend/turip-app/src/test/java/turip/content/domain/ContentPendingTest.java
@@ -25,7 +25,7 @@ class ContentPendingTest {
                     ContentPendingStatus.PENDING,
                     collector,
                     null,
-                    null,
+                    "거절 사유",
                     null
             );
             Content content = null;
@@ -36,6 +36,7 @@ class ContentPendingTest {
             // then
             assertThat(pendingContent.getStatus()).isEqualTo(ContentPendingStatus.APPROVED);
             assertThat(pendingContent.getValidatorAccount()).isEqualTo(validator);
+            assertThat(pendingContent.getRejectReason()).isBlank();
         }
 
         @DisplayName("PENDING -> REJECTED 상태 변경 테스트")

--- a/backend/turip-app/src/test/java/turip/content/domain/ContentPendingTest.java
+++ b/backend/turip-app/src/test/java/turip/content/domain/ContentPendingTest.java
@@ -1,11 +1,13 @@
 package turip.content.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import turip.account.domain.Account;
+import turip.common.exception.custom.IllegalStateException;
 import turip.util.fixture.AccountFixture;
 
 class ContentPendingTest {
@@ -14,54 +16,107 @@ class ContentPendingTest {
     @Nested
     class ContentPendingStatusTest {
 
-        @DisplayName("PENDING -> APPROVED 상태 변경 테스트")
-        @Test
-        void approve() {
-            // given
-            Account collector = AccountFixture.createAdmin();
-            Account validator = AccountFixture.createAdmin();
-            ContentPending pendingContent = new ContentPending(
-                    "{\"cityName\":\"서울\"}",
-                    ContentPendingStatus.PENDING,
-                    collector,
-                    null,
-                    "거절 사유",
-                    null
-            );
-            Content content = null;
+        @DisplayName("approve() 단위 테스트")
+        @Nested
+        class Approve {
 
-            // when
-            pendingContent.approve(validator, content);
+            @DisplayName("PENDING -> APPROVED 상태 변경 테스트")
+            @Test
+            void approve1() {
+                // given
+                Account collector = AccountFixture.createAdmin();
+                Account validator = AccountFixture.createAdmin();
+                ContentPending pendingContent = new ContentPending(
+                        "{\"cityName\":\"서울\"}",
+                        ContentPendingStatus.PENDING,
+                        collector,
+                        null,
+                        "거절 사유",
+                        null
+                );
+                Content content = null;
 
-            // then
-            assertThat(pendingContent.getStatus()).isEqualTo(ContentPendingStatus.APPROVED);
-            assertThat(pendingContent.getValidatorAccount()).isEqualTo(validator);
-            assertThat(pendingContent.getRejectReason()).isBlank();
+                // when
+                pendingContent.approve(validator, content);
+
+                // then
+                assertThat(pendingContent.getStatus()).isEqualTo(ContentPendingStatus.APPROVED);
+                assertThat(pendingContent.getValidatorAccount()).isEqualTo(validator);
+                assertThat(pendingContent.getRejectReason()).isBlank();
+            }
+
+            @DisplayName("APPROVED -> APPROVED 상태로 변경할 수 없다.")
+            @Test
+            void approve2() {
+                // given
+                Account collector = AccountFixture.createAdmin();
+                Account validator = AccountFixture.createAdmin();
+                ContentPending pendingContent = new ContentPending(
+                        "{\"cityName\":\"서울\"}",
+                        ContentPendingStatus.APPROVED,
+                        collector,
+                        null,
+                        "거절 사유",
+                        null
+                );
+                Content content = null;
+
+                // when & then
+                assertThatThrownBy(() -> pendingContent.approve(validator, content))
+                        .isInstanceOf(IllegalStateException.class);
+            }
         }
 
-        @DisplayName("PENDING -> REJECTED 상태 변경 테스트")
-        @Test
-        void reject() {
-            // given
-            Account collector = AccountFixture.createAdmin();
-            Account validator = AccountFixture.createAdmin();
-            ContentPending pendingContent = new ContentPending(
-                    "{\"cityName\":\"서울\"}",
-                    ContentPendingStatus.PENDING,
-                    collector,
-                    null,
-                    null,
-                    null
-            );
-            String rejectReason = "장소 하나가 빠졌어요";
 
-            // when
-            pendingContent.reject(validator, rejectReason);
+        @DisplayName("reject() 단위 테스트")
+        @Nested
+        class Reject {
 
-            // then
-            assertThat(pendingContent.getStatus()).isEqualTo(ContentPendingStatus.REJECTED);
-            assertThat(pendingContent.getValidatorAccount()).isEqualTo(validator);
-            assertThat(pendingContent.getRejectReason()).isEqualTo(rejectReason);
+            @DisplayName("PENDING -> REJECTED 상태 변경 테스트")
+            @Test
+            void reject1() {
+                // given
+                Account collector = AccountFixture.createAdmin();
+                Account validator = AccountFixture.createAdmin();
+                ContentPending pendingContent = new ContentPending(
+                        "{\"cityName\":\"서울\"}",
+                        ContentPendingStatus.PENDING,
+                        collector,
+                        null,
+                        null,
+                        null
+                );
+                String rejectReason = "장소 하나가 빠졌어요";
+
+                // when
+                pendingContent.reject(validator, rejectReason);
+
+                // then
+                assertThat(pendingContent.getStatus()).isEqualTo(ContentPendingStatus.REJECTED);
+                assertThat(pendingContent.getValidatorAccount()).isEqualTo(validator);
+                assertThat(pendingContent.getRejectReason()).isEqualTo(rejectReason);
+            }
+
+            @DisplayName("APPROVED -> REJECTED 상태로 변경할 수 없다")
+            @Test
+            void reject2() {
+                // given
+                Account collector = AccountFixture.createAdmin();
+                Account validator = AccountFixture.createAdmin();
+                ContentPending pendingContent = new ContentPending(
+                        "{\"cityName\":\"서울\"}",
+                        ContentPendingStatus.APPROVED,
+                        collector,
+                        null,
+                        null,
+                        null
+                );
+                String rejectReason = "장소 하나가 빠졌어요";
+
+                // when
+                assertThatThrownBy(() -> pendingContent.reject(validator, rejectReason))
+                        .isInstanceOf(IllegalStateException.class);
+            }
         }
 
         @DisplayName("ContentPending 생성 시 PENDING 상태로 초기화")

--- a/backend/turip-app/src/test/java/turip/content/domain/ContentPendingTest.java
+++ b/backend/turip-app/src/test/java/turip/content/domain/ContentPendingTest.java
@@ -96,14 +96,10 @@ class ContentPendingTest {
         @Test
         void createWithPendingStatus() {
             // given
-            Account collector = AccountFixture.createUser();
+            ContentPending pendingContent = new ContentPending(null, null, null, null, null);
 
-            // when
-            ContentPending pendingContent = ContentPendingFixture.createPending(collector);
-
-            // then
+            // when & then
             assertThat(pendingContent.getStatus()).isEqualTo(ContentPendingStatus.PENDING);
-            assertThat(pendingContent.getContentData().cityName()).isEqualTo("부산");
         }
     }
 }

--- a/backend/turip-app/src/test/java/turip/util/fixture/ContentPendingFixture.java
+++ b/backend/turip-app/src/test/java/turip/util/fixture/ContentPendingFixture.java
@@ -1,0 +1,81 @@
+package turip.util.fixture;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.test.util.ReflectionTestUtils;
+import turip.account.domain.Account;
+import turip.content.domain.Content;
+import turip.content.domain.ContentPending;
+import turip.content.domain.ContentPendingData;
+import turip.content.domain.ContentPendingData.ContentPlaceData;
+import turip.content.domain.ContentPendingData.PlaceData;
+import turip.content.domain.ContentPendingData.VideoData;
+import turip.content.domain.ContentPendingStatus;
+
+public class ContentPendingFixture {
+
+    public static ContentPendingData createTestContentData(String cityName) {
+        VideoData video = new VideoData(
+                "video123",
+                "테스트 비디오",
+                "https://youtube.com/watch?v=test",
+                "테스트 채널",
+                "https://example.com/channel.jpg",
+                LocalDate.of(2024, 1, 1)
+        );
+
+        PlaceData place = new PlaceData(
+                "테스트 장소",
+                "https://example.com/place",
+                "서울시 강남구",
+                37.5,
+                127.0,
+                "카페"
+        );
+
+        ContentPlaceData contentPlace = new ContentPlaceData(
+                1,
+                1,
+                "10:00",
+                place
+        );
+
+        return new ContentPendingData(cityName, video, List.of(contentPlace));
+    }
+
+    public static ContentPending createPending(Account collector) {
+        ContentPendingData contentData = createTestContentData("서울");
+        return new ContentPending(
+                contentData,
+                collector,
+                null,
+                null,
+                null
+        );
+    }
+
+    public static ContentPending createApproved(Account collector, Account validator, Content content) {
+        ContentPendingData contentData = createTestContentData("서울");
+        ContentPending pending = new ContentPending(
+                contentData,
+                collector,
+                null,
+                null,
+                null
+        );
+        ReflectionTestUtils.setField(pending, "status", ContentPendingStatus.APPROVED);
+        ReflectionTestUtils.setField(pending, "validatorAccount", validator);
+        ReflectionTestUtils.setField(pending, "content", content);
+        return pending;
+    }
+
+    public static ContentPending createPendingWithData(ContentPendingData contentData, Account collector) {
+        return new ContentPending(
+                contentData,
+                collector,
+                null,
+                null,
+                null
+        );
+    }
+}


### PR DESCRIPTION
## Issues
- closed #639 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description

[이번 PR 변경 내용](https://github.com/woowacourse-teams/2025-Turip/pull/640/changes/5e5395beb6def8a7522d6261d7efa03e64da78d9..13c5ab3affa53b0cee2c5f361949882760580a91)

- approve 하면 status를 APPROVED로 설정하고, 추가된 content의 id를 fk(content_id)로 설정하도록 했어요.
- 디코에서 언급했던 것처럼 city_id, creator_id를 컬럼으로 가질 필요가 없다고 생각해서 제외했습니다! (place, category도 이미 존재하는 데이터를 가져올 수 있고, 이 place, category들에 대한 연관관계에 대한 정합성을 confim시에 검증할거라면 creator, city도 confim시에 검증해도 상관없을 것이라는 의견이었습니당)

## 📷 Screenshot

## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 게스트 닉네임 생성 방식이 도입되어 일관된 형식(게스트_번호)으로 생성됩니다.
  * 콘텐츠 제출에 대한 승인 대기(검증/거절) 워크플로우가 추가되었습니다.
* **버그 픽스 / 동작 변경**
  * 이미 승인된 콘텐츠에 대한 재승인 시 명확한 예외가 발생하고 HTTP 400으로 응답됩니다.
* **데이터베이스 마이그레이션**
  * 기존 게스트 닉네임 일괄 정규화 및 승인 대기 테이블 추가 마이그레이션 포함.
* **테스트**
  * 관련 단위 테스트와 테스트 픽스처가 추가/수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->