### PR TITLE
[fix] MySQL에 적합하지 않은 커스텀 쿼리 메서드 수정

### DIFF
--- a/backend/turip-app/src/main/java/turip/favorite/repository/FavoriteFolderRepository.java
+++ b/backend/turip-app/src/main/java/turip/favorite/repository/FavoriteFolderRepository.java
@@ -34,22 +34,18 @@ public interface FavoriteFolderRepository extends JpaRepository<FavoriteFolder, 
     boolean existsCustomFolderByAccount(@Param("account") Account account);
 
     @Modifying
-    @Query("DELETE FROM FavoriteFolder ff " +
-            "WHERE ff.id IN (" +
-            "   SELECT ffa.favoriteFolder.id " +
-            "   FROM FavoriteFolderAccount ffa " +
-            "   WHERE ffa.account = :account " +
-            ") " +
-            "AND ff.isShared = false")
+    @Query(value = "DELETE ff FROM favorite_folder ff " +
+            "JOIN favorite_folder_account ffa ON ffa.favorite_folder_id = ff.id " +
+            "WHERE ffa.account_id = :#{#account.id} " +
+            "AND ff.is_shared = false",
+            nativeQuery = true)
     void deletePersonalFoldersByAccount(@Param("account") Account account);
 
     @Modifying
-    @Query("DELETE FROM FavoriteFolder ff " +
-            "WHERE ff.id = (" +
-            "   SELECT ffa.favoriteFolder.id " +
-            "   FROM FavoriteFolderAccount ffa " +
-            "   WHERE ffa.account = :account " +
-            "   AND ffa.favoriteFolder.isDefault = true" +
-            ")")
+    @Query(value = "DELETE ff FROM favorite_folder ff " +
+            "JOIN favorite_folder_account ffa ON ffa.favorite_folder_id = ff.id " +
+            "WHERE ffa.account_id = :#{#account.id} " +
+            "AND ff.is_default = true",
+            nativeQuery = true)
     void deleteDefaultFolderByAccount(@Param("account") Account account);
 }

--- a/backend/turip-app/src/test/java/turip/account/api/GuestApiTest.java
+++ b/backend/turip-app/src/test/java/turip/account/api/GuestApiTest.java
@@ -12,18 +12,16 @@ import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import turip.container.TestContainerConfig;
 import turip.favorite.domain.AccountRole;
 import turip.util.helper.TestDataHelper;
 
