### PR TITLE
[fix] TransientObjectException 문제 해결

### DIFF
--- a/backend/turip-app/src/main/java/turip/account/service/AccountService.java
+++ b/backend/turip-app/src/main/java/turip/account/service/AccountService.java
@@ -13,16 +13,14 @@ import turip.common.exception.ErrorTag;
 import turip.common.exception.custom.InternalServerException;
 import turip.common.exception.custom.NotFoundException;
 import turip.favorite.repository.FavoriteContentRepository;
-import turip.favorite.repository.FavoriteFolderRepository;
 import turip.favorite.service.FavoriteFolderService;
 
 @Service
 @RequiredArgsConstructor
-public class AccountService { 
+public class AccountService {
 
     private final AccountRepository accountRepository;
     private final FavoriteContentRepository favoriteContentRepository;
-    private final FavoriteFolderRepository favoriteFolderRepository;
     private final FavoriteFolderService favoriteFolderService;
     private final AccountInsertRepository accountInsertRepository;
 
@@ -51,7 +49,7 @@ public class AccountService {
     @Transactional
     public void deleteAccountAndFavorites(Account account) {
         favoriteContentRepository.deleteByAccount(account);
-        favoriteFolderRepository.deletePersonalFoldersByAccount(account);
+        favoriteFolderService.deletePersonalFoldersByAccount(account);
         accountRepository.delete(account);
     }
 }

--- a/backend/turip-app/src/main/java/turip/account/service/GuestService.java
+++ b/backend/turip-app/src/main/java/turip/account/service/GuestService.java
@@ -1,5 +1,6 @@
 package turip.account.service;
 
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +23,7 @@ public class GuestService {
     private final FavoritePlaceService favoritePlaceService;
     private final FavoriteFolderService favoriteFolderService;
     private final GuestNicknameCreator guestNicknameCreator;
+    private final EntityManager entityManager;
 
     @Transactional
     public Guest findOrCreateByDeviceFid(String deviceFid) {
@@ -46,6 +48,7 @@ public class GuestService {
     @Transactional
     public void delete(Guest guest) {
         guestRepository.delete(guest);
+        entityManager.clear();
         accountService.deleteAccountAndFavorites(guest.getAccount());
     }
 }

--- a/backend/turip-app/src/main/java/turip/account/service/GuestService.java
+++ b/backend/turip-app/src/main/java/turip/account/service/GuestService.java
@@ -1,6 +1,5 @@
 package turip.account.service;
 
-import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +22,6 @@ public class GuestService {
     private final FavoritePlaceService favoritePlaceService;
     private final FavoriteFolderService favoriteFolderService;
     private final GuestNicknameCreator guestNicknameCreator;
-    private final EntityManager entityManager;
 
     @Transactional
     public Guest findOrCreateByDeviceFid(String deviceFid) {
@@ -48,7 +46,6 @@ public class GuestService {
     @Transactional
     public void delete(Guest guest) {
         guestRepository.delete(guest);
-        entityManager.clear();
         accountService.deleteAccountAndFavorites(guest.getAccount());
     }
 }

--- a/backend/turip-app/src/main/java/turip/account/service/MemberService.java
+++ b/backend/turip-app/src/main/java/turip/account/service/MemberService.java
@@ -16,6 +16,8 @@ import turip.common.exception.custom.NotFoundException;
 import turip.favorite.repository.FavoriteContentRepository;
 import turip.favorite.repository.FavoriteFolderAccountRepository;
 import turip.favorite.repository.FavoriteFolderRepository;
+import turip.favorite.service.FavoriteFolderAccountService;
+import turip.favorite.service.FavoriteFolderService;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +31,8 @@ public class MemberService {
     private final FavoriteFolderAccountRepository favoriteFolderAccountRepository;
     private final FavoriteFolderRepository favoriteFolderRepository;
     private final RandomNicknameCreator randomNicknameCreator;
+    private final FavoriteFolderService favoriteFolderService;
+    private final FavoriteFolderAccountService favoriteFolderAccountService;
 
     @Transactional
     public Member create(String email) {
@@ -72,7 +76,7 @@ public class MemberService {
     }
 
     private void migrateFavoriteFolders(Member member, Guest guest) {
-        favoriteFolderRepository.deleteDefaultFolderByAccount(member.getAccount());
-        favoriteFolderAccountRepository.updateAccount(guest.getAccount(), member.getAccount());
+        favoriteFolderService.deleteDefaultFolderByAccount(member.getAccount());
+        favoriteFolderAccountService.updateAccount(guest.getAccount(), member.getAccount());
     }
 }

--- a/backend/turip-app/src/main/java/turip/common/exception/ErrorTag.java
+++ b/backend/turip-app/src/main/java/turip/common/exception/ErrorTag.java
@@ -40,6 +40,7 @@ public enum ErrorTag {
     ACCOUNT_NOT_FOUND("계정을 찾을 수 없습니다."),
     CONTENT_NOT_FOUND("컨텐츠를 찾을 수 없습니다."),
     FAVORITE_FOLDER_NOT_FOUND("찜폴더를 찾을 수 없습니다."),
+    DEFAULT_FOLDER_NOT_FOUND("기본 찜폴더를 찾을 수 없습니다."),
     PLACE_NOT_FOUND("장소를 찾을 수 없습니다."),
     FAVORITE_PLACE_NOT_FOUND("찜한 장소를 찾을 수 없습니다."),
     CREATOR_NOT_FOUND("크리에이터를 찾을 수 없습니다."),

--- a/backend/turip-app/src/main/java/turip/favorite/repository/FavoriteFolderAccountRepository.java
+++ b/backend/turip-app/src/main/java/turip/favorite/repository/FavoriteFolderAccountRepository.java
@@ -15,6 +15,8 @@ import turip.favorite.repository.dto.FavoriteFolderItemCountResult;
 
 public interface FavoriteFolderAccountRepository extends JpaRepository<FavoriteFolderAccount, Long> {
 
+    List<FavoriteFolderAccount> findByAccount(Account account);
+
     int countByFavoriteFolder(FavoriteFolder favoriteFolder);
 
     @Query("""

--- a/backend/turip-app/src/main/java/turip/favorite/repository/FavoriteFolderRepository.java
+++ b/backend/turip-app/src/main/java/turip/favorite/repository/FavoriteFolderRepository.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import turip.account.domain.Account;
@@ -33,19 +32,13 @@ public interface FavoriteFolderRepository extends JpaRepository<FavoriteFolder, 
             "WHERE ffa.account = :account AND ff.isDefault = false")
     boolean existsCustomFolderByAccount(@Param("account") Account account);
 
-    @Modifying
-    @Query(value = "DELETE ff FROM favorite_folder ff " +
-            "JOIN favorite_folder_account ffa ON ffa.favorite_folder_id = ff.id " +
-            "WHERE ffa.account_id = :#{#account.id} " +
-            "AND ff.is_shared = false",
-            nativeQuery = true)
-    void deletePersonalFoldersByAccount(@Param("account") Account account);
+    @Query("SELECT ff FROM FavoriteFolder ff " +
+            "JOIN FavoriteFolderAccount ffa ON ffa.favoriteFolder = ff " +
+            "WHERE ffa.account = :account AND ff.isShared = false")
+    List<FavoriteFolder> findPersonalFoldersByAccount(@Param("account") Account account);
 
-    @Modifying
-    @Query(value = "DELETE ff FROM favorite_folder ff " +
-            "JOIN favorite_folder_account ffa ON ffa.favorite_folder_id = ff.id " +
-            "WHERE ffa.account_id = :#{#account.id} " +
-            "AND ff.is_default = true",
-            nativeQuery = true)
-    void deleteDefaultFolderByAccount(@Param("account") Account account);
+    @Query("SELECT ff FROM FavoriteFolder ff " +
+            "JOIN FavoriteFolderAccount ffa ON ffa.favoriteFolder = ff " +
+            "WHERE ffa.account = :account AND ff.isDefault = true")
+    Optional<FavoriteFolder> findDefaultFoldersByAccount(@Param("account") Account account);
 }

--- a/backend/turip-app/src/main/java/turip/favorite/service/FavoriteFolderAccountService.java
+++ b/backend/turip-app/src/main/java/turip/favorite/service/FavoriteFolderAccountService.java
@@ -77,6 +77,12 @@ public class FavoriteFolderAccountService {
     }
 
     @Transactional
+    public void updateAccount(Account oldAccount, Account newAccount) {
+        List<FavoriteFolderAccount> folders = favoriteFolderAccountRepository.findByAccount(oldAccount);
+        folders.forEach(folder -> folder.updateAccount(newAccount));
+    }
+
+    @Transactional
     public void deleteByFavoriteFolderAndAccount(FavoriteFolder favoriteFolder, Account account) {
         FavoriteFolderAccount favoriteFolderAccount = favoriteFolderAccountRepository.findByFavoriteFolderAndAccount(
                         favoriteFolder, account)

--- a/backend/turip-app/src/main/java/turip/favorite/service/FavoriteFolderService.java
+++ b/backend/turip-app/src/main/java/turip/favorite/service/FavoriteFolderService.java
@@ -223,8 +223,7 @@ public class FavoriteFolderService {
     public void deletePersonalFoldersByAccount(Account account) {
         List<FavoriteFolder> personalFolders = favoriteFolderRepository.findPersonalFoldersByAccount(account);
         for (FavoriteFolder personalFolder : personalFolders) {
-            favoriteFolderAccountService.deleteByFavoriteFolderAndAccount(personalFolder, account);
-            favoriteFolderRepository.delete(personalFolder);
+            deleteFavoriteFolderWithAssociations(account, personalFolder);
         }
     }
 
@@ -232,8 +231,7 @@ public class FavoriteFolderService {
     public void deleteDefaultFolderByAccount(Account account) {
         FavoriteFolder defaultFolder = favoriteFolderRepository.findDefaultFoldersByAccount(account)
                 .orElseThrow(() -> new NotFoundException(ErrorTag.DEFAULT_FOLDER_NOT_FOUND));
-        favoriteFolderAccountService.deleteByFavoriteFolderAndAccount(defaultFolder, account);
-        favoriteFolderRepository.delete(defaultFolder);
+        deleteFavoriteFolderWithAssociations(account, defaultFolder);
     }
 
     public void validateFolderExists(Long favoriteFolderId) {
@@ -288,5 +286,11 @@ public class FavoriteFolderService {
     private void removeFavoriteFolderWithFavoritePlaces(Long favoriteFolderId, FavoriteFolder favoriteFolder) {
         favoritePlaceRepository.deleteAllByFavoriteFolder(favoriteFolder);
         favoriteFolderRepository.deleteById(favoriteFolderId);
+    }
+
+    private void deleteFavoriteFolderWithAssociations(Account account, FavoriteFolder defaultFolder) {
+        favoritePlaceRepository.deleteAllByFavoriteFolder(defaultFolder);
+        favoriteFolderAccountService.deleteByFavoriteFolderAndAccount(defaultFolder, account);
+        favoriteFolderRepository.delete(defaultFolder);
     }
 }

--- a/backend/turip-app/src/main/java/turip/favorite/service/FavoriteFolderService.java
+++ b/backend/turip-app/src/main/java/turip/favorite/service/FavoriteFolderService.java
@@ -219,6 +219,23 @@ public class FavoriteFolderService {
         return FavoriteFolderExitResponse.of(false);
     }
 
+    @Transactional
+    public void deletePersonalFoldersByAccount(Account account) {
+        List<FavoriteFolder> personalFolders = favoriteFolderRepository.findPersonalFoldersByAccount(account);
+        for (FavoriteFolder personalFolder : personalFolders) {
+            favoriteFolderAccountService.deleteByFavoriteFolderAndAccount(personalFolder, account);
+            favoriteFolderRepository.delete(personalFolder);
+        }
+    }
+
+    @Transactional
+    public void deleteDefaultFolderByAccount(Account account) {
+        FavoriteFolder defaultFolder = favoriteFolderRepository.findDefaultFoldersByAccount(account)
+                .orElseThrow(() -> new NotFoundException(ErrorTag.DEFAULT_FOLDER_NOT_FOUND));
+        favoriteFolderAccountService.deleteByFavoriteFolderAndAccount(defaultFolder, account);
+        favoriteFolderRepository.delete(defaultFolder);
+    }
+
     public void validateFolderExists(Long favoriteFolderId) {
         if (!favoriteFolderRepository.existsById(favoriteFolderId)) {
             throw new NotFoundException(ErrorTag.FAVORITE_FOLDER_NOT_FOUND);

--- a/backend/turip-app/src/test/java/turip/account/service/AccountServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/account/service/AccountServiceTest.java
@@ -23,7 +23,6 @@ import turip.common.exception.ErrorTag;
 import turip.common.exception.custom.InternalServerException;
 import turip.common.exception.custom.NotFoundException;
 import turip.favorite.repository.FavoriteContentRepository;
-import turip.favorite.repository.FavoriteFolderRepository;
 import turip.favorite.service.FavoriteFolderService;
 import turip.util.fixture.AccountFixture;
 
@@ -41,9 +40,6 @@ class AccountServiceTest {
 
     @Mock
     private AccountInsertRepository accountInsertRepository;
-
-    @Mock
-    private FavoriteFolderRepository favoriteFolderRepository;
 
     @Mock
     private FavoriteFolderService favoriteFolderService;
@@ -137,7 +133,7 @@ class AccountServiceTest {
 
             // then
             verify(favoriteContentRepository).deleteByAccount(account);
-            verify(favoriteFolderRepository).deletePersonalFoldersByAccount(account);
+            verify(favoriteFolderService).deletePersonalFoldersByAccount(account);
             verify(accountRepository).delete(account);
         }
     }

--- a/backend/turip-app/src/test/java/turip/account/service/GuestServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/account/service/GuestServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import jakarta.persistence.EntityManager;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -43,6 +44,9 @@ class GuestServiceTest {
 
     @Mock
     private FavoriteFolderService favoriteFolderService;
+
+    @Mock
+    private EntityManager entityManager;
 
     @DisplayName("DeviceFid로 Guest 조회 또는 생성 테스트")
     @Nested

--- a/backend/turip-app/src/test/java/turip/account/service/MemberServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/account/service/MemberServiceTest.java
@@ -25,8 +25,8 @@ import turip.common.exception.ErrorTag;
 import turip.common.exception.custom.BadRequestException;
 import turip.favorite.domain.FavoriteContent;
 import turip.favorite.repository.FavoriteContentRepository;
-import turip.favorite.repository.FavoriteFolderAccountRepository;
-import turip.favorite.repository.FavoriteFolderRepository;
+import turip.favorite.service.FavoriteFolderAccountService;
+import turip.favorite.service.FavoriteFolderService;
 import turip.util.fixture.AccountFixture;
 import turip.util.fixture.GuestFixture;
 import turip.util.fixture.MemberFixture;
@@ -44,10 +44,10 @@ class MemberServiceTest {
     private FavoriteContentRepository favoriteContentRepository;
 
     @Mock
-    private FavoriteFolderAccountRepository favoriteFolderAccountRepository;
+    private FavoriteFolderService favoriteFolderService;
 
     @Mock
-    private FavoriteFolderRepository favoriteFolderRepository;
+    private FavoriteFolderAccountService favoriteFolderAccountService;
 
     @Mock
     private GuestService guestService;
@@ -120,8 +120,8 @@ class MemberServiceTest {
             memberService.migrate(member, guest);
 
             // then
-            verify(favoriteFolderRepository).deleteDefaultFolderByAccount(memberAccount);
-            verify(favoriteFolderAccountRepository).updateAccount(guestAccount, memberAccount);
+            verify(favoriteFolderService).deleteDefaultFolderByAccount(memberAccount);
+            verify(favoriteFolderAccountService).updateAccount(guestAccount, memberAccount);
         }
 
         @DisplayName("마이그레이션이 완료되면 Guest를 삭제한다")

--- a/backend/turip-app/src/test/java/turip/favorite/repository/FavoriteFolderRepositoryTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/repository/FavoriteFolderRepositoryTest.java
@@ -2,17 +2,15 @@ package turip.favorite.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import jakarta.persistence.EntityManager;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
 import turip.account.domain.Account;
 import turip.account.repository.AccountRepository;
-import turip.container.TestContainerConfig;
 import turip.favorite.domain.AccountRole;
 import turip.favorite.domain.FavoriteFolder;
 import turip.util.fixture.AccountFixture;
@@ -20,9 +18,8 @@ import turip.util.fixture.FavoriteFolderAccountFixture;
 import turip.util.fixture.FavoriteFolderFixture;
 
 @DataJpaTest
-@ActiveProfiles("test-mysql")
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class FavoriteFolderRepositoryTest extends TestContainerConfig {
+@ActiveProfiles("test")
+class FavoriteFolderRepositoryTest {
 
     @Autowired
     private FavoriteFolderRepository favoriteFolderRepository;
@@ -32,9 +29,6 @@ class FavoriteFolderRepositoryTest extends TestContainerConfig {
 
     @Autowired
     private AccountRepository accountRepository;
-
-    @Autowired
-    private EntityManager entityManager;
 
     @Test
     @DisplayName("계정의 모든 폴더를 조회한다")
@@ -123,59 +117,51 @@ class FavoriteFolderRepositoryTest extends TestContainerConfig {
     }
 
     @Test
-    @DisplayName("계정에 대한 폴더를 삭제할 때, 공유 폴더는 삭제하지 않는다")
-    void deletePersonalFoldersByAccount() {
+    @DisplayName("계정에 대한 개인 폴더들을 조회한다")
+    void findPersonalFoldersByAccount() {
         // given
-        Account account = accountRepository.save(AccountFixture.createEntity());
+        Account account1 = accountRepository.save(AccountFixture.createEntity());
 
-        // Personal folders (isShared = false)
-        FavoriteFolder personalFolder1 = favoriteFolderRepository.save(
-                FavoriteFolderFixture.createCustomFolder("개인 폴더1"));
-        FavoriteFolder personalFolder2 = favoriteFolderRepository.save(FavoriteFolderFixture.createDefaultFolder());
+        FavoriteFolder folder1 = favoriteFolderRepository.save(FavoriteFolderFixture.createDefaultFolder());
+        FavoriteFolder folder2 = favoriteFolderRepository.save(FavoriteFolderFixture.createSharedFolder("공유 폴더"));
+        FavoriteFolder folder3 = favoriteFolderRepository.save(FavoriteFolderFixture.createCustomFolder("개인 폴더"));
 
-        // Shared folder (isShared = true)
-        FavoriteFolder sharedFolder = favoriteFolderRepository.save(FavoriteFolderFixture.createCustomFolder("공유 폴더"));
-        sharedFolder.convertToSharedFolder();
-        favoriteFolderRepository.save(sharedFolder);
-
-        // 폴더와 계정 연결
         favoriteFolderAccountRepository.save(
-                FavoriteFolderAccountFixture.createFavoriteFolderAccount(personalFolder1, account, AccountRole.OWNER));
+                FavoriteFolderAccountFixture.createFavoriteFolderAccount(folder1, account1, AccountRole.OWNER));
         favoriteFolderAccountRepository.save(
-                FavoriteFolderAccountFixture.createFavoriteFolderAccount(personalFolder2, account, AccountRole.OWNER));
+                FavoriteFolderAccountFixture.createFavoriteFolderAccount(folder2, account1, AccountRole.OWNER));
         favoriteFolderAccountRepository.save(
-                FavoriteFolderAccountFixture.createFavoriteFolderAccount(sharedFolder, account, AccountRole.OWNER));
+                FavoriteFolderAccountFixture.createFavoriteFolderAccount(folder3, account1, AccountRole.OWNER));
 
         // when
-        favoriteFolderRepository.deletePersonalFoldersByAccount(account);
-        entityManager.flush();
-        entityManager.clear();
+        List<FavoriteFolder> personalFolders = favoriteFolderRepository.findPersonalFoldersByAccount(account1);
 
         // then
-        assertThat(favoriteFolderRepository.findById(personalFolder1.getId())).isEmpty();
-        assertThat(favoriteFolderRepository.findById(personalFolder2.getId())).isEmpty();
-        assertThat(favoriteFolderRepository.findById(sharedFolder.getId())).isPresent();
+        assertThat(personalFolders).hasSize(2);
+        assertThat(personalFolders).containsExactly(folder1, folder3);
     }
 
     @Test
-    @DisplayName("특정 계정의 기본 폴더를 삭제할 수 있다")
-    void deleteDefaultFoldersByAccount() {
+    @DisplayName("계정에 대한 기본 폴더를 조회한다")
+    void findDefaultFoldersByAccount() {
         // given
-        Account account = accountRepository.save(AccountFixture.createEntity());
+        Account account1 = accountRepository.save(AccountFixture.createEntity());
 
-        FavoriteFolder defaultFolder = favoriteFolderRepository.save(FavoriteFolderFixture.createDefaultFolder());
+        FavoriteFolder folder1 = favoriteFolderRepository.save(FavoriteFolderFixture.createDefaultFolder());
+        FavoriteFolder folder2 = favoriteFolderRepository.save(FavoriteFolderFixture.createSharedFolder("공유 폴더"));
+        FavoriteFolder folder3 = favoriteFolderRepository.save(FavoriteFolderFixture.createCustomFolder("개인 폴더"));
 
-        // 폴더와 계정 연결
         favoriteFolderAccountRepository.save(
-                FavoriteFolderAccountFixture.createFavoriteFolderAccount(defaultFolder, account, AccountRole.OWNER));
+                FavoriteFolderAccountFixture.createFavoriteFolderAccount(folder1, account1, AccountRole.OWNER));
+        favoriteFolderAccountRepository.save(
+                FavoriteFolderAccountFixture.createFavoriteFolderAccount(folder2, account1, AccountRole.OWNER));
+        favoriteFolderAccountRepository.save(
+                FavoriteFolderAccountFixture.createFavoriteFolderAccount(folder3, account1, AccountRole.OWNER));
 
         // when
-        favoriteFolderRepository.deleteDefaultFolderByAccount(account);
-        entityManager.flush();
-        entityManager.clear();
+        Optional<FavoriteFolder> defaultFolder = favoriteFolderRepository.findDefaultFoldersByAccount(account1);
 
         // then
-        assertThat(favoriteFolderRepository.findById(defaultFolder.getId())).isEmpty();
-        assertThat(favoriteFolderAccountRepository.findByFavoriteFolderAndAccount(defaultFolder, account)).isEmpty();
+        assertThat(defaultFolder.get()).isEqualTo(folder1);
     }
 }

--- a/backend/turip-app/src/test/java/turip/favorite/service/FavoriteFolderAccountServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/service/FavoriteFolderAccountServiceTest.java
@@ -1,0 +1,154 @@
+package turip.favorite.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import turip.account.domain.Account;
+import turip.common.exception.ErrorTag;
+import turip.common.exception.custom.ForbiddenException;
+import turip.common.exception.custom.NotFoundException;
+import turip.favorite.domain.AccountRole;
+import turip.favorite.domain.FavoriteFolder;
+import turip.favorite.domain.FavoriteFolderAccount;
+import turip.favorite.repository.FavoriteFolderAccountRepository;
+import turip.util.fixture.AccountFixture;
+import turip.util.fixture.FavoriteFolderAccountFixture;
+import turip.util.fixture.FavoriteFolderFixture;
+
+@ExtendWith(MockitoExtension.class)
+class FavoriteFolderAccountServiceTest {
+
+    @InjectMocks
+    private FavoriteFolderAccountService favoriteFolderAccountService;
+
+    @Mock
+    private FavoriteFolderAccountRepository favoriteFolderAccountRepository;
+
+    @DisplayName("폴더에 대한 OWNER인지 확인한다")
+    @Test
+    void validateOwnership1() {
+        // given
+        Account account = AccountFixture.createUser();
+        FavoriteFolder folder = FavoriteFolderFixture.createCustomFolder("옮길 폴더");
+
+        given(favoriteFolderAccountRepository.existsByFavoriteFolderAndAccountAndAccountRole(folder, account,
+                AccountRole.OWNER))
+                .willReturn(true);
+
+        // when & then
+        assertDoesNotThrow(() -> favoriteFolderAccountService.validateOwnership(account, folder));
+    }
+
+    @DisplayName("폴더에 대한 OWNER가 아닌 경우 예외가 발생한다")
+    @Test
+    void validateOwnership2() {
+        // given
+        Account account = AccountFixture.createUser();
+        FavoriteFolder folder = FavoriteFolderFixture.createCustomFolder("옮길 폴더");
+
+        given(favoriteFolderAccountRepository.existsByFavoriteFolderAndAccountAndAccountRole(folder, account,
+                AccountRole.OWNER))
+                .willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> favoriteFolderAccountService.validateOwnership(account, folder))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @DisplayName("폴더에 대한 OWNER 혹은 MEMBER인지 확인한다")
+    @Test
+    void validateMembership1() {
+        // given
+        Account account = AccountFixture.createUser();
+        FavoriteFolder folder = FavoriteFolderFixture.createCustomFolder("옮길 폴더");
+
+        given(favoriteFolderAccountRepository.existsByFavoriteFolderIdAndAccount(folder.getId(), account))
+                .willReturn(true);
+
+        // when & then
+        assertDoesNotThrow(() -> favoriteFolderAccountService.validateMembership(account, folder));
+    }
+
+    @DisplayName("폴더에 대한 OWNER 혹은 MEMBER가 아닌 경우 예외가 발생한다")
+    @Test
+    void validateMembership2() {
+        // given
+        Account account = AccountFixture.createUser();
+        FavoriteFolder folder = FavoriteFolderFixture.createCustomFolder("옮길 폴더");
+
+        given(favoriteFolderAccountRepository.existsByFavoriteFolderIdAndAccount(folder.getId(), account))
+                .willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> favoriteFolderAccountService.validateMembership(account, folder))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @DisplayName("FavoriteFolderAccount의 Account를 업데이트한다")
+    @Test
+    void updateAccount() {
+        // given
+        Account oldAccount = AccountFixture.createUser();
+        Account newAccount = AccountFixture.createUser();
+
+        FavoriteFolder folder = FavoriteFolderFixture.createCustomFolder("옮길 폴더");
+        FavoriteFolderAccount favoriteFolderAccount = FavoriteFolderAccountFixture.createFavoriteFolderAccount(folder,
+                oldAccount, AccountRole.OWNER);
+        given(favoriteFolderAccountRepository.findByAccount(oldAccount))
+                .willReturn(List.of(favoriteFolderAccount));
+
+        // when
+        favoriteFolderAccountService.updateAccount(oldAccount, newAccount);
+
+        // then
+        assertThat(favoriteFolderAccount.getAccount())
+                .isEqualTo(newAccount);
+    }
+
+    @DisplayName("account와 folder에 대한 FavoriteFolderAccount를 삭제한다")
+    @Test
+    void deleteByFavoriteFolderAndAccount1() {
+        // given
+        Account account = AccountFixture.createUser();
+
+        FavoriteFolder folder = FavoriteFolderFixture.createCustomFolder("옮길 폴더");
+        FavoriteFolderAccount favoriteFolderAccount = FavoriteFolderAccountFixture.createFavoriteFolderAccount(folder,
+                account, AccountRole.OWNER);
+        given(favoriteFolderAccountRepository.findByFavoriteFolderAndAccount(folder, account))
+                .willReturn(Optional.of(favoriteFolderAccount));
+
+        // when
+        favoriteFolderAccountService.deleteByFavoriteFolderAndAccount(folder, account);
+
+        // then
+        verify(favoriteFolderAccountRepository, times(1)).delete(favoriteFolderAccount);
+    }
+
+    @DisplayName("account와 folder에 대한 FavoriteFolderAccount를 찾을 수 없는 경우 예외가 발생한다")
+    @Test
+    void deleteByFavoriteFolderAndAccount2() {
+        // given
+        Account account = AccountFixture.createUser();
+
+        FavoriteFolder folder = FavoriteFolderFixture.createCustomFolder("옮길 폴더");
+        given(favoriteFolderAccountRepository.findByFavoriteFolderAndAccount(folder, account))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> favoriteFolderAccountService.deleteByFavoriteFolderAndAccount(folder, account))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ErrorTag.FAVORITE_FOLDER_ACCOUNT_NOT_FOUND.getMessage());
+    }
+}

--- a/backend/turip-app/src/test/java/turip/favorite/service/FavoriteFolderServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/service/FavoriteFolderServiceTest.java
@@ -826,6 +826,86 @@ class FavoriteFolderServiceTest {
         }
     }
 
+    @DisplayName("개인 폴더 삭제 테스트")
+    @Nested
+    class DeletePersonalFoldersByAccount {
+
+        @DisplayName("개인 폴더들을 삭제할 수 있다")
+        @Test
+        void deletePersonalFoldersByAccount() {
+            // given
+            Long accountId = 1L;
+            Long folderId1 = 1L;
+            Long folderId2 = 2L;
+
+            Account account = AccountFixture.createCustomAccount(accountId, Role.USER);
+            FavoriteFolder personalFolder1 = FavoriteFolderFixture.createCustomFolderWithId(folderId1, "개인 폴더 1");
+            FavoriteFolder personalFolder2 = FavoriteFolderFixture.createCustomFolderWithId(folderId2, "개인 폴더 2");
+
+            given(favoriteFolderRepository.findPersonalFoldersByAccount(account))
+                    .willReturn(List.of(personalFolder1, personalFolder2));
+
+            // when
+            favoriteFolderService.deletePersonalFoldersByAccount(account);
+
+            // then
+            assertAll(
+                    () -> verify(favoriteFolderAccountService).deleteByFavoriteFolderAndAccount(personalFolder1,
+                            account),
+                    () -> verify(favoriteFolderAccountService).deleteByFavoriteFolderAndAccount(personalFolder2,
+                            account),
+                    () -> verify(favoriteFolderRepository).delete(personalFolder1),
+                    () -> verify(favoriteFolderRepository).delete(personalFolder2)
+            );
+        }
+    }
+
+    @DisplayName("기본 폴더 삭제 테스트")
+    @Nested
+    class DeleteDefaultFolderByAccount {
+
+        @DisplayName("계정 삭제 혹은 마이그레이션을 위해 기본 폴더를 삭제할 수 있다")
+        @Test
+        void deleteDefaultFolderByAccount1() {
+            // given
+            Long accountId = 1L;
+            Long folderId = 1L;
+
+            Account account = AccountFixture.createCustomAccount(accountId, Role.USER);
+            FavoriteFolder defaultFolder = FavoriteFolderFixture.createDefaultFolderWithId(folderId);
+
+            given(favoriteFolderRepository.findDefaultFoldersByAccount(account))
+                    .willReturn(Optional.of(defaultFolder));
+
+            // when
+            favoriteFolderService.deleteDefaultFolderByAccount(account);
+
+            // then
+            assertAll(
+                    () -> verify(favoriteFolderAccountService).deleteByFavoriteFolderAndAccount(defaultFolder,
+                            account),
+                    () -> verify(favoriteFolderRepository).delete(defaultFolder)
+            );
+        }
+
+        @DisplayName("기본 폴더를 찾을 수 없는 경우 예외가 발생한다")
+        @Test
+        void deleteDefaultFolderByAccount2() {
+            // given
+            Long accountId = 1L;
+
+            Account account = AccountFixture.createCustomAccount(accountId, Role.USER);
+
+            given(favoriteFolderRepository.findDefaultFoldersByAccount(account))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> favoriteFolderService.deleteDefaultFolderByAccount(account))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage(ErrorTag.DEFAULT_FOLDER_NOT_FOUND.getMessage());
+        }
+    }
+
     @DisplayName("공유 폴더 초대 토큰 생성 테스트")
     @Nested
     class CreateInvitationCode {

--- a/backend/turip-app/src/test/java/turip/favorite/service/FavoriteFolderServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/service/FavoriteFolderServiceTest.java
@@ -850,6 +850,8 @@ class FavoriteFolderServiceTest {
 
             // then
             assertAll(
+                    () -> verify(favoritePlaceRepository).deleteAllByFavoriteFolder(personalFolder1),
+                    () -> verify(favoritePlaceRepository).deleteAllByFavoriteFolder(personalFolder2),
                     () -> verify(favoriteFolderAccountService).deleteByFavoriteFolderAndAccount(personalFolder1,
                             account),
                     () -> verify(favoriteFolderAccountService).deleteByFavoriteFolderAndAccount(personalFolder2,
@@ -882,6 +884,7 @@ class FavoriteFolderServiceTest {
 
             // then
             assertAll(
+                    () -> verify(favoritePlaceRepository).deleteAllByFavoriteFolder(defaultFolder),
                     () -> verify(favoriteFolderAccountService).deleteByFavoriteFolderAndAccount(defaultFolder,
                             account),
                     () -> verify(favoriteFolderRepository).delete(defaultFolder)


### PR DESCRIPTION
## Issues
- closed #661 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description

### 📍 문제 상황

- 마이그레이션 API, 게스트 탈퇴 API에서 `500 Internal Server Error` 발생

```json
{"timestamp":"2026-04-06 22:57:20.037","level":"ERROR","message":"org.hibernate.TransientObjectException: persistent instance references an unsaved transient instance of 'turip.account.domain.Account' (save the transient instance before flushing)" ...
```

- `TransientObjectException`이 발생

### 📍 문제 원인
- 두 API에서 문제가 되는 부분은, **Guest를 삭제하는 부분**
    - Guest 삭제 과정
    
    ```java
    // GuestService
    @Transactional
    public void delete(Guest guest) {
        guestRepository.delete(guest); // Guest 삭제
        accountService.deleteAccountAndFavorites(guest.getAccount());
    }
    
    // AccountService
    @Transactional
    public void deleteAccountAndFavorites(Account account) {
        favoriteContentRepository.deleteByAccount(account); // Account에 대한 콘텐츠찜 삭제
        favoriteFolderRepository.deletePersonalFoldersByAccount(account); // Account에 대한 찜폴더 삭제
        accountRepository.delete(account); // 여기서 에러 발생함
    }
    ```
    
- Account 삭제 쿼리를 날려야 하는데, **Account 엔티티를 참조하는 엔티티 중 `REMOVED`가 아닌 `MANAGED`(영속 상태)인 엔티티가 존재해서 Account를 삭제할 수 없는 상태**
    - `FavoriteFolder`, `FavoriteFolderAccount` 등을`@Modifying` (JPQL / native query)로 삭제 or 수정
    - `@Modifying`, native query를 사용하면 **영속성 컨텍스트를 bypass**하기 때문에, 삭제된 상태 등을 영속성 컨텍스트에 업데이트 해주지 않는다.

### 📍 해결 방법
- 영속성 컨텍스트와 DB 상태를 항상 맞추기 위해, `@Modifying` 쿼리를 사용하지 않고 JPA 메서드를 활용하도록 수정
 

## 📷 Screenshot

## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 기본 찜폴더가 없을 때 명확한 404 오류 메시지 제공

* **개선사항**
  * 계정 삭제 시 개인 찜폴더 및 연관 항목 삭제 흐름 안정화
  * 회원 마이그레이션 시 찜폴더 소유권 및 연관 데이터 이전 신뢰성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->  *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   *   * 