### PR TITLE
[feat] 회원 탈퇴 시 혼자 남은 공유 폴더 제거하도록 수정

### DIFF
--- a/backend/turip-app/src/main/java/turip/account/service/AccountService.java
+++ b/backend/turip-app/src/main/java/turip/account/service/AccountService.java
@@ -49,7 +49,7 @@ public class AccountService {
     @Transactional
     public void deleteAccountAndFavorites(Account account) {
         favoriteContentRepository.deleteByAccount(account);
-        favoriteFolderService.deletePersonalFoldersByAccount(account);
+        favoriteFolderService.deleteAloneFoldersByAccount(account);
         accountRepository.delete(account);
     }
 }

--- a/backend/turip-app/src/main/java/turip/favorite/repository/FavoriteFolderRepository.java
+++ b/backend/turip-app/src/main/java/turip/favorite/repository/FavoriteFolderRepository.java
@@ -34,8 +34,9 @@ public interface FavoriteFolderRepository extends JpaRepository<FavoriteFolder, 
 
     @Query("SELECT ff FROM FavoriteFolder ff " +
             "JOIN FavoriteFolderAccount ffa ON ffa.favoriteFolder = ff " +
-            "WHERE ffa.account = :account AND ff.isShared = false")
-    List<FavoriteFolder> findPersonalFoldersByAccount(@Param("account") Account account);
+            "WHERE ffa.account = :account " +
+            "AND (SELECT COUNT(ffa2) FROM FavoriteFolderAccount ffa2 WHERE ffa2.favoriteFolder = ff) = 1")
+    List<FavoriteFolder> findAloneFoldersByAccount(@Param("account") Account account);
 
     @Query("SELECT ff FROM FavoriteFolder ff " +
             "JOIN FavoriteFolderAccount ffa ON ffa.favoriteFolder = ff " +

--- a/backend/turip-app/src/main/java/turip/favorite/service/FavoriteFolderService.java
+++ b/backend/turip-app/src/main/java/turip/favorite/service/FavoriteFolderService.java
@@ -220,9 +220,9 @@ public class FavoriteFolderService {
     }
 
     @Transactional
-    public void deletePersonalFoldersByAccount(Account account) {
-        List<FavoriteFolder> personalFolders = favoriteFolderRepository.findPersonalFoldersByAccount(account);
-        for (FavoriteFolder personalFolder : personalFolders) {
+    public void deleteAloneFoldersByAccount(Account account) {
+        List<FavoriteFolder> aloneFolders = favoriteFolderRepository.findAloneFoldersByAccount(account);
+        for (FavoriteFolder personalFolder : aloneFolders) {
             deleteFavoriteFolderWithAssociations(account, personalFolder);
         }
     }

--- a/backend/turip-app/src/test/java/turip/account/service/AccountServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/account/service/AccountServiceTest.java
@@ -133,7 +133,7 @@ class AccountServiceTest {
 
             // then
             verify(favoriteContentRepository).deleteByAccount(account);
-            verify(favoriteFolderService).deletePersonalFoldersByAccount(account);
+            verify(favoriteFolderService).deleteAloneFoldersByAccount(account);
             verify(accountRepository).delete(account);
         }
     }

--- a/backend/turip-app/src/test/java/turip/favorite/repository/FavoriteFolderRepositoryTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/repository/FavoriteFolderRepositoryTest.java
@@ -117,10 +117,11 @@ class FavoriteFolderRepositoryTest {
     }
 
     @Test
-    @DisplayName("계정에 대한 개인 폴더들을 조회한다")
-    void findPersonalFoldersByAccount() {
+    @DisplayName("계정에 대해 혼자 참여중인 폴더들을 조회한다")
+    void findAloneFoldersByAccount() {
         // given
         Account account1 = accountRepository.save(AccountFixture.createEntity());
+        Account account2 = accountRepository.save(AccountFixture.createEntity());
 
         FavoriteFolder folder1 = favoriteFolderRepository.save(FavoriteFolderFixture.createDefaultFolder());
         FavoriteFolder folder2 = favoriteFolderRepository.save(FavoriteFolderFixture.createSharedFolder("공유 폴더"));
@@ -131,10 +132,12 @@ class FavoriteFolderRepositoryTest {
         favoriteFolderAccountRepository.save(
                 FavoriteFolderAccountFixture.createFavoriteFolderAccount(folder2, account1, AccountRole.OWNER));
         favoriteFolderAccountRepository.save(
+                FavoriteFolderAccountFixture.createFavoriteFolderAccount(folder2, account2, AccountRole.MEMBER));
+        favoriteFolderAccountRepository.save(
                 FavoriteFolderAccountFixture.createFavoriteFolderAccount(folder3, account1, AccountRole.OWNER));
 
         // when
-        List<FavoriteFolder> personalFolders = favoriteFolderRepository.findPersonalFoldersByAccount(account1);
+        List<FavoriteFolder> personalFolders = favoriteFolderRepository.findAloneFoldersByAccount(account1);
 
         // then
         assertThat(personalFolders).hasSize(2);

--- a/backend/turip-app/src/test/java/turip/favorite/service/FavoriteFolderServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/service/FavoriteFolderServiceTest.java
@@ -842,11 +842,11 @@ class FavoriteFolderServiceTest {
             FavoriteFolder personalFolder1 = FavoriteFolderFixture.createCustomFolderWithId(folderId1, "개인 폴더 1");
             FavoriteFolder personalFolder2 = FavoriteFolderFixture.createCustomFolderWithId(folderId2, "개인 폴더 2");
 
-            given(favoriteFolderRepository.findPersonalFoldersByAccount(account))
+            given(favoriteFolderRepository.findAloneFoldersByAccount(account))
                     .willReturn(List.of(personalFolder1, personalFolder2));
 
             // when
-            favoriteFolderService.deletePersonalFoldersByAccount(account);
+            favoriteFolderService.deleteAloneFoldersByAccount(account);
 
             // then
             assertAll(


### PR DESCRIPTION
## Issues
- closed #669 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
기존에는 Account 삭제(게스트 탈퇴, 회원 탈퇴 등)개인 폴더만 삭제하도록 했는데, 공유 폴더여도 혼자 남은 경우 삭제하도록 하여 유령 폴더를 남기지 않도록 했습니다!

## 📷 Screenshot

## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 계정 삭제 시 즐겨찾기 폴더 정리 로직을 개선했습니다. 이제 오직 한 계정만 참여하는 폴더를 더욱 정확하게 식별하여 삭제합니다.

* **Tests**
  * 즐겨찾기 폴더 관리 관련 테스트를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->