-@ActiveProfiles("test")
-@Import(TestContainerConfig.class)
+@ActiveProfiles("test-mysql")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class GuestApiTest {
+class GuestApiTest extends TestContainerConfig {
 
     @LocalServerPort
     private int port;

--- a/backend/turip-app/src/test/java/turip/account/api/GuestApiTest.java
+++ b/backend/turip-app/src/test/java/turip/account/api/GuestApiTest.java
@@ -8,15 +8,20 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
+import turip.container.TestContainerConfig;
 import turip.favorite.domain.AccountRole;
 import turip.util.helper.TestDataHelper;
 
 @ActiveProfiles("test")
+@Import(TestContainerConfig.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class GuestApiTest {
 
@@ -33,29 +38,21 @@ class GuestApiTest {
     void setUp() {
         RestAssured.port = port;
 
-        jdbcTemplate.update("DELETE FROM refresh_token");
-        jdbcTemplate.update("DELETE FROM favorite_content");
-        jdbcTemplate.update("DELETE FROM favorite_place");
-        jdbcTemplate.update("DELETE FROM favorite_folder");
-        jdbcTemplate.update("DELETE FROM member");
-        jdbcTemplate.update("DELETE FROM guest");
-        jdbcTemplate.update("DELETE FROM account");
-        jdbcTemplate.update("DELETE FROM content");
-        jdbcTemplate.update("DELETE FROM creator");
-        jdbcTemplate.update("DELETE FROM city");
-        jdbcTemplate.update("DELETE FROM country");
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0");
 
-        jdbcTemplate.update("ALTER TABLE refresh_token ALTER COLUMN id RESTART WITH 1");
-        jdbcTemplate.update("ALTER TABLE favorite_content ALTER COLUMN id RESTART WITH 1");
-        jdbcTemplate.update("ALTER TABLE favorite_place ALTER COLUMN id RESTART WITH 1");
-        jdbcTemplate.update("ALTER TABLE favorite_folder ALTER COLUMN id RESTART WITH 1");
-        jdbcTemplate.update("ALTER TABLE member ALTER COLUMN id RESTART WITH 1");
-        jdbcTemplate.update("ALTER TABLE guest ALTER COLUMN id RESTART WITH 1");
-        jdbcTemplate.update("ALTER TABLE account ALTER COLUMN id RESTART WITH 1");
-        jdbcTemplate.update("ALTER TABLE content ALTER COLUMN id RESTART WITH 1");
-        jdbcTemplate.update("ALTER TABLE creator ALTER COLUMN id RESTART WITH 1");
-        jdbcTemplate.update("ALTER TABLE city ALTER COLUMN id RESTART WITH 1");
-        jdbcTemplate.update("ALTER TABLE country ALTER COLUMN id RESTART WITH 1");
+        jdbcTemplate.update("TRUNCATE TABLE refresh_token");
+        jdbcTemplate.update("TRUNCATE TABLE favorite_content");
+        jdbcTemplate.update("TRUNCATE TABLE favorite_place");
+        jdbcTemplate.update("TRUNCATE TABLE favorite_folder");
+        jdbcTemplate.update("TRUNCATE TABLE member");
+        jdbcTemplate.update("TRUNCATE TABLE guest");
+        jdbcTemplate.update("TRUNCATE TABLE account");
+        jdbcTemplate.update("TRUNCATE TABLE content");
+        jdbcTemplate.update("TRUNCATE TABLE creator");
+        jdbcTemplate.update("TRUNCATE TABLE city");
+        jdbcTemplate.update("TRUNCATE TABLE country");
+
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1");
     }
 
     @Nested

--- a/backend/turip-app/src/test/java/turip/account/api/MemberApiTest.java
+++ b/backend/turip-app/src/test/java/turip/account/api/MemberApiTest.java
@@ -7,19 +7,24 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import turip.account.domain.Provider;
 import turip.account.domain.Role;
 import turip.auth.token.GoogleTokenParser;
+import turip.container.TestContainerConfig;
 import turip.favorite.domain.AccountRole;
 import turip.util.helper.TestDataHelper;
 
 @ActiveProfiles("test")
+@Import(TestContainerConfig.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class MemberApiTest {
 
@@ -39,33 +44,23 @@ class MemberApiTest {
     void setUp() {
         RestAssured.port = port;
 
-        jdbcTemplate.update("DELETE FROM refresh_token");
-        jdbcTemplate.update("DELETE FROM favorite_content");
-        jdbcTemplate.update("DELETE FROM favorite_place");
-        jdbcTemplate.update("DELETE FROM favorite_folder_account");
-        jdbcTemplate.update("DELETE FROM favorite_folder");
-        jdbcTemplate.update("DELETE FROM social_member");
-        jdbcTemplate.update("DELETE FROM member");
-        jdbcTemplate.update("DELETE FROM guest");
-        jdbcTemplate.update("DELETE FROM account");
-        jdbcTemplate.update("DELETE FROM content");
-        jdbcTemplate.update("DELETE FROM creator");
-        jdbcTemplate.update("DELETE FROM city");
-        jdbcTemplate.update("DELETE FROM country");
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0");
 
-        jdbcTemplate.update("ALTER TABLE refresh_token ALTER COLUMN id RESTART WITH 1");
-        jdbcTemplate.update("ALTER TABLE favorite_content ALTER COLUMN id RESTART WITH 1");
-        jdbcTemplate.update("ALTER TABLE favorite_place ALTER COLUMN id RESTART WITH 1");
-        jdbcTemplate.update("ALTER TABLE favorite_folder ALTER COLUMN id RESTART WITH 1");
-        jdbcTemplate.update("ALTER TABLE social_member ALTER COLUMN id RESTART WITH 1");
-        jdbcTemplate.update("ALTER TABLE member ALTER COLUMN id RESTART WITH 1");
-        jdbcTemplate.update("ALTER TABLE guest ALTER COLUMN id RESTART WITH 1");
-        jdbcTemplate.update("ALTER TABLE account ALTER COLUMN id RESTART WITH 1");
-        jdbcTemplate.update("ALTER TABLE favorite_folder_account ALTER COLUMN id RESTART WITH 1");
-        jdbcTemplate.update("ALTER TABLE content ALTER COLUMN id RESTART WITH 1");
-        jdbcTemplate.update("ALTER TABLE creator ALTER COLUMN id RESTART WITH 1");
-        jdbcTemplate.update("ALTER TABLE city ALTER COLUMN id RESTART WITH 1");
-        jdbcTemplate.update("ALTER TABLE country ALTER COLUMN id RESTART WITH 1");
+        jdbcTemplate.update("TRUNCATE TABLE refresh_token");
+        jdbcTemplate.update("TRUNCATE TABLE favorite_content");
+        jdbcTemplate.update("TRUNCATE TABLE favorite_place");
+        jdbcTemplate.update("TRUNCATE TABLE favorite_folder_account");
+        jdbcTemplate.update("TRUNCATE TABLE favorite_folder");
+        jdbcTemplate.update("TRUNCATE TABLE social_member");
+        jdbcTemplate.update("TRUNCATE TABLE member");
+        jdbcTemplate.update("TRUNCATE TABLE guest");
+        jdbcTemplate.update("TRUNCATE TABLE account");
+        jdbcTemplate.update("TRUNCATE TABLE content");
+        jdbcTemplate.update("TRUNCATE TABLE creator");
+        jdbcTemplate.update("TRUNCATE TABLE city");
+        jdbcTemplate.update("TRUNCATE TABLE country");
+
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1");
     }
 
     @Nested

--- a/backend/turip-app/src/test/java/turip/account/api/MemberApiTest.java
+++ b/backend/turip-app/src/test/java/turip/account/api/MemberApiTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -22,11 +21,10 @@ import turip.container.TestContainerConfig;
 import turip.favorite.domain.AccountRole;
 import turip.util.helper.TestDataHelper;
 
-@ActiveProfiles("test")
-@Import(TestContainerConfig.class)
+@ActiveProfiles("test-mysql")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class MemberApiTest {
+class MemberApiTest extends TestContainerConfig {
 
     @LocalServerPort
     private int port;

--- a/backend/turip-app/src/test/java/turip/account/repository/AccountInsertRepositoryTest.java
+++ b/backend/turip-app/src/test/java/turip/account/repository/AccountInsertRepositoryTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import turip.account.domain.Account;
@@ -17,10 +16,9 @@ import turip.account.domain.Role;
 import turip.container.TestContainerConfig;
 
 @SpringBootTest
-@ActiveProfiles("test")
-@Import(TestContainerConfig.class)
+@ActiveProfiles("test-mysql")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class AccountInsertRepositoryTest {
+class AccountInsertRepositoryTest extends TestContainerConfig {
 
     @Autowired
     private AccountInsertRepository accountInsertRepository;

--- a/backend/turip-app/src/test/java/turip/container/TestContainerConfig.java
+++ b/backend/turip-app/src/test/java/turip/container/TestContainerConfig.java
@@ -1,19 +1,30 @@
 package turip.container;
 
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
-@TestConfiguration
-public class TestContainerConfig {
+@Testcontainers
+public abstract class TestContainerConfig {
 
-    @Bean
-    @ServiceConnection
-    public MySQLContainer mySQLContainer() {
-        return new MySQLContainer("mysql:8.0.42")
-                .withUsername("root")
-                .withPassword("rootpwd")
-                .withDatabaseName("test_db");
+    static final MySQLContainer<?> MYSQL_CONTAINER =
+            new MySQLContainer<>("mysql:8.0.42")
+                    .withDatabaseName("test_db")
+                    .withUsername("root")
+                    .withPassword("rootpwd")
+                    .withReuse(true);
+
+    static {
+        MYSQL_CONTAINER.start();
+    }
+
+    @DynamicPropertySource
+    static void overrideProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL_CONTAINER::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL_CONTAINER::getUsername);
+        registry.add("spring.datasource.password", MYSQL_CONTAINER::getPassword);
+        registry.add("spring.datasource.driver-class-name",
+                MYSQL_CONTAINER::getDriverClassName);
     }
 }

--- a/backend/turip-app/src/test/java/turip/container/TestContainerConfig.java
+++ b/backend/turip-app/src/test/java/turip/container/TestContainerConfig.java
@@ -3,9 +3,7 @@ package turip.container;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Testcontainers
 public abstract class TestContainerConfig {
 
     static final MySQLContainer<?> MYSQL_CONTAINER =

--- a/backend/turip-app/src/test/java/turip/content/api/ContentKeywordApiTest.java
+++ b/backend/turip-app/src/test/java/turip/content/api/ContentKeywordApiTest.java
@@ -3,7 +3,6 @@ package turip.content.api;
 import static org.hamcrest.Matchers.is;
 
 import io.restassured.RestAssured;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -28,15 +27,6 @@ public class ContentKeywordApiTest extends TestContainerConfig {
 
     @LocalServerPort
     protected int port;
-
-    @BeforeAll
-    void setUp() {
-        // Fulltext index 생성
-        jdbcTemplate.execute("ALTER TABLE content ADD FULLTEXT INDEX idx_title (title) WITH PARSER ngram");
-        jdbcTemplate.execute(
-                "ALTER TABLE creator ADD FULLTEXT INDEX idx_channel_name (channel_name) WITH PARSER ngram");
-        jdbcTemplate.execute("ALTER TABLE place ADD FULLTEXT INDEX idx_name (name) WITH PARSER ngram");
-    }
 
     @BeforeEach
     void clear() {

--- a/backend/turip-app/src/test/java/turip/content/api/ContentKeywordApiTest.java
+++ b/backend/turip-app/src/test/java/turip/content/api/ContentKeywordApiTest.java
@@ -12,18 +12,16 @@ import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 import turip.container.TestContainerConfig;
 
-@ActiveProfiles("test")
-@Import(TestContainerConfig.class)
+@ActiveProfiles("test-mysql")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Transactional(propagation = org.springframework.transaction.annotation.Propagation.NOT_SUPPORTED)
-public class ContentKeywordApiTest {
+public class ContentKeywordApiTest extends TestContainerConfig {
 
     @Autowired
     private JdbcTemplate jdbcTemplate;

--- a/backend/turip-app/src/test/java/turip/content/repository/ContentRepositoryTest.java
+++ b/backend/turip-app/src/test/java/turip/content/repository/ContentRepositoryTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -49,14 +48,6 @@ class ContentRepositoryTest extends TestContainerConfig {
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
-
-    @BeforeAll
-    void setUp() {
-        jdbcTemplate.execute("ALTER TABLE content ADD FULLTEXT INDEX idx_title (title) WITH PARSER ngram");
-        jdbcTemplate.execute(
-                "ALTER TABLE creator ADD FULLTEXT INDEX idx_channel_name (channel_name) WITH PARSER ngram");
-        jdbcTemplate.execute("ALTER TABLE place ADD FULLTEXT INDEX idx_name (name) WITH PARSER ngram");
-    }
 
     @BeforeEach
     void clear() {

--- a/backend/turip-app/src/test/java/turip/content/repository/ContentRepositoryTest.java
+++ b/backend/turip-app/src/test/java/turip/content/repository/ContentRepositoryTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -32,10 +31,9 @@ import turip.region.repository.CityRepository;
 import turip.region.repository.CountryRepository;
 
 @DataJpaTest
-@ActiveProfiles("test")
-@Import(TestContainerConfig.class)
+@ActiveProfiles("test-mysql")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class ContentRepositoryTest {
+class ContentRepositoryTest extends TestContainerConfig {
 
     @Autowired
     private CreatorRepository creatorRepository;

--- a/backend/turip-app/src/test/java/turip/favorite/repository/FavoriteFolderRepositoryTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/repository/FavoriteFolderRepositoryTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import turip.account.domain.Account;
 import turip.account.repository.AccountRepository;
@@ -21,10 +20,9 @@ import turip.util.fixture.FavoriteFolderAccountFixture;
 import turip.util.fixture.FavoriteFolderFixture;
 
 @DataJpaTest
-@ActiveProfiles("test")
-@Import(TestContainerConfig.class)
+@ActiveProfiles("test-mysql")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class FavoriteFolderRepositoryTest {
+class FavoriteFolderRepositoryTest extends TestContainerConfig {
 
     @Autowired
     private FavoriteFolderRepository favoriteFolderRepository;

--- a/backend/turip-app/src/test/java/turip/favorite/repository/FavoriteFolderRepositoryTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/repository/FavoriteFolderRepositoryTest.java
@@ -6,11 +6,14 @@ import jakarta.persistence.EntityManager;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import turip.account.domain.Account;
 import turip.account.repository.AccountRepository;
+import turip.container.TestContainerConfig;
 import turip.favorite.domain.AccountRole;
 import turip.favorite.domain.FavoriteFolder;
 import turip.util.fixture.AccountFixture;
@@ -19,6 +22,8 @@ import turip.util.fixture.FavoriteFolderFixture;
 
 @DataJpaTest
 @ActiveProfiles("test")
+@Import(TestContainerConfig.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class FavoriteFolderRepositoryTest {
 
     @Autowired

--- a/backend/turip-app/src/test/resources/application-test-mysql.yml
+++ b/backend/turip-app/src/test/resources/application-test-mysql.yml
@@ -64,9 +64,3 @@ invitation:
 sse:
   heartbeat:
     interval: 2  # 2초
-
-# test container 로그 설정
-logging:
-  level:
-    org.testcontainers: DEBUG
-    com.github.dockerjava: DEBUG

--- a/backend/turip-app/src/test/resources/application-test-mysql.yml
+++ b/backend/turip-app/src/test/resources/application-test-mysql.yml
@@ -1,10 +1,12 @@
 spring:
   sql:
     init:
-      mode: never
+      mode: always
+      schema-locations: classpath:init-test-db.sql
       data-locations: [ ]
-
+      continue-on-error: false
   jpa:
+    defer-datasource-initialization: true
     hibernate:
       ddl-auto: create-drop
     properties:

--- a/backend/turip-app/src/test/resources/application-test-mysql.yml
+++ b/backend/turip-app/src/test/resources/application-test-mysql.yml
@@ -1,0 +1,70 @@
+spring:
+  sql:
+    init:
+      mode: never
+      data-locations: [ ]
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+
+  # 테스트 환경에서 Flyway 비활성화
+  flyway:
+    enabled: false
+
+# JWT 설정 (테스트용)
+jwt:
+  secret-key: turip-test-jwt-secret-key-for-testing-purposes-only-32bytes
+  access-token-expiration-ms: 3600000  # 1시간
+  refresh-token-expiration-ms: 604800000  # 7일
+
+# Google OAuth 설정 (테스트용)
+google:
+  client-id: test-google-client-id.apps.googleusercontent.com
+  api:
+    key: test-google-api-key
+    url: https://test.google.com
+
+kakao:
+  api:
+    key: test-kakao-api-key
+    url: https://test.kakao.com
+
+youtube:
+  api:
+    key: test-youtube-api-key
+    url: https://test.youtube.com
+
+# CSV Import 설정
+csv:
+  import:
+    password: test_password_123
+
+# Region Category 기타 이미지 설정 (테스트용 더미 값)
+region:
+  category:
+    domestic:
+      etc:
+        image-url: https://test.example.com/domestic-etc.jpg
+    overseas:
+      etc:
+        image-url: https://test.example.com/overseas-etc.jpg
+
+invitation:
+  jwt:
+    secret-key: turip-test-invitation-jwt-secret-key-for-testing-purposes
+    token-expiration: 1h
+
+# SSE 설정 (테스트용 - 빠른 하트비트)
+sse:
+  heartbeat:
+    interval: 2  # 2초
+
+# test container 로그 설정
+logging:
+  level:
+    org.testcontainers: DEBUG
+    com.github.dockerjava: DEBUG

--- a/backend/turip-app/src/test/resources/application-test.yml
+++ b/backend/turip-app/src/test/resources/application-test.yml
@@ -71,9 +71,3 @@ invitation:
 sse:
   heartbeat:
     interval: 2  # 2초
-
-# test container 로그 설정
-logging:
-  level:
-    org.testcontainers: DEBUG
-    com.github.dockerjava: DEBUG

--- a/backend/turip-app/src/test/resources/init-test-db.sql
+++ b/backend/turip-app/src/test/resources/init-test-db.sql
@@ -1,0 +1,4 @@
+-- 테스트 환경용 FTS 인덱스 생성
+ALTER TABLE content ADD FULLTEXT INDEX idx_title (title) WITH PARSER ngram;
+ALTER TABLE creator ADD FULLTEXT INDEX idx_channel_name (channel_name) WITH PARSER ngram;
+ALTER TABLE place ADD FULLTEXT INDEX idx_name (name) WITH PARSER ngram;

--- a/backend/turip-app/src/test/resources/testcontainers.properties
+++ b/backend/turip-app/src/test/resources/testcontainers.properties
@@ -1,0 +1,1 @@
+#testcontainers.reuse.enable=true

--- a/backend/turip-app/src/test/resources/testcontainers.properties
+++ b/backend/turip-app/src/test/resources/testcontainers.properties
@@ -1,1 +1,1 @@
-#testcontainers.reuse.enable=true
+testcontainers.reuse.enable=true


### PR DESCRIPTION
## Issues
- closed #654

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description

### 쿼리 수정

- MySQL에 적합하지 않은 커스텀 쿼리 메서드를 Native Query로 수정했습니다.
- Native Query를 사용하는 테스트를 MySQL Container 상에서 돌아가도록 수정했습니다.

### TestContainer 설정 수정
- 기존에는 Container를 빈으로 등록해서 사용했기 때문에, Spring Context가 새로 띄워지는 테스트(DataJpaTest, SpringBootTest)마다 컨테이너를 새로 띄우는 것을 반복했습니다. TestContainer를 사용하는 클래스가 늘어감에 따라 매 테스트 클래스(매 컨텍스트)마다 컨테이너를 띄우는 것은 불필요하다고 느꼈습니다!
- 따라서 컨테이너를 컨텍스트가 아닌 JVM단에서 한 번만 띄우기 위해, Bean이 아닌 전역(static)으로 등록 후, 필요한 테스트 클래스에서 이 설정을 extend해서 컨테이너를 활용하도록 했어요.

## 📷 Screenshot

## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * 테스트 인프라가 MySQL 기반으로 통합되어 일관된 컨테이너 기반 테스트 환경이 제공됩니다.
  * 테스트 클래스들이 공통 컨테이너 설정을 상속하도록 변경되어 환경 설정이 통합되었습니다.
  * 테스트 데이터 초기화가 더 빠른 방식으로 개선되었습니다.

* **Chores**
  * MySQL 전용 테스트 설정 파일 및 초기화 스크립트가 추가되었습니다.
  * Testcontainers 재사용이 활성화되어 테스트 실행 효율이 향상됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->