### PR TITLE
[feat] 어드민 콘텐츠 검수 기능 추가

### DIFF
--- a/backend/turip-admin/build.gradle
+++ b/backend/turip-admin/build.gradle
@@ -4,4 +4,8 @@ dependencies {
     implementation 'org.json:json:20231013'
 
     testImplementation project(':turip-app').sourceSets.test.output
+    testImplementation "org.springframework.boot:spring-boot-testcontainers"
+    testImplementation "org.testcontainers:testcontainers-junit-jupiter:2.0.2"
+    testImplementation "org.testcontainers:testcontainers:2.0.2"
+    testImplementation "org.testcontainers:testcontainers-mysql:2.0.2"
 }

--- a/backend/turip-admin/src/main/java/turip/controller/AdminContentController.java
+++ b/backend/turip-admin/src/main/java/turip/controller/AdminContentController.java
@@ -11,9 +11,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import turip.account.domain.Member;
-import turip.auth.resolver.AuthMember;
 import turip.controller.dto.request.AdminContentSaveRequest;
 import turip.controller.dto.response.MyCollectContentResponse;
+import turip.resolver.AuthAdmin;
 import turip.service.AdminContentPendingService;
 import turip.service.AdminContentService;
 
@@ -27,7 +27,7 @@ public class AdminContentController {
     private final AdminContentPendingService adminContentPendingService;
 
     @PostMapping
-    public ResponseEntity<Long> save(@AuthMember Member member, @RequestBody AdminContentSaveRequest request) {
+    public ResponseEntity<Long> save(@AuthAdmin Member member, @RequestBody AdminContentSaveRequest request) {
         Long contentId = adminContentService.save(request);
         log.info("[콘텐츠 수집] nickname: {}", member.getAccount().getNickname());
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -35,7 +35,7 @@ public class AdminContentController {
     }
 
     @GetMapping("/my")
-    public ResponseEntity<List<MyCollectContentResponse>> getMyHistory(@AuthMember Member member) {
+    public ResponseEntity<List<MyCollectContentResponse>> getMyHistory(@AuthAdmin Member member) {
         return ResponseEntity.ok(adminContentPendingService.getMyHistory(member.getAccount()));
     }
 }

--- a/backend/turip-admin/src/main/java/turip/controller/AdminContentController.java
+++ b/backend/turip-admin/src/main/java/turip/controller/AdminContentController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import turip.account.domain.Member;
+import turip.account.domain.TuripMember;
 import turip.controller.dto.request.AdminContentSaveRequest;
 import turip.controller.dto.response.MyCollectContentResponse;
 import turip.resolver.AuthAdmin;
@@ -27,15 +27,15 @@ public class AdminContentController {
     private final AdminContentPendingService adminContentPendingService;
 
     @PostMapping
-    public ResponseEntity<Long> save(@AuthAdmin Member member, @RequestBody AdminContentSaveRequest request) {
+    public ResponseEntity<Long> save(@AuthAdmin TuripMember admin, @RequestBody AdminContentSaveRequest request) {
         Long contentId = adminContentService.save(request);
-        log.info("[콘텐츠 수집] nickname: {}", member.getAccount().getNickname());
+        log.info("[콘텐츠 수집] nickname: {}", admin.getMember().getAccount().getNickname());
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(contentId);
     }
 
     @GetMapping("/my")
-    public ResponseEntity<List<MyCollectContentResponse>> getMyHistory(@AuthAdmin Member member) {
-        return ResponseEntity.ok(adminContentPendingService.getMyHistory(member.getAccount()));
+    public ResponseEntity<List<MyCollectContentResponse>> getMyHistory(@AuthAdmin TuripMember admin) {
+        return ResponseEntity.ok(adminContentPendingService.getMyHistory(admin.getMember().getAccount()));
     }
 }

--- a/backend/turip-admin/src/main/java/turip/controller/AdminContentController.java
+++ b/backend/turip-admin/src/main/java/turip/controller/AdminContentController.java
@@ -1,9 +1,11 @@
 package turip.controller;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +13,8 @@ import org.springframework.web.bind.annotation.RestController;
 import turip.account.domain.Member;
 import turip.auth.resolver.AuthMember;
 import turip.controller.dto.request.AdminContentSaveRequest;
+import turip.controller.dto.response.MyCollectContentResponse;
+import turip.service.AdminContentPendingService;
 import turip.service.AdminContentService;
 
 @Slf4j
@@ -20,6 +24,7 @@ import turip.service.AdminContentService;
 public class AdminContentController {
 
     private final AdminContentService adminContentService;
+    private final AdminContentPendingService adminContentPendingService;
 
     @PostMapping
     public ResponseEntity<Long> save(@AuthMember Member member, @RequestBody AdminContentSaveRequest request) {
@@ -27,5 +32,10 @@ public class AdminContentController {
         log.info("[콘텐츠 수집] nickname: {}", member.getAccount().getNickname());
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(contentId);
+    }
+
+    @GetMapping("/my")
+    public ResponseEntity<List<MyCollectContentResponse>> getMyHistory(@AuthMember Member member) {
+        return ResponseEntity.ok(adminContentPendingService.getMyHistory(member.getAccount()));
     }
 }

--- a/backend/turip-admin/src/main/java/turip/controller/AdminPendingContentController.java
+++ b/backend/turip-admin/src/main/java/turip/controller/AdminPendingContentController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import turip.account.domain.Member;
 import turip.account.domain.TuripMember;
-import turip.auth.resolver.AuthMember;
 import turip.content.domain.ContentPendingData;
 import turip.controller.dto.request.ContentPendingRejectRequest;
 import turip.controller.dto.response.ContentPendingApprovalResponse;
@@ -48,7 +47,7 @@ public class AdminPendingContentController {
 
     @PostMapping
     public ResponseEntity<Long> pending(
-            @AuthMember Member member,
+            @AuthAdmin Member member,
             @RequestBody ContentPendingData contentData
     ) {
         Long pendingId = adminContentPendingService.pending(member.getAccount(), contentData);

--- a/backend/turip-admin/src/main/java/turip/controller/AdminPendingContentController.java
+++ b/backend/turip-admin/src/main/java/turip/controller/AdminPendingContentController.java
@@ -1,7 +1,9 @@
 package turip.controller;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -9,11 +11,15 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import turip.account.domain.Member;
 import turip.account.domain.TuripMember;
+import turip.auth.resolver.AuthMember;
+import turip.content.domain.ContentPendingData;
 import turip.controller.dto.request.ContentPendingRejectRequest;
 import turip.controller.dto.response.ContentPendingApprovalResponse;
 import turip.controller.dto.response.ContentPendingRejectResponse;
 import turip.controller.dto.response.ContentPendingResponse;
+import turip.controller.dto.response.PendingListResponse;
 import turip.resolver.AuthAdmin;
 import turip.service.AdminContentPendingService;
 
@@ -26,6 +32,11 @@ public class AdminPendingContentController {
 
     private final AdminContentPendingService adminContentPendingService;
 
+    @GetMapping("/list")
+    public ResponseEntity<List<PendingListResponse>> findAll(@AuthAdmin TuripMember admin) {
+        return ResponseEntity.ok(adminContentPendingService.findAll());
+    }
+
     @GetMapping("/{id}")
     public ResponseEntity<ContentPendingResponse> findById(
             @AuthAdmin TuripMember admin,
@@ -33,6 +44,15 @@ public class AdminPendingContentController {
     ) {
         ContentPendingResponse response = adminContentPendingService.findById(id);
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping
+    public ResponseEntity<Long> pending(
+            @AuthMember Member member,
+            @RequestBody ContentPendingData contentData
+    ) {
+        Long pendingId = adminContentPendingService.pending(member.getAccount(), contentData);
+        return ResponseEntity.status(HttpStatus.CREATED).body(pendingId);
     }
 
     @PostMapping("/{id}/approve")
@@ -44,7 +64,6 @@ public class AdminPendingContentController {
                 admin.getMember().getAccount());
         return ResponseEntity.ok(response);
     }
-
 
     @PostMapping("/{id}/reject")
     public ResponseEntity<ContentPendingRejectResponse> reject(

--- a/backend/turip-admin/src/main/java/turip/controller/AdminPendingContentController.java
+++ b/backend/turip-admin/src/main/java/turip/controller/AdminPendingContentController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import turip.account.domain.Member;
 import turip.account.domain.TuripMember;
 import turip.content.domain.ContentPendingData;
 import turip.controller.dto.request.ContentPendingRejectRequest;
@@ -47,10 +46,10 @@ public class AdminPendingContentController {
 
     @PostMapping
     public ResponseEntity<Long> pending(
-            @AuthAdmin Member member,
+            @AuthAdmin TuripMember admin,
             @RequestBody ContentPendingData contentData
     ) {
-        Long pendingId = adminContentPendingService.pending(member.getAccount(), contentData);
+        Long pendingId = adminContentPendingService.pending(admin.getMember().getAccount(), contentData);
         return ResponseEntity.status(HttpStatus.CREATED).body(pendingId);
     }
 

--- a/backend/turip-admin/src/main/java/turip/controller/AdminViewController.java
+++ b/backend/turip-admin/src/main/java/turip/controller/AdminViewController.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import turip.account.domain.TuripMember;
 import turip.resolver.AuthAdmin;
@@ -36,7 +37,8 @@ public class AdminViewController {
     }
 
     @GetMapping("/home")
-    public String homePage(@AuthAdmin TuripMember admin) {
+    public String homePage(@AuthAdmin TuripMember admin, Model model) {
+        model.addAttribute("admin", admin);
         return "admin/home";
     }
 
@@ -45,5 +47,22 @@ public class AdminViewController {
         model.addAttribute("googleApiKey", googleApiKey);
         model.addAttribute("youtubeApiKey", youtubeApiKey);
         return "admin/content";
+    }
+
+    @GetMapping("/contents/pending")
+    public String pendingListPage(@AuthAdmin TuripMember admin) {
+        return "admin/pending-list";
+    }
+
+    @GetMapping("/contents/pending/{id}")
+    public String pendingReviewPage(@AuthAdmin TuripMember admin, @PathVariable Long id, Model model) {
+        model.addAttribute("pendingId", id);
+        return "admin/pending-review";
+    }
+
+    @GetMapping("/my")
+    public String myPage(@AuthAdmin TuripMember admin, Model model) {
+        model.addAttribute("admin", admin);
+        return "admin/my";
     }
 }

--- a/backend/turip-admin/src/main/java/turip/controller/dto/response/ContentPendingApprovalResponse.java
+++ b/backend/turip-admin/src/main/java/turip/controller/dto/response/ContentPendingApprovalResponse.java
@@ -1,7 +1,14 @@
 package turip.controller.dto.response;
 
+import turip.content.domain.Content;
+import turip.content.domain.ContentPending;
+
 public record ContentPendingApprovalResponse(
         Long contentId,
         Long contentPendingId
 ) {
+
+    public static ContentPendingApprovalResponse of(Content content, ContentPending contentPending) {
+        return new ContentPendingApprovalResponse(content.getId(), contentPending.getId());
+    }
 }

--- a/backend/turip-admin/src/main/java/turip/controller/dto/response/MyCollectContentResponse.java
+++ b/backend/turip-admin/src/main/java/turip/controller/dto/response/MyCollectContentResponse.java
@@ -1,0 +1,13 @@
+package turip.controller.dto.response;
+
+import java.time.LocalDateTime;
+
+public record MyCollectContentResponse(
+        Long id,
+        String videoTitle,
+        String cityName,
+        String status,
+        String rejectReason,
+        LocalDateTime createdAt
+) {
+}

--- a/backend/turip-admin/src/main/java/turip/controller/dto/response/MyCollectContentResponse.java
+++ b/backend/turip-admin/src/main/java/turip/controller/dto/response/MyCollectContentResponse.java
@@ -1,6 +1,7 @@
 package turip.controller.dto.response;
 
 import java.time.LocalDateTime;
+import turip.content.domain.ContentPending;
 
 public record MyCollectContentResponse(
         Long id,
@@ -10,4 +11,15 @@ public record MyCollectContentResponse(
         String rejectReason,
         LocalDateTime createdAt
 ) {
+
+    public static MyCollectContentResponse from(ContentPending p) {
+        return new MyCollectContentResponse(
+                p.getId(),
+                p.getContentData().video().title(),
+                p.getContentData().cityName(),
+                p.getStatus().name(),
+                p.getRejectReason(),
+                p.getCreatedAt()
+        );
+    }
 }

--- a/backend/turip-admin/src/main/java/turip/controller/dto/response/PendingListResponse.java
+++ b/backend/turip-admin/src/main/java/turip/controller/dto/response/PendingListResponse.java
@@ -1,6 +1,7 @@
 package turip.controller.dto.response;
 
 import java.time.LocalDateTime;
+import turip.content.domain.ContentPending;
 
 public record PendingListResponse(
         Long id,
@@ -9,4 +10,14 @@ public record PendingListResponse(
         String collectorNickname,
         LocalDateTime createdAt
 ) {
+
+    public static PendingListResponse from(ContentPending p) {
+        return new PendingListResponse(
+                p.getId(),
+                p.getContentData().video().title(),
+                p.getContentData().video().channelName(),
+                p.getCollectorAccount().getNickname(),
+                p.getCreatedAt()
+        );
+    }
 }

--- a/backend/turip-admin/src/main/java/turip/controller/dto/response/PendingListResponse.java
+++ b/backend/turip-admin/src/main/java/turip/controller/dto/response/PendingListResponse.java
@@ -1,0 +1,12 @@
+package turip.controller.dto.response;
+
+import java.time.LocalDateTime;
+
+public record PendingListResponse(
+        Long id,
+        String videoTitle,
+        String channelName,
+        String collectorNickname,
+        LocalDateTime createdAt
+) {
+}

--- a/backend/turip-admin/src/main/java/turip/service/AdminContentPendingService.java
+++ b/backend/turip-admin/src/main/java/turip/service/AdminContentPendingService.java
@@ -45,27 +45,14 @@ public class AdminContentPendingService {
     public List<PendingListResponse> findAll() {
         return contentPendingRepository.findAllByStatusOrderByIdDesc(ContentPendingStatus.PENDING)
                 .stream()
-                .map(p -> new PendingListResponse(
-                        p.getId(),
-                        p.getContentData().video().title(),
-                        p.getContentData().video().channelName(),
-                        p.getCollectorAccount().getNickname(),
-                        p.getCreatedAt()
-                ))
+                .map(PendingListResponse::from)
                 .toList();
     }
 
     public List<MyCollectContentResponse> getMyHistory(Account account) {
         return contentPendingRepository.findAllByCollectorAccountOrderByIdDesc(account)
                 .stream()
-                .map(p -> new MyCollectContentResponse(
-                        p.getId(),
-                        p.getContentData().video().title(),
-                        p.getContentData().cityName(),
-                        p.getStatus().name(),
-                        p.getRejectReason(),
-                        p.getCreatedAt()
-                ))
+                .map(MyCollectContentResponse::from)
                 .toList();
     }
 
@@ -89,7 +76,7 @@ public class AdminContentPendingService {
                 .orElseThrow(() -> new NotFoundException(ErrorTag.CONTENT_NOT_FOUND));
         contentPending.approve(validatorAccount, content);
 
-        return new ContentPendingApprovalResponse(content.getId(), contentPending.getId());
+        return ContentPendingApprovalResponse.of(content, contentPending);
     }
 
     @Transactional

--- a/backend/turip-admin/src/main/java/turip/service/AdminContentPendingService.java
+++ b/backend/turip-admin/src/main/java/turip/service/AdminContentPendingService.java
@@ -1,15 +1,20 @@
 package turip.service;
 
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import turip.account.domain.Account;
+import turip.account.domain.Role;
+import turip.account.repository.AccountRepository;
 import turip.common.exception.ErrorTag;
+import turip.common.exception.custom.ConflictException;
 import turip.common.exception.custom.NotFoundException;
 import turip.content.domain.Content;
 import turip.content.domain.ContentPending;
 import turip.content.domain.ContentPendingData;
+import turip.content.domain.ContentPendingStatus;
 import turip.content.repository.ContentPendingRepository;
 import turip.content.repository.ContentRepository;
 import turip.controller.dto.request.AdminContentSaveRequest;
@@ -19,6 +24,8 @@ import turip.controller.dto.request.ContentPendingRejectRequest;
 import turip.controller.dto.response.ContentPendingApprovalResponse;
 import turip.controller.dto.response.ContentPendingRejectResponse;
 import turip.controller.dto.response.ContentPendingResponse;
+import turip.controller.dto.response.MyCollectContentResponse;
+import turip.controller.dto.response.PendingListResponse;
 
 @Service
 @RequiredArgsConstructor
@@ -26,12 +33,48 @@ public class AdminContentPendingService {
 
     private final ContentPendingRepository contentPendingRepository;
     private final ContentRepository contentRepository;
+    private final AccountRepository accountRepository;
     private final AdminContentService adminContentService;
 
     @Transactional
     public ContentPendingResponse findById(Long id) {
         ContentPending contentPending = getById(id);
         return ContentPendingResponse.from(contentPending);
+    }
+
+    public List<PendingListResponse> findAll() {
+        return contentPendingRepository.findAllByStatusOrderByIdDesc(ContentPendingStatus.PENDING)
+                .stream()
+                .map(p -> new PendingListResponse(
+                        p.getId(),
+                        p.getContentData().video().title(),
+                        p.getContentData().video().channelName(),
+                        p.getCollectorAccount().getNickname(),
+                        p.getCreatedAt()
+                ))
+                .toList();
+    }
+
+    public List<MyCollectContentResponse> getMyHistory(Account account) {
+        return contentPendingRepository.findAllByCollectorAccountOrderByIdDesc(account)
+                .stream()
+                .map(p -> new MyCollectContentResponse(
+                        p.getId(),
+                        p.getContentData().video().title(),
+                        p.getContentData().cityName(),
+                        p.getStatus().name(),
+                        p.getRejectReason(),
+                        p.getCreatedAt()
+                ))
+                .toList();
+    }
+
+    @Transactional
+    public Long pending(Account collectorAccount, ContentPendingData contentData) {
+        validateDuplicatePending(contentData.video().url());
+        Account validatorAccount = determineValidator(collectorAccount);
+        ContentPending contentPending = new ContentPending(contentData, collectorAccount, validatorAccount, null, null);
+        return contentPendingRepository.save(contentPending).getId();
     }
 
     @Transactional
@@ -59,6 +102,41 @@ public class AdminContentPendingService {
         String rejectReason = request.rejectReason();
         contentPending.reject(validatorAccount, rejectReason);
         return ContentPendingRejectResponse.from(contentPendingId);
+    }
+
+    private void validateDuplicatePending(String videoUrl) {
+        if (contentPendingRepository.existsByVideoUrlAndStatus(videoUrl, ContentPendingStatus.PENDING)) {
+            throw new ConflictException(ErrorTag.DUPLICATE_PENDING_CONTENT);
+        }
+    }
+
+    private Account determineValidator(Account collectorAccount) {
+        List<Account> candidates = accountRepository.findAllByRole(Role.ADMIN)
+                .stream()
+                .filter(a -> !a.getId().equals(collectorAccount.getId()))
+                .toList();
+
+        if (candidates.isEmpty()) {
+            throw new NotFoundException(ErrorTag.NO_AVAILABLE_VALIDATOR);
+        }
+
+        Optional<ContentPending> lastPending = contentPendingRepository.findTopByOrderByIdDesc();
+        if (lastPending.isEmpty()) {
+            return candidates.get(0);
+        }
+
+        Account lastValidator = lastPending.get().getValidatorAccount();
+        if (lastValidator == null) {
+            return candidates.get(0);
+        }
+
+        Long lastValidatorId = lastValidator.getId();
+        for (int i = 0; i < candidates.size(); i++) {
+            if (candidates.get(i).getId().equals(lastValidatorId)) {
+                return candidates.get((i + 1) % candidates.size());
+            }
+        }
+        return candidates.get(0);
     }
 
     private ContentPending getById(Long id) {

--- a/backend/turip-admin/src/main/resources/templates/admin/content.html
+++ b/backend/turip-admin/src/main/resources/templates/admin/content.html
@@ -705,6 +705,7 @@
             });
         } catch (error) {
             console.error('도시 목록 로드 실패:', error);
+            showErrorToast('도시 목록을 불러오는데 실패했습니다: ' + error.message);
         }
     }
 

--- a/backend/turip-admin/src/main/resources/templates/admin/content.html
+++ b/backend/turip-admin/src/main/resources/templates/admin/content.html
@@ -13,7 +13,7 @@
         body {
             background: linear-gradient(135deg, #becdfd, #ffffff);
             min-height: 100vh;
-            padding: 40px 0;
+            padding-bottom: 40px;
             font-family: 'Pretendard', sans-serif;
         }
 
@@ -144,43 +144,31 @@
             display: flex;
             justify-content: space-between;
             align-items: center;
-            margin-bottom: 20px;
-        }
-
-        .header h1 {
-            color: #667eea;
-            font-size: 24px;
-            margin: 0;
-        }
-
-        .home-btn {
-            padding: 10px 20px;
-            background: #667eea;
-            color: white;
-            border: none;
-            border-radius: 6px;
-            font-size: 14px;
-            font-weight: 600;
-            cursor: pointer;
-            transition: background 0.3s;
-            text-decoration: none;
-            display: inline-block;
-        }
-
-        .home-btn:hover {
-            background: #5568d3;
-            color: white;
+            position: fixed;
+            top: 0;
+            width: 100%;
+            z-index: 1000;
         }
     </style>
 </head>
 <body>
 
-<div class="header">
-    <h1>Turip 관리자 - 콘텐츠 수집</h1>
-    <a href="/admin/home" class="home-btn">홈으로 돌아가기</a>
+<!-- Toast 알림 -->
+<div aria-atomic="true" aria-live="polite" class="position-fixed top-0 end-0 p-3" style="z-index: 9999;">
+    <div class="toast align-items-center border-0" id="errorToast" role="alert">
+        <div class="d-flex">
+            <div class="toast-body fw-bold" id="toastMessage"></div>
+            <button aria-label="Close" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" type="button"></button>
+        </div>
+    </div>
 </div>
 
-<div class="container">
+<div class="header">
+    <h1 style="color: #667eea; font-size: 22px; font-weight: 800; margin:0;">Turip Admin</h1>
+    <a class="btn btn-sm btn-outline-primary fw-bold" href="/admin/home">홈으로 돌아가기</a>
+</div>
+
+<div class="container" style="margin-top: 80px;">
     <div class="row justify-content-center">
         <div class="col-lg-12">
             <div class="admin-card">
@@ -603,14 +591,40 @@
 
         try {
             saveButton.disabled = true;
-            saveButton.innerHTML = '💾 저장 중...';
-            await authFetch('/api/v1/admin/contents', {method: 'POST', body: JSON.stringify(payload)});
-            alert("🎉 콘텐츠 저장 완료!");
-            location.reload();
+
+            if (editPendingId) {
+                // 반려 후 재검수 요청: ContentPendingData 형식으로 POST
+                saveButton.innerHTML = '📨 요청 중...';
+                const pendingPayload = {
+                    cityName: cityName,
+                    video: {
+                        videoId: vId,
+                        url: document.getElementById('v_url').value,
+                        title: document.getElementById('v_video_title').innerText,
+                        channelName: document.getElementById('v_channel_name').innerText,
+                        channelImage: document.getElementById('v_channel_img').src,
+                        uploadedDate: document.getElementById('v_date_val').value || null
+                    },
+                    contentPlaces: collectedPlaces.map(p => ({
+                        visitDay: p.visitDay,
+                        visitOrder: p.visitOrder,
+                        timeLine: p.timeLine,
+                        place: p.place
+                    }))
+                };
+                await authFetch('/api/v1/admin/content-pendings', {method: 'POST', body: JSON.stringify(pendingPayload)});
+                alert("📨 재검수 요청이 완료되었습니다!");
+                location.href = '/admin/my';
+            } else {
+                saveButton.innerHTML = '💾 저장 중...';
+                await authFetch('/api/v1/admin/contents', {method: 'POST', body: JSON.stringify(payload)});
+                alert("🎉 콘텐츠 저장 완료!");
+                location.reload();
+            }
         } catch (e) {
-            alert("⚠️ 저장 실패\n" + e.message);
+            showErrorToast(e.message);
             saveButton.disabled = false;
-            saveButton.innerHTML = '💾 서버에 콘텐츠 저장';
+            saveButton.innerHTML = editPendingId ? '📨 재검수 요청' : '💾 서버에 콘텐츠 저장';
         }
     }
 
@@ -658,8 +672,79 @@
         }
     }
 
-    // 페이지 로드 시 도시 목록 불러오기
-    document.addEventListener('DOMContentLoaded', loadCities);
+    function showErrorToast(message) {
+        const toastEl = document.getElementById('errorToast');
+        document.getElementById('toastMessage').textContent = '⚠️ ' + message;
+        toastEl.classList.remove('text-bg-success', 'text-bg-danger');
+        toastEl.classList.add('text-bg-danger');
+        bootstrap.Toast.getOrCreateInstance(toastEl, {delay: 5000}).show();
+    }
+
+    let editPendingId = null;
+
+    async function loadEditData(pendingId) {
+        try {
+            const res = await authFetch(`/api/v1/admin/content-pendings/${pendingId}`);
+            const data = await res.json();
+            const cd = data.contentData;
+
+            // 편집 모드 배너 표시
+            const banner = document.createElement('div');
+            banner.className = 'alert alert-warning';
+            banner.style.cssText = 'margin: 0 0 16px 0; border-radius: 12px;';
+            banner.innerHTML = `✏️ <strong>반려된 콘텐츠 수정 중</strong> — 반려 사유: ${data.rejectReason || '(사유 없음)'}`;
+            document.querySelector('.container').prepend(banner);
+
+            // 저장 버튼 텍스트 변경
+            document.getElementById('saveContentBtn').innerHTML = '📨 재검수 요청';
+
+            // 영상 정보 채우기
+            document.getElementById('videoUrlInput').value = cd.video.url;
+            document.getElementById('v_id').value = cd.video.videoId;
+            document.getElementById('v_url').value = cd.video.url;
+            document.getElementById('v_channel_name').innerText = cd.video.channelName;
+            document.getElementById('v_video_title').innerText = cd.video.title;
+            document.getElementById('v_channel_img').src = cd.video.channelImage || 'https://via.placeholder.com/90?text=No+Image';
+            document.getElementById('v_date_val').value = cd.video.uploadedDate || '';
+            document.getElementById('videoInfoArea').classList.remove('d-none');
+            createPlayer(cd.video.videoId);
+
+            // 도시 이름
+            document.getElementById('cityName').value = cd.cityName;
+
+            // 장소 목록 복원
+            collectedPlaces = cd.contentPlaces.map((cp, i) => ({
+                id: Date.now() + i,
+                visitDay: cp.visitDay,
+                visitOrder: cp.visitOrder,
+                timeLine: cp.timeLine,
+                place: {
+                    name: cp.place.name,
+                    url: cp.place.url,
+                    address: cp.place.address,
+                    latitude: cp.place.latitude,
+                    longitude: cp.place.longitude,
+                    categoryName: cp.place.categoryName
+                }
+            }));
+            renderPlaceList();
+            calculateDuration();
+            updateMapMarkers();
+        } catch (e) {
+            alert('기존 데이터를 불러오는 데 실패했습니다.\n' + e.message);
+        }
+    }
+
+    // 페이지 로드 시 도시 목록 불러오기 + editId 처리
+    document.addEventListener('DOMContentLoaded', async () => {
+        await loadCities();
+        const params = new URLSearchParams(location.search);
+        const editId = params.get('editId');
+        if (editId) {
+            editPendingId = editId;
+            await loadEditData(editId);
+        }
+    });
 
     /*]]>*/
 </script>

--- a/backend/turip-admin/src/main/resources/templates/admin/content.html
+++ b/backend/turip-admin/src/main/resources/templates/admin/content.html
@@ -444,7 +444,16 @@
             data.items.forEach(item => {
                 const div = document.createElement('div');
                 div.className = 'search-result-item';
-                div.innerHTML = `<strong>${item.name}</strong><br><small>${item.address}</small>`;
+
+                const strong = document.createElement('strong');
+                strong.textContent = item.name;
+                div.appendChild(strong);
+                div.appendChild(document.createElement('br'));
+
+                const small = document.createElement('small');
+                small.textContent = item.address;
+                div.appendChild(small);
+
                 div.onclick = () => {
                     selectedPlaceData = item;
                     document.getElementById('placeQuery').value = item.name;
@@ -521,7 +530,33 @@
             container.appendChild(dayBox);
             const listDiv = document.getElementById(`day-list-${day}`);
             grouped[day].forEach(item => {
-                listDiv.insertAdjacentHTML('beforeend', `<div class="place-item" data-id="${item.id}" onclick="focusOnPlace(${item.id})" style="cursor: pointer;"><div><b>${item.place.name}</b> <small>🕒 ${item.timeLine}</small></div><button class="btn btn-sm text-danger" onclick="event.stopPropagation(); removePlace(${item.id})">✕</button></div>`);
+                const placeDiv = document.createElement('div');
+                placeDiv.className = 'place-item';
+                placeDiv.setAttribute('data-id', item.id);
+                placeDiv.style.cursor = 'pointer';
+                placeDiv.onclick = () => focusOnPlace(item.id);
+
+                const infoDiv = document.createElement('div');
+                const placeName = document.createElement('b');
+                placeName.textContent = item.place.name;
+                infoDiv.appendChild(placeName);
+                infoDiv.appendChild(document.createTextNode(' '));
+
+                const timeSmall = document.createElement('small');
+                timeSmall.textContent = `🕒 ${item.timeLine}`;
+                infoDiv.appendChild(timeSmall);
+
+                const removeBtn = document.createElement('button');
+                removeBtn.className = 'btn btn-sm text-danger';
+                removeBtn.textContent = '✕';
+                removeBtn.onclick = (e) => {
+                    e.stopPropagation();
+                    removePlace(item.id);
+                };
+
+                placeDiv.appendChild(infoDiv);
+                placeDiv.appendChild(removeBtn);
+                listDiv.appendChild(placeDiv);
             });
             Sortable.create(listDiv, {
                 group: 'places', animation: 150,
@@ -693,7 +728,11 @@
             const banner = document.createElement('div');
             banner.className = 'alert alert-warning';
             banner.style.cssText = 'margin: 0 0 16px 0; border-radius: 12px;';
-            banner.innerHTML = `✏️ <strong>반려된 콘텐츠 수정 중</strong> — 반려 사유: ${data.rejectReason || '(사유 없음)'}`;
+            banner.textContent = '✏️ ';
+            const strong = document.createElement('strong');
+            strong.textContent = '반려된 콘텐츠 수정 중';
+            banner.appendChild(strong);
+            banner.appendChild(document.createTextNode(' — 반려 사유: ' + (data.rejectReason || '(사유 없음)')));
             document.querySelector('.container').prepend(banner);
 
             // 저장 버튼 텍스트 변경

--- a/backend/turip-admin/src/main/resources/templates/admin/content.html
+++ b/backend/turip-admin/src/main/resources/templates/admin/content.html
@@ -616,10 +616,11 @@
                 alert("📨 재검수 요청이 완료되었습니다!");
                 location.href = '/admin/my';
             } else {
-                saveButton.innerHTML = '💾 저장 중...';
-                await authFetch('/api/v1/admin/contents', {method: 'POST', body: JSON.stringify(payload)});
-                alert("🎉 콘텐츠 저장 완료!");
-                location.reload();
+                saveButton.innerHTML = '📨 검수 요청 중...';
+                const { tripDuration, ...pendingPayload } = payload;
+                await authFetch('/api/v1/admin/content-pendings', {method: 'POST', body: JSON.stringify(pendingPayload)});
+                alert("📨 검수 요청이 완료되었습니다!");
+                location.href = '/admin/my';
             }
         } catch (e) {
             showErrorToast(e.message);

--- a/backend/turip-admin/src/main/resources/templates/admin/home.html
+++ b/backend/turip-admin/src/main/resources/templates/admin/home.html
@@ -1,131 +1,324 @@
 <!DOCTYPE html>
-<html lang="ko">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
     <title>관리자 메인 - Turip</title>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
     <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+        * { margin: 0; padding: 0; box-sizing: border-box; }
 
         body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-            background: #f5f5f5;
+            font-family: 'Pretendard', -apple-system, sans-serif;
+            background: linear-gradient(135deg, #becdfd, #ffffff);
             min-height: 100vh;
         }
 
         .header {
             background: white;
             box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-            padding: 20px 40px;
+            padding: 15px 40px;
             display: flex;
             justify-content: space-between;
             align-items: center;
+            position: fixed;
+            top: 0;
+            width: 100%;
+            z-index: 1000;
         }
 
         .header h1 {
             color: #667eea;
-            font-size: 24px;
+            font-size: 22px;
+            font-weight: 800;
+            margin: 0;
         }
 
-        .logout-btn {
-            padding: 10px 20px;
-            background: #667eea;
+        .header-right {
+            display: flex;
+            align-items: center;
+            gap: 25px;
+        }
+
+        .notification-container { position: relative; }
+
+        .notification-bell {
+            position: relative;
+            font-size: 22px;
+            color: #667eea;
+            cursor: pointer;
+            transition: transform 0.2s;
+            padding: 5px;
+        }
+
+        .notification-bell:hover { transform: scale(1.1); }
+
+        .badge {
+            position: absolute;
+            top: 0;
+            right: -2px;
+            background: #ff4d4f;
             color: white;
+            font-size: 11px;
+            font-weight: bold;
+            padding: 2px 6px;
+            border-radius: 10px;
+            border: 2px solid white;
+            display: none;
+        }
+
+        .notification-dropdown {
+            position: absolute;
+            top: calc(100% + 12px);
+            right: 0;
+            width: 300px;
+            background: white;
+            border-radius: 15px;
+            box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+            display: none;
+            z-index: 1100;
+            overflow: hidden;
+            border: 1px solid rgba(0, 0, 0, 0.05);
+        }
+
+        .notification-dropdown.active {
+            display: block;
+            animation: fadeIn 0.2s ease-out;
+        }
+
+        @keyframes fadeIn {
+            from { opacity: 0; transform: translateY(-10px); }
+            to   { opacity: 1; transform: translateY(0); }
+        }
+
+        .dropdown-header {
+            padding: 12px 18px;
+            font-weight: 700;
+            border-bottom: 1px solid #eee;
+            color: #333;
+            font-size: 14px;
+        }
+
+        .dropdown-body { max-height: 300px; overflow-y: auto; }
+
+        .notif-item {
+            padding: 12px 18px;
+            display: flex;
+            flex-direction: column;
+            text-decoration: none;
+            color: #444;
+            border-bottom: 1px solid #f8f8f8;
+        }
+
+        .notif-item:hover { background: #f1f4ff; }
+
+        .notif-title {
+            font-size: 13px;
+            font-weight: 700;
+            margin-bottom: 2px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .notif-user { font-size: 11px; color: #999; }
+
+        .dropdown-footer { padding: 10px; text-align: center; background: #fafafa; }
+
+        .btn-all {
+            color: #667eea;
+            text-decoration: none;
+            font-size: 12px;
+            font-weight: 700;
+        }
+
+        .empty-state { padding: 30px; text-align: center; color: #ccc; font-size: 13px; }
+
+        .mypage-btn {
+            font-size: 22px;
+            color: #667eea;
+            text-decoration: none;
+            transition: transform 0.2s;
+            display: flex;
+            align-items: center;
+        }
+
+        .mypage-btn:hover { transform: scale(1.1); }
+
+        .logout-btn {
+            padding: 8px 18px;
+            background: #f1f3f9;
+            color: #555;
             border: none;
             border-radius: 6px;
             font-size: 14px;
             font-weight: 600;
             cursor: pointer;
-            transition: background 0.3s;
+            transition: all 0.3s;
         }
 
-        .logout-btn:hover {
-            background: #5568d3;
-        }
+        .logout-btn:hover { background: #e2e8f0; color: #333; }
 
         .main-content {
-            max-width: 1200px;
-            margin: 40px auto;
+            max-width: 900px;
+            margin: 100px auto 40px;
             padding: 0 20px;
         }
 
         .welcome-card {
             background: white;
-            border-radius: 12px;
-            padding: 40px;
+            border-radius: 20px;
+            padding: 50px;
             text-align: center;
-            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
         }
 
-        .welcome-card h2 {
-            color: #333;
-            font-size: 28px;
-            margin-bottom: 16px;
-        }
+        .welcome-card h2 { color: #333; font-size: 28px; margin-bottom: 10px; }
+        .welcome-card p { color: #888; margin-bottom: 35px; }
 
-        .welcome-card p {
-            color: #666;
-            font-size: 16px;
-            margin-bottom: 30px;
-        }
+        .btn-group { display: flex; gap: 15px; justify-content: center; }
 
         .action-btn {
-            padding: 14px 30px;
-            background: #667eea;
-            color: white;
+            padding: 16px 32px;
             border: none;
-            border-radius: 6px;
+            border-radius: 12px;
             font-size: 16px;
-            font-weight: 600;
+            font-weight: 700;
             cursor: pointer;
             transition: all 0.3s;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            text-decoration: none;
         }
 
-        .action-btn:hover {
+        .btn-collect { background: #667eea; color: white; }
+
+        .btn-collect:hover {
             background: #5568d3;
-            transform: translateY(-2px);
-            box-shadow: 0 5px 15px rgba(102, 126, 234, 0.3);
+            transform: translateY(-3px);
+            box-shadow: 0 8px 20px rgba(102, 126, 234, 0.3);
         }
+
+        .btn-pending { background: #fff; color: #667eea; border: 2px solid #667eea; }
+
+        .btn-pending:hover { background: #f8faff; transform: translateY(-3px); }
     </style>
 </head>
 <body>
-    <div class="header">
-        <h1>Turip 관리자</h1>
+
+<div class="header">
+    <h1>Turip Admin</h1>
+    <div class="header-right">
+        <div class="notification-container">
+            <div class="notification-bell" id="bellIcon">
+                <i class="fa-solid fa-bell"></i>
+                <span class="badge" id="pendingBadge">0</span>
+            </div>
+            <div class="notification-dropdown" id="notifDropdown">
+                <div class="dropdown-header">최신 검수 요청</div>
+                <div class="dropdown-body" id="notifList">
+                    <div class="empty-state">내역이 없습니다.</div>
+                </div>
+                <div class="dropdown-footer">
+                    <a class="btn-all" href="/admin/contents/pending">전체 보기</a>
+                </div>
+            </div>
+        </div>
+
+        <a class="mypage-btn" href="/admin/my" title="마이페이지">
+            <i class="fa-solid fa-circle-user"></i>
+        </a>
+
         <button class="logout-btn" onclick="logout()">로그아웃</button>
     </div>
+</div>
 
-    <div class="main-content">
-        <div class="welcome-card">
-            <h2>환영합니다!</h2>
-            <p>Turip 관리자 페이지입니다.</p>
-            <button class="action-btn" onclick="location.href='/admin/contents'">콘텐츠 수집</button>
+<div class="main-content">
+    <div class="welcome-card">
+        <h2>반갑습니다, <span style="color:#667eea;" th:text="${admin.member.account.nickname}">관리자</span>님! 👋</h2>
+        <p>오늘도 새로운 여행 콘텐츠를 수집해볼까요?</p>
+        <div class="btn-group">
+            <a class="action-btn btn-collect" href="/admin/contents">
+                <i class="fa-solid fa-plus"></i> 콘텐츠 수집하기
+            </a>
+            <a class="action-btn btn-pending" href="/admin/contents/pending">
+                <i class="fa-solid fa-list-check"></i> 검수 대기 목록
+            </a>
         </div>
     </div>
+</div>
 
 <script>
-    async function logout() {
-        try {
-            // 서버에 로그아웃 요청 (RefreshToken 삭제 + 쿠키 무효화)
-            const response = await fetch('/api/v1/auth/logout', {
-                method: 'POST',
-                headers: {
-                    'device-fid': 'admin-web'
-                },
-                credentials: 'include'  // 쿠키 자동 전송
-            });
+    const bellIcon = document.getElementById('bellIcon');
+    const notifDropdown = document.getElementById('notifDropdown');
 
-                // 성공 여부와 관계없이 로그인 페이지로 리다이렉트
-                window.location.href = '/admin/login';
-            } catch (error) {
-                console.error('로그아웃 중 오류:', error);
-                // 오류가 발생해도 로그인 페이지로 이동
-                window.location.href = '/admin/login';
-            }
+    bellIcon.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const isActive = notifDropdown.classList.toggle('active');
+        if (isActive) fetchRecentPending();
+    });
+
+    document.addEventListener('click', (e) => {
+        if (!notifDropdown.contains(e.target) && e.target !== bellIcon) {
+            notifDropdown.classList.remove('active');
         }
-    </script>
+    });
+
+    async function fetchRecentPending() {
+        try {
+            const res = await fetch('/api/v1/admin/content-pendings/list');
+            const list = await res.json();
+            const container = document.getElementById('notifList');
+
+            if (!list || list.length === 0) {
+                container.innerHTML = '<div class="empty-state">새로운 요청이 없습니다.</div>';
+                return;
+            }
+
+            container.innerHTML = list.slice(0, 5).map(item => `
+                <a href="/admin/contents/pending/${item.id}" class="notif-item">
+                    <span class="notif-title">${item.videoTitle}</span>
+                    <span class="notif-user">${item.collectorNickname}님의 요청</span>
+                </a>
+            `).join('');
+        } catch (e) {
+            console.error(e);
+        }
+    }
+
+    async function updatePendingCount() {
+        try {
+            const res = await fetch('/api/v1/admin/content-pendings/list');
+            const list = await res.json();
+            const badge = document.getElementById('pendingBadge');
+            if (list.length > 0) {
+                badge.innerText = list.length > 99 ? '99+' : list.length;
+                badge.style.display = 'block';
+            } else {
+                badge.style.display = 'none';
+            }
+        } catch (e) {
+            console.error(e);
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        updatePendingCount();
+        setInterval(updatePendingCount, 60000);
+    });
+
+    async function logout() {
+        if (!confirm('로그아웃 하시겠습니까?')) return;
+        try {
+            await fetch('/api/v1/auth/logout', {
+                method: 'POST',
+                headers: {'device-fid': 'admin-web'},
+                credentials: 'include'
+            });
+        } catch (e) {}
+        window.location.href = '/admin/login';
+    }
+</script>
 </body>
 </html>

--- a/backend/turip-admin/src/main/resources/templates/admin/home.html
+++ b/backend/turip-admin/src/main/resources/templates/admin/home.html
@@ -276,12 +276,24 @@
                 return;
             }
 
-            container.innerHTML = list.slice(0, 5).map(item => `
-                <a href="/admin/contents/pending/${item.id}" class="notif-item">
-                    <span class="notif-title">${item.videoTitle}</span>
-                    <span class="notif-user">${item.collectorNickname}님의 요청</span>
-                </a>
-            `).join('');
+            container.innerHTML = '';
+            list.slice(0, 5).forEach(item => {
+                const link = document.createElement('a');
+                link.href = `/admin/contents/pending/${item.id}`;
+                link.className = 'notif-item';
+
+                const titleSpan = document.createElement('span');
+                titleSpan.className = 'notif-title';
+                titleSpan.textContent = item.videoTitle;
+                link.appendChild(titleSpan);
+
+                const userSpan = document.createElement('span');
+                userSpan.className = 'notif-user';
+                userSpan.textContent = `${item.collectorNickname}님의 요청`;
+                link.appendChild(userSpan);
+
+                container.appendChild(link);
+            });
         } catch (e) {
             console.error(e);
         }

--- a/backend/turip-admin/src/main/resources/templates/admin/home.html
+++ b/backend/turip-admin/src/main/resources/templates/admin/home.html
@@ -266,10 +266,17 @@
     });
 
     async function fetchRecentPending() {
+        const container = document.getElementById('notifList');
         try {
             const res = await fetch('/api/v1/admin/content-pendings/list');
+
+            if (!res.ok) {
+                const errorData = await res.json().catch(() => null);
+                const errorMessage = errorData?.message || `서버 오류 (${res.status})`;
+                throw new Error(errorMessage);
+            }
+
             const list = await res.json();
-            const container = document.getElementById('notifList');
 
             if (!list || list.length === 0) {
                 container.innerHTML = '<div class="empty-state">새로운 요청이 없습니다.</div>';
@@ -296,12 +303,18 @@
             });
         } catch (e) {
             console.error(e);
+            container.innerHTML = '<div class="empty-state" style="color: #dc3545;">⚠️ 로드 실패: ' + e.message + '</div>';
         }
     }
 
     async function updatePendingCount() {
         try {
             const res = await fetch('/api/v1/admin/content-pendings/list');
+
+            if (!res.ok) {
+                throw new Error(`서버 오류 (${res.status})`);
+            }
+
             const list = await res.json();
             const badge = document.getElementById('pendingBadge');
             if (list.length > 0) {
@@ -311,7 +324,8 @@
                 badge.style.display = 'none';
             }
         } catch (e) {
-            console.error(e);
+            console.error('배지 업데이트 실패:', e);
+            // 배지 업데이트 실패 시 조용히 실패 (사용자에게 방해되지 않도록)
         }
     }
 

--- a/backend/turip-admin/src/main/resources/templates/admin/my.html
+++ b/backend/turip-admin/src/main/resources/templates/admin/my.html
@@ -164,10 +164,17 @@
 
 <script th:inline="javascript">
     async function loadMyHistory() {
+        const tbody = document.getElementById('myCollectList');
         try {
             const response = await fetch('/api/v1/admin/contents/my');
+
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => null);
+                const errorMessage = errorData?.message || `서버 오류 (${response.status})`;
+                throw new Error(errorMessage);
+            }
+
             const list = await response.json();
-            const tbody = document.getElementById('myCollectList');
 
             if (list.length === 0) {
                 tbody.innerHTML = '<tr><td colspan="3" class="text-center py-5 text-muted small">수집한 내역이 없습니다.</td></tr>';
@@ -229,6 +236,7 @@
             });
         } catch (error) {
             console.error("내역 로드 실패:", error);
+            tbody.innerHTML = '<tr><td colspan="3" class="text-center py-5 text-danger">⚠️ 데이터를 불러오는데 실패했습니다: ' + error.message + '</td></tr>';
         }
     }
 

--- a/backend/turip-admin/src/main/resources/templates/admin/my.html
+++ b/backend/turip-admin/src/main/resources/templates/admin/my.html
@@ -174,26 +174,59 @@
                 return;
             }
 
-            tbody.innerHTML = list.map(item => `
-                <tr>
-                    <td>
-                        <div class="fw-bold" style="font-size: 15px; letter-spacing: -0.5px;">${item.videoTitle}</div>
-                        <div class="text-muted small">${item.cityName} · ${new Date(item.createdAt).toLocaleDateString()}</div>
-                        ${item.status === 'REJECTED' && item.rejectReason ?
-                `<span class="reject-reason"><i class="fa-solid fa-circle-exclamation me-1"></i>반려 사유: ${item.rejectReason}</span>` : ''}
-                    </td>
-                    <td class="text-center">
-                        <span class="status-badge status-${item.status.toLowerCase()}">
-                            ${item.status === 'PENDING' ? '검수 중' : item.status === 'APPROVED' ? '승인 완료' : '반려됨'}
-                        </span>
-                    </td>
-                    <td class="text-end">
-                        ${item.status === 'REJECTED' ?
-                `<a href="/admin/contents?editId=${item.id}" class="btn-edit">수정하기</a>` :
-                `<span class="text-muted small">수정 불가</span>`}
-                    </td>
-                </tr>
-            `).join('');
+            tbody.innerHTML = '';
+            list.forEach(item => {
+                const tr = document.createElement('tr');
+
+                const tdInfo = document.createElement('td');
+                const titleDiv = document.createElement('div');
+                titleDiv.className = 'fw-bold';
+                titleDiv.style.cssText = 'font-size: 15px; letter-spacing: -0.5px;';
+                titleDiv.textContent = item.videoTitle;
+                tdInfo.appendChild(titleDiv);
+
+                const metaDiv = document.createElement('div');
+                metaDiv.className = 'text-muted small';
+                metaDiv.textContent = `${item.cityName} · ${new Date(item.createdAt).toLocaleDateString()}`;
+                tdInfo.appendChild(metaDiv);
+
+                if (item.status === 'REJECTED' && item.rejectReason) {
+                    const rejectSpan = document.createElement('span');
+                    rejectSpan.className = 'reject-reason';
+                    const icon = document.createElement('i');
+                    icon.className = 'fa-solid fa-circle-exclamation me-1';
+                    rejectSpan.appendChild(icon);
+                    rejectSpan.appendChild(document.createTextNode('반려 사유: ' + item.rejectReason));
+                    tdInfo.appendChild(rejectSpan);
+                }
+                tr.appendChild(tdInfo);
+
+                const tdStatus = document.createElement('td');
+                tdStatus.className = 'text-center';
+                const statusBadge = document.createElement('span');
+                statusBadge.className = 'status-badge status-' + item.status.toLowerCase();
+                statusBadge.textContent = item.status === 'PENDING' ? '검수 중' : item.status === 'APPROVED' ? '승인 완료' : '반려됨';
+                tdStatus.appendChild(statusBadge);
+                tr.appendChild(tdStatus);
+
+                const tdAction = document.createElement('td');
+                tdAction.className = 'text-end';
+                if (item.status === 'REJECTED') {
+                    const link = document.createElement('a');
+                    link.href = `/admin/contents?editId=${item.id}`;
+                    link.className = 'btn-edit';
+                    link.textContent = '수정하기';
+                    tdAction.appendChild(link);
+                } else {
+                    const span = document.createElement('span');
+                    span.className = 'text-muted small';
+                    span.textContent = '수정 불가';
+                    tdAction.appendChild(span);
+                }
+                tr.appendChild(tdAction);
+
+                tbody.appendChild(tr);
+            });
         } catch (error) {
             console.error("내역 로드 실패:", error);
         }

--- a/backend/turip-admin/src/main/resources/templates/admin/my.html
+++ b/backend/turip-admin/src/main/resources/templates/admin/my.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Turip Admin - 마이페이지</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+    <style>
+        @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
+
+        body {
+            background: linear-gradient(135deg, #becdfd, #ffffff);
+            min-height: 100vh;
+            font-family: 'Pretendard', sans-serif;
+            padding-bottom: 50px;
+        }
+
+        .header {
+            background: white;
+            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+            padding: 20px 40px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            position: fixed;
+            top: 0;
+            width: 100%;
+            z-index: 1000;
+        }
+
+        .admin-card {
+            background: white;
+            border-radius: 20px;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+            padding: 30px;
+            margin-bottom: 25px;
+        }
+
+        .section-title {
+            font-weight: 800;
+            color: #333;
+            margin-bottom: 25px;
+            border-left: 5px solid #6e8efb;
+            padding-left: 15px;
+            font-size: 1.1rem;
+        }
+
+        .user-profile {
+            display: flex;
+            align-items: center;
+            gap: 20px;
+            margin-bottom: 10px;
+        }
+
+        .user-avatar {
+            width: 60px;
+            height: 60px;
+            background: #f0f3ff;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 30px;
+            color: #667eea;
+        }
+
+        .table {
+            --bs-table-hover-bg: #f8faff;
+            vertical-align: middle;
+        }
+
+        .table thead th {
+            border-bottom: 2px solid #f0f0f0;
+            color: #888;
+            font-size: 14px;
+            font-weight: 600;
+        }
+
+        .status-badge {
+            padding: 4px 12px;
+            border-radius: 50px;
+            font-size: 12px;
+            font-weight: 700;
+        }
+
+        .status-pending {
+            background: #fef9e7;
+            color: #d4ac0d;
+        }
+
+        .status-approved {
+            background: #e8f5e9;
+            color: #2e7d32;
+        }
+
+        .status-rejected {
+            background: #ffebee;
+            color: #c62828;
+        }
+
+        .btn-edit {
+            background: #6e8efb;
+            color: white;
+            border: none;
+            padding: 6px 14px;
+            border-radius: 8px;
+            font-size: 13px;
+            font-weight: 600;
+            text-decoration: none;
+            transition: 0.2s;
+        }
+
+        .btn-edit:hover {
+            background: #5a78d8;
+            color: white;
+            transform: translateY(-2px);
+        }
+
+        .reject-reason {
+            font-size: 12px;
+            color: #c62828;
+            margin-top: 4px;
+            display: block;
+        }
+    </style>
+</head>
+<body>
+
+<div class="header">
+    <h1 style="color: #667eea; font-size: 22px; font-weight: 800; margin:0;">Turip Admin</h1>
+    <a class="btn btn-sm btn-outline-primary fw-bold" href="/admin/home">홈으로 돌아가기</a>
+</div>
+
+<div class="container" style="margin-top: 80px;">
+    <div class="admin-card">
+        <div class="user-profile">
+            <div class="user-avatar">
+                <i class="fa-solid fa-user"></i>
+            </div>
+            <div>
+                <h4 class="fw-bold mb-1"><span th:text="${admin.member.account.nickname}">닉네임</span>님</h4>
+                <p class="text-muted small mb-0" th:text="${admin.member.email}">email@example.com</p>
+            </div>
+        </div>
+    </div>
+
+    <div class="admin-card">
+        <h3 class="section-title">내 콘텐츠 수집 현황</h3>
+        <div class="table-responsive">
+            <table class="table table-hover">
+                <thead>
+                <tr>
+                    <th>영상 정보</th>
+                    <th class="text-center">상태</th>
+                    <th class="text-end">관리</th>
+                </tr>
+                </thead>
+                <tbody id="myCollectList">
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<script th:inline="javascript">
+    async function loadMyHistory() {
+        try {
+            const response = await fetch('/api/v1/admin/contents/my');
+            const list = await response.json();
+            const tbody = document.getElementById('myCollectList');
+
+            if (list.length === 0) {
+                tbody.innerHTML = '<tr><td colspan="3" class="text-center py-5 text-muted small">수집한 내역이 없습니다.</td></tr>';
+                return;
+            }
+
+            tbody.innerHTML = list.map(item => `
+                <tr>
+                    <td>
+                        <div class="fw-bold" style="font-size: 15px; letter-spacing: -0.5px;">${item.videoTitle}</div>
+                        <div class="text-muted small">${item.cityName} · ${new Date(item.createdAt).toLocaleDateString()}</div>
+                        ${item.status === 'REJECTED' && item.rejectReason ?
+                `<span class="reject-reason"><i class="fa-solid fa-circle-exclamation me-1"></i>반려 사유: ${item.rejectReason}</span>` : ''}
+                    </td>
+                    <td class="text-center">
+                        <span class="status-badge status-${item.status.toLowerCase()}">
+                            ${item.status === 'PENDING' ? '검수 중' : item.status === 'APPROVED' ? '승인 완료' : '반려됨'}
+                        </span>
+                    </td>
+                    <td class="text-end">
+                        ${item.status === 'REJECTED' ?
+                `<a href="/admin/contents?editId=${item.id}" class="btn-edit">수정하기</a>` :
+                `<span class="text-muted small">수정 불가</span>`}
+                    </td>
+                </tr>
+            `).join('');
+        } catch (error) {
+            console.error("내역 로드 실패:", error);
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', loadMyHistory);
+</script>
+</body>
+</html>

--- a/backend/turip-admin/src/main/resources/templates/admin/pending-list.html
+++ b/backend/turip-admin/src/main/resources/templates/admin/pending-list.html
@@ -161,18 +161,49 @@
                 return;
             }
 
-            tbody.innerHTML = list.map(item => `
-                <tr>
-                    <td>${item.id}</td>
-                    <td>
-                        <span class="video-title">${item.videoTitle}</span>
-                        <span class="channel-name">${item.channelName}</span>
-                    </td>
-                    <td class="collector-name">${item.collectorNickname}</td>
-                    <td class="text-center"><span class="status-badge">대기 중</span></td>
-                    <td class="text-end"><a href="/admin/contents/pending/${item.id}" class="btn-review">상세 검수</a></td>
-                </tr>
-            `).join('');
+            tbody.innerHTML = '';
+            list.forEach(item => {
+                const tr = document.createElement('tr');
+
+                const tdId = document.createElement('td');
+                tdId.textContent = item.id;
+                tr.appendChild(tdId);
+
+                const tdVideo = document.createElement('td');
+                const videoTitle = document.createElement('span');
+                videoTitle.className = 'video-title';
+                videoTitle.textContent = item.videoTitle;
+                const channelName = document.createElement('span');
+                channelName.className = 'channel-name';
+                channelName.textContent = item.channelName;
+                tdVideo.appendChild(videoTitle);
+                tdVideo.appendChild(channelName);
+                tr.appendChild(tdVideo);
+
+                const tdCollector = document.createElement('td');
+                tdCollector.className = 'collector-name';
+                tdCollector.textContent = item.collectorNickname;
+                tr.appendChild(tdCollector);
+
+                const tdStatus = document.createElement('td');
+                tdStatus.className = 'text-center';
+                const statusBadge = document.createElement('span');
+                statusBadge.className = 'status-badge';
+                statusBadge.textContent = '대기 중';
+                tdStatus.appendChild(statusBadge);
+                tr.appendChild(tdStatus);
+
+                const tdAction = document.createElement('td');
+                tdAction.className = 'text-end';
+                const link = document.createElement('a');
+                link.href = `/admin/contents/pending/${item.id}`;
+                link.className = 'btn-review';
+                link.textContent = '상세 검수';
+                tdAction.appendChild(link);
+                tr.appendChild(tdAction);
+
+                tbody.appendChild(tr);
+            });
         } catch (e) {
             console.error("데이터 로드 실패:", e);
         }

--- a/backend/turip-admin/src/main/resources/templates/admin/pending-list.html
+++ b/backend/turip-admin/src/main/resources/templates/admin/pending-list.html
@@ -151,10 +151,17 @@
 
 <script>
     async function loadPendingList() {
+        const tbody = document.getElementById('pendingTableBody');
         try {
             const res = await fetch('/api/v1/admin/content-pendings/list');
+
+            if (!res.ok) {
+                const errorData = await res.json().catch(() => null);
+                const errorMessage = errorData?.message || `서버 오류 (${res.status})`;
+                throw new Error(errorMessage);
+            }
+
             const list = await res.json();
-            const tbody = document.getElementById('pendingTableBody');
 
             if (list.length === 0) {
                 tbody.innerHTML = '<tr><td colspan="5" class="text-center py-5 text-muted">검수 대기 중인 콘텐츠가 없습니다.</td></tr>';
@@ -206,6 +213,7 @@
             });
         } catch (e) {
             console.error("데이터 로드 실패:", e);
+            tbody.innerHTML = '<tr><td colspan="5" class="text-center py-5 text-danger">⚠️ 데이터를 불러오는데 실패했습니다: ' + e.message + '</td></tr>';
         }
     }
 

--- a/backend/turip-admin/src/main/resources/templates/admin/pending-list.html
+++ b/backend/turip-admin/src/main/resources/templates/admin/pending-list.html
@@ -143,26 +143,6 @@
                 </tr>
                 </thead>
                 <tbody id="pendingTableBody">
-                <tr>
-                    <td>2</td>
-                    <td>
-                        <span class="video-title">Time Lapse</span>
-                        <span class="channel-name">TAEYEON - Topic</span>
-                    </td>
-                    <td class="collector-name">발견하는 창의적인 팔로워</td>
-                    <td class="text-center"><span class="status-badge">대기 중</span></td>
-                    <td class="text-end"><a class="btn-review" href="/admin/contents/pending/2">상세 검수</a></td>
-                </tr>
-                <tr>
-                    <td>1</td>
-                    <td>
-                        <span class="video-title">권또또, 킹키&승헌과 '동해'로 가다...</span>
-                        <span class="channel-name">한국관광공사TV</span>
-                    </td>
-                    <td class="collector-name">발견하는 창의적인 팔로워</td>
-                    <td class="text-center"><span class="status-badge">대기 중</span></td>
-                    <td class="text-end"><a class="btn-review" href="/admin/contents/pending/1">상세 검수</a></td>
-                </tr>
                 </tbody>
             </table>
         </div>

--- a/backend/turip-admin/src/main/resources/templates/admin/pending-list.html
+++ b/backend/turip-admin/src/main/resources/templates/admin/pending-list.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Turip Admin - 검수 대기 목록</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
+
+        body {
+            background: linear-gradient(135deg, #becdfd, #ffffff);
+            min-height: 100vh;
+            font-family: 'Pretendard', sans-serif;
+            padding: 40px 0;
+        }
+
+        .header {
+            background: white;
+            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+            padding: 20px 40px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            position: fixed;
+            top: 0;
+            width: 100%;
+            z-index: 1000;
+        }
+
+        .admin-card {
+            background: white;
+            border-radius: 20px;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+            padding: 35px;
+            margin-top: 60px;
+        }
+
+        .section-title {
+            font-size: 28px;
+            font-weight: 800;
+            color: #333;
+            margin-bottom: 30px;
+            border-left: 6px solid #6e8efb;
+            padding-left: 20px;
+            letter-spacing: -1px;
+        }
+
+        /* 테이블 스타일 개선 (이미지 스타일 반영) */
+        .table {
+            --bs-table-hover-bg: #f8faff;
+            vertical-align: middle;
+        }
+
+        .table thead th {
+            border-bottom: 2px solid #f0f0f0;
+            color: #444;
+            font-weight: 700;
+            font-size: 15px;
+            padding: 15px 10px;
+        }
+
+        .table tbody td {
+            padding: 20px 10px;
+            border-bottom: 1px solid #f1f1f1;
+            color: #555;
+            font-size: 14px;
+        }
+
+        /* 영상 정보 텍스트 처리 */
+        .video-title {
+            font-weight: 700;
+            color: #333;
+            font-size: 15px;
+            margin-bottom: 4px;
+            display: block;
+            line-height: 1.4;
+        }
+
+        .channel-name {
+            font-size: 13px;
+            color: #888;
+            font-weight: 500;
+        }
+
+        /* 배지 스타일 (이미지의 부드러운 노란색 배지) */
+        .status-badge {
+            display: inline-block;
+            padding: 4px 12px;
+            border-radius: 50px;
+            font-size: 12px;
+            font-weight: 700;
+            background: #fef9e7; /* 이미지와 유사한 연한 노랑 */
+            color: #d4ac0d;
+            border: 1px solid #f9ebbe;
+        }
+
+        /* 상세 검수 버튼 (이미지의 파란색 둥근 스타일) */
+        .btn-review {
+            background: #8099ff; /* 이미지와 유사한 파란색 */
+            border: none;
+            color: white;
+            padding: 10px 20px;
+            border-radius: 12px 12px 12px 2px; /* 살짝 변형된 둥근 모서리 */
+            font-size: 13px;
+            font-weight: 700;
+            transition: 0.2s;
+            text-decoration: none;
+            box-shadow: 0 4px 10px rgba(128, 153, 255, 0.3);
+        }
+
+        .btn-review:hover {
+            background: #6684ff;
+            color: white;
+            transform: translateY(-2px);
+        }
+
+        .collector-name {
+            font-weight: 600;
+            color: #444;
+        }
+    </style>
+</head>
+<body>
+
+<div class="header">
+    <h1 style="color: #667eea; font-size: 22px; font-weight: 800; margin:0;">Turip Admin</h1>
+    <a class="btn btn-sm btn-outline-primary fw-bold" href="/admin/home">홈으로 돌아가기</a>
+</div>
+
+<div class="container">
+    <div class="admin-card">
+        <h3 class="section-title">검수 대기 목록</h3>
+
+        <div class="table-responsive">
+            <table class="table table-hover">
+                <thead>
+                <tr>
+                    <th style="width: 50px;">ID</th>
+                    <th>영상 정보</th>
+                    <th style="width: 200px;">수집자</th>
+                    <th style="width: 100px; text-align: center;">상태</th>
+                    <th style="width: 120px; text-align: right;">관리</th>
+                </tr>
+                </thead>
+                <tbody id="pendingTableBody">
+                <tr>
+                    <td>2</td>
+                    <td>
+                        <span class="video-title">Time Lapse</span>
+                        <span class="channel-name">TAEYEON - Topic</span>
+                    </td>
+                    <td class="collector-name">발견하는 창의적인 팔로워</td>
+                    <td class="text-center"><span class="status-badge">대기 중</span></td>
+                    <td class="text-end"><a class="btn-review" href="/admin/contents/pending/2">상세 검수</a></td>
+                </tr>
+                <tr>
+                    <td>1</td>
+                    <td>
+                        <span class="video-title">권또또, 킹키&승헌과 '동해'로 가다...</span>
+                        <span class="channel-name">한국관광공사TV</span>
+                    </td>
+                    <td class="collector-name">발견하는 창의적인 팔로워</td>
+                    <td class="text-center"><span class="status-badge">대기 중</span></td>
+                    <td class="text-end"><a class="btn-review" href="/admin/contents/pending/1">상세 검수</a></td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<script>
+    async function loadPendingList() {
+        try {
+            const res = await fetch('/api/v1/admin/content-pendings/list');
+            const list = await res.json();
+            const tbody = document.getElementById('pendingTableBody');
+
+            if (list.length === 0) {
+                tbody.innerHTML = '<tr><td colspan="5" class="text-center py-5 text-muted">검수 대기 중인 콘텐츠가 없습니다.</td></tr>';
+                return;
+            }
+
+            tbody.innerHTML = list.map(item => `
+                <tr>
+                    <td>${item.id}</td>
+                    <td>
+                        <span class="video-title">${item.videoTitle}</span>
+                        <span class="channel-name">${item.channelName}</span>
+                    </td>
+                    <td class="collector-name">${item.collectorNickname}</td>
+                    <td class="text-center"><span class="status-badge">대기 중</span></td>
+                    <td class="text-end"><a href="/admin/contents/pending/${item.id}" class="btn-review">상세 검수</a></td>
+                </tr>
+            `).join('');
+        } catch (e) {
+            console.error("데이터 로드 실패:", e);
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', loadPendingList);
+</script>
+</body>
+</html>

--- a/backend/turip-admin/src/main/resources/templates/admin/pending-review.html
+++ b/backend/turip-admin/src/main/resources/templates/admin/pending-review.html
@@ -232,10 +232,18 @@
 
     async function approve() {
         if(!confirm("이 콘텐츠를 최종 승인하시겠습니까?")) return;
-        const res = await fetch(`/api/v1/admin/content-pendings/${pendingId}/approve`, { method: 'POST' });
-        if(res.ok) {
-            alert("승인이 완료되었습니다!");
-            location.href = "/admin/contents/pending";
+        try {
+            const res = await fetch(`/api/v1/admin/content-pendings/${pendingId}/approve`, { method: 'POST' });
+            if(res.ok) {
+                alert("승인이 완료되었습니다!");
+                location.href = "/admin/contents/pending";
+            } else {
+                const errorData = await res.json().catch(() => null);
+                const errorMessage = errorData?.message || `승인 실패 (${res.status})`;
+                alert("⚠️ " + errorMessage);
+            }
+        } catch (e) {
+            alert("⚠️ 승인 처리 중 오류가 발생했습니다: " + e.message);
         }
     }
 
@@ -248,15 +256,23 @@
         const rejectReason = document.getElementById('rejectReason').value;
         if(!rejectReason) return alert("반려 사유를 입력해주세요.");
 
-        const res = await fetch(`/api/v1/admin/content-pendings/${pendingId}/reject`, {
-            method: 'POST',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({ rejectReason })
-        });
+        try {
+            const res = await fetch(`/api/v1/admin/content-pendings/${pendingId}/reject`, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({ rejectReason })
+            });
 
-        if(res.ok) {
-            alert("반려 처리가 완료되었습니다.");
-            location.href = "/admin/contents/pending";
+            if(res.ok) {
+                alert("반려 처리가 완료되었습니다.");
+                location.href = "/admin/contents/pending";
+            } else {
+                const errorData = await res.json().catch(() => null);
+                const errorMessage = errorData?.message || `반려 실패 (${res.status})`;
+                alert("⚠️ " + errorMessage);
+            }
+        } catch (e) {
+            alert("⚠️ 반려 처리 중 오류가 발생했습니다: " + e.message);
         }
     }
 

--- a/backend/turip-admin/src/main/resources/templates/admin/pending-review.html
+++ b/backend/turip-admin/src/main/resources/templates/admin/pending-review.html
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Turip Admin - 상세 검수</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <style>
+        @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
+
+        body {
+            background: linear-gradient(135deg, #becdfd, #ffffff);
+            min-height: 100vh;
+            padding-bottom: 60px;
+            font-family: 'Pretendard', sans-serif;
+        }
+
+        .header {
+            background: white;
+            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+            padding: 20px 40px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            position: fixed;
+            top: 0;
+            width: 100%;
+            z-index: 1000;
+        }
+
+        /* 카드 UI (수집 페이지와 동일한 둥근 모서리 및 그림자) */
+        .admin-card {
+            background: white;
+            border-radius: 20px;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+            padding: 30px;
+            margin-bottom: 25px;
+            border: none;
+        }
+
+        .section-title {
+            font-weight: 800;
+            color: #333;
+            margin-bottom: 25px;
+            border-left: 5px solid #6e8efb;
+            padding-left: 15px;
+            font-size: 1.1rem;
+            display: flex;
+            align-items: center;
+        }
+
+        /* 장소 리스트 스타일 */
+        .place-item {
+            background: #f8faff;
+            border: 1px solid #edf2f7;
+            border-radius: 16px;
+            padding: 20px;
+            margin-bottom: 15px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            transition: 0.2s;
+        }
+        .place-item:hover { border-color: #6e8efb; transform: translateX(5px); }
+
+        .day-badge {
+            background: #6e8efb;
+            color: white;
+            font-size: 11px;
+            font-weight: 700;
+            padding: 4px 10px;
+            border-radius: 8px;
+            margin-bottom: 8px;
+            display: inline-block;
+        }
+
+        /* 우측 정보 테이블 스타일 */
+        .info-table { width: 100%; border-top: 1px solid #f0f0f0; }
+        .info-table td { padding: 12px 0; border-bottom: 1px solid #f0f0f0; font-size: 14px; }
+        .info-label { color: #888; width: 80px; }
+        .info-value { text-align: right; font-weight: 700; color: #333; }
+
+        /* 버튼 스타일 (스크린샷 반영) */
+        .btn-approve { background-color: #1a9a5a; border: none; font-weight: 700; font-size: 16px; padding: 12px; }
+        .btn-reject-trigger {
+            background: white;
+            color: #dc3545;
+            border: 1px solid #dc3545;
+            font-weight: 600;
+            padding: 10px;
+            margin-top: 8px;
+        }
+        .btn-reject-trigger:hover { background: #fff5f5; color: #dc3545; }
+
+        .reject-box { background: #fff8f8; border: 1px solid #ffe3e3; border-radius: 15px; padding: 20px; display: none; margin-top: 15px; }
+
+        #video_preview { border-radius: 15px; overflow: hidden; background: #000; }
+    </style>
+</head>
+<body>
+
+<div class="header">
+    <h1 style="color: #667eea; font-size: 22px; font-weight: 800; margin:0;">Turip Admin</h1>
+    <a class="btn btn-sm btn-outline-primary fw-bold" href="/admin/contents/pending">목록으로</a>
+</div>
+
+<div class="container" style="margin-top: 80px;">
+    <div class="row">
+        <div class="col-lg-8">
+            <div class="admin-card">
+                <h3 class="section-title">1. 영상 및 기본 정보</h3>
+                <div class="mb-4">
+                    <h4 id="display_title" class="fw-bold mb-1" style="letter-spacing: -0.5px;">-</h4>
+                    <p id="display_channel" class="text-primary fw-bold small mb-3"></p>
+                </div>
+                <div id="video_preview" class="ratio ratio-16x9">
+                    <iframe id="video_iframe" src="" title="YouTube" allowfullscreen style="border: none;"></iframe>
+                </div>
+            </div>
+
+            <div class="admin-card">
+                <h3 class="section-title">2. 수집된 장소 (경로)</h3>
+                <div id="placeListContainer">
+                </div>
+            </div>
+        </div>
+
+        <div class="col-lg-4">
+            <div class="admin-card">
+                <h3 class="section-title">검수 처리</h3>
+                <div class="d-grid gap-2">
+                    <button class="btn btn-approve btn-lg text-white shadow-sm" onclick="approve()">
+                        <i class="fa-solid fa-check-double me-2"></i>최종 승인
+                    </button>
+                    <button class="btn btn-reject-trigger btn-sm" onclick="toggleReject()">
+                        <i class="fa-solid fa-rotate-left me-2"></i>반려(Reject)
+                    </button>
+                </div>
+
+                <div id="rejectArea" class="reject-box">
+                    <label class="form-label fw-bold text-danger small">반려 사유</label>
+                    <textarea id="rejectReason" class="form-control mb-3 form-control-sm" rows="4" placeholder="수집자가 확인할 피드백을 입력하세요."></textarea>
+                    <button class="btn btn-danger btn-sm w-100 fw-bold" onclick="reject()">반려 전송</button>
+                </div>
+            </div>
+
+            <div class="admin-card">
+                <h3 class="section-title" style="border-left-color: #ced4da; font-size: 15px;">수집 정보 요약</h3>
+                <table class="info-table">
+                    <tr>
+                        <td class="info-label">도시</td>
+                        <td class="info-value text-primary" id="display_city">-</td>
+                    </tr>
+                    <tr>
+                        <td class="info-label">수집자</td>
+                        <td class="info-value" id="display_collector">-</td>
+                    </tr>
+                    <tr>
+                        <td class="info-label">요청일</td>
+                        <td class="info-value" id="display_date">-</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script th:inline="javascript">
+    const pendingId = [[${pendingId}]];
+
+    async function loadDetail() {
+        try {
+            const res = await fetch(`/api/v1/admin/content-pendings/${pendingId}`);
+            const data = await res.json();
+
+            // 상단 정보 바인딩
+            document.getElementById('display_title').innerText = data.contentData.video.title;
+            document.getElementById('display_channel').innerText = data.contentData.video.channelName;
+            document.getElementById('display_city').innerText = data.contentData.cityName;
+            document.getElementById('display_collector').innerText = data.collectorAccount.nickname;
+            document.getElementById('display_date').innerText = new Date(data.createdAt).toLocaleDateString();
+
+            // 유튜브 임베드
+            const vId = data.contentData.video.videoId;
+            document.getElementById('video_iframe').src = `https://www.youtube.com/embed/${vId}`;
+
+            // 장소 리스트 렌더링
+            const container = document.getElementById('placeListContainer');
+            container.innerHTML = data.contentData.contentPlaces.map(p => `
+                <div class="place-item">
+                    <div>
+                        <span class="day-badge">${p.visitDay}일차 - ${p.visitOrder}번</span>
+                        <h6 class="fw-bold mb-1" style="font-size: 16px;">${p.place.name}</h6>
+                        <div class="text-muted small"><i class="fa-solid fa-location-dot me-1"></i> ${p.place.address}</div>
+                    </div>
+                    <div class="text-end">
+                        <span class="badge bg-light text-dark border fw-bold" style="font-size: 13px;">🕒 ${p.timeLine}</span>
+                    </div>
+                </div>
+            `).join('');
+        } catch (e) {
+            console.error(e);
+            alert("데이터 로드 중 에러가 발생했습니다.");
+        }
+    }
+
+    async function approve() {
+        if(!confirm("이 콘텐츠를 최종 승인하시겠습니까?")) return;
+        const res = await fetch(`/api/v1/admin/content-pendings/${pendingId}/approve`, { method: 'POST' });
+        if(res.ok) {
+            alert("승인이 완료되었습니다!");
+            location.href = "/admin/contents/pending";
+        }
+    }
+
+    function toggleReject() {
+        const area = document.getElementById('rejectArea');
+        area.style.display = area.style.display === 'none' ? 'block' : 'none';
+    }
+
+    async function reject() {
+        const rejectReason = document.getElementById('rejectReason').value;
+        if(!rejectReason) return alert("반려 사유를 입력해주세요.");
+
+        const res = await fetch(`/api/v1/admin/content-pendings/${pendingId}/reject`, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({ rejectReason })
+        });
+
+        if(res.ok) {
+            alert("반려 처리가 완료되었습니다.");
+            location.href = "/admin/contents/pending";
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', loadDetail);
+</script>
+</body>
+</html>

--- a/backend/turip-admin/src/main/resources/templates/admin/pending-review.html
+++ b/backend/turip-admin/src/main/resources/templates/admin/pending-review.html
@@ -186,18 +186,44 @@
 
             // 장소 리스트 렌더링
             const container = document.getElementById('placeListContainer');
-            container.innerHTML = data.contentData.contentPlaces.map(p => `
-                <div class="place-item">
-                    <div>
-                        <span class="day-badge">${p.visitDay}일차 - ${p.visitOrder}번</span>
-                        <h6 class="fw-bold mb-1" style="font-size: 16px;">${p.place.name}</h6>
-                        <div class="text-muted small"><i class="fa-solid fa-location-dot me-1"></i> ${p.place.address}</div>
-                    </div>
-                    <div class="text-end">
-                        <span class="badge bg-light text-dark border fw-bold" style="font-size: 13px;">🕒 ${p.timeLine}</span>
-                    </div>
-                </div>
-            `).join('');
+            container.innerHTML = '';
+            data.contentData.contentPlaces.forEach(p => {
+                const placeItem = document.createElement('div');
+                placeItem.className = 'place-item';
+
+                const leftDiv = document.createElement('div');
+                const dayBadge = document.createElement('span');
+                dayBadge.className = 'day-badge';
+                dayBadge.textContent = `${p.visitDay}일차 - ${p.visitOrder}번`;
+                leftDiv.appendChild(dayBadge);
+
+                const placeName = document.createElement('h6');
+                placeName.className = 'fw-bold mb-1';
+                placeName.style.fontSize = '16px';
+                placeName.textContent = p.place.name;
+                leftDiv.appendChild(placeName);
+
+                const addressDiv = document.createElement('div');
+                addressDiv.className = 'text-muted small';
+                const icon = document.createElement('i');
+                icon.className = 'fa-solid fa-location-dot me-1';
+                addressDiv.appendChild(icon);
+                addressDiv.appendChild(document.createTextNode(' ' + p.place.address));
+                leftDiv.appendChild(addressDiv);
+
+                placeItem.appendChild(leftDiv);
+
+                const rightDiv = document.createElement('div');
+                rightDiv.className = 'text-end';
+                const timeBadge = document.createElement('span');
+                timeBadge.className = 'badge bg-light text-dark border fw-bold';
+                timeBadge.style.fontSize = '13px';
+                timeBadge.textContent = `🕒 ${p.timeLine}`;
+                rightDiv.appendChild(timeBadge);
+                placeItem.appendChild(rightDiv);
+
+                container.appendChild(placeItem);
+            });
         } catch (e) {
             console.error(e);
             alert("데이터 로드 중 에러가 발생했습니다.");

--- a/backend/turip-admin/src/test/java/turip/controller/AdminContentApiTest.java
+++ b/backend/turip-admin/src/test/java/turip/controller/AdminContentApiTest.java
@@ -1,0 +1,122 @@
+package turip.controller;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import turip.account.domain.Account;
+import turip.account.domain.Role;
+import turip.content.domain.ContentPending;
+import turip.content.domain.ContentPendingData;
+import turip.content.repository.ContentPendingRepository;
+import turip.util.fixture.AccountFixture;
+import turip.util.fixture.ContentPendingFixture;
+import turip.util.helper.TestDataHelper;
+
+@ActiveProfiles("test")
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = turip.TuripAdminApplication.class
+)
+class AdminContentApiTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestDataHelper testDataHelper;
+
+    @Autowired
+    private ContentPendingRepository contentPendingRepository;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        testDataHelper.cleanDatabase();
+    }
+
+    @Nested
+    @DisplayName("/api/v1/admin/contents/my GET 나의 콘텐츠 수집 내역 조회 테스트")
+    class GetMyHistoryTest {
+
+        @Test
+        @DisplayName("관리자가 자신의 콘텐츠 수집 내역을 조회하면 200 OK와 수집 내역 리스트를 응답한다")
+        void getMyHistory_Success() {
+            // given
+            Account collectorAccount = AccountFixture.createCustomAccount(1L, Role.ADMIN);
+            Long collectorAccountId = testDataHelper.insertAccount(collectorAccount);
+            ReflectionTestUtils.setField(collectorAccount, "id", collectorAccountId);
+
+            testDataHelper.insertTuripMember(collectorAccountId, "admin@turip.com", false, "admin", "password123!");
+            String adminAccessToken = testDataHelper.createAccessToken(collectorAccountId, Role.ADMIN);
+
+            ContentPendingData contentData1 = ContentPendingFixture.createTestContentData("서울");
+            ContentPending contentPending1 = new ContentPending(contentData1, collectorAccount, null, null, null);
+            contentPendingRepository.save(contentPending1);
+
+            ContentPendingData contentData2 = ContentPendingFixture.createTestContentData("부산");
+            ContentPending contentPending2 = new ContentPending(contentData2, collectorAccount, null, null, null);
+            contentPendingRepository.save(contentPending2);
+
+            // when & then
+            RestAssured.given().port(port)
+                    .header("Authorization", "Bearer " + adminAccessToken)
+                    .when().get("/api/v1/admin/contents/my")
+                    .then()
+                    .statusCode(200)
+                    .body("$", hasSize(2))
+                    .body("[0].id", notNullValue())
+                    .body("[0].videoTitle", is("테스트 비디오"))
+                    .body("[0].cityName", is("부산"))
+                    .body("[0].status", is("PENDING"))
+                    .body("[0].rejectReason", nullValue())
+                    .body("[1].id", notNullValue())
+                    .body("[1].videoTitle", is("테스트 비디오"))
+                    .body("[1].cityName", is("서울"))
+                    .body("[1].status", is("PENDING"));
+        }
+
+        @Test
+        @DisplayName("관리자가 수집 내역이 없는 경우 빈 리스트를 응답한다")
+        void getMyHistory_EmptyList() {
+            // given
+            Long adminAccountId = testDataHelper.insertAccount(Role.ADMIN);
+            testDataHelper.insertTuripMember(adminAccountId, "admin@turip.com", false, "admin", "password123!");
+            String adminAccessToken = testDataHelper.createAccessToken(adminAccountId, Role.ADMIN);
+
+            // when & then
+            RestAssured.given().port(port)
+                    .header("Authorization", "Bearer " + adminAccessToken)
+                    .when().get("/api/v1/admin/contents/my")
+                    .then()
+                    .statusCode(200)
+                    .body("$", hasSize(0));
+        }
+
+        @Test
+        @DisplayName("관리자가 아닌 사용자가 수집 내역을 조회하면 403 Forbidden을 응답한다")
+        void getMyHistory_Forbidden() {
+            // given
+            Long userAccountId = testDataHelper.insertAccount(Role.USER);
+            String userAccessToken = testDataHelper.createAccessToken(userAccountId, Role.USER);
+
+            // when & then
+            RestAssured.given().port(port)
+                    .header("Authorization", "Bearer " + userAccessToken)
+                    .when().get("/api/v1/admin/contents/my")
+                    .then()
+                    .statusCode(403);
+        }
+    }
+}

--- a/backend/turip-admin/src/test/java/turip/controller/AdminPendingContentApiTest.java
+++ b/backend/turip-admin/src/test/java/turip/controller/AdminPendingContentApiTest.java
@@ -1,5 +1,6 @@
 package turip.controller;
 
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -12,10 +13,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 import turip.account.domain.Account;
 import turip.account.domain.Role;
+import turip.container.TestContainerConfig;
 import turip.content.domain.ContentPending;
 import turip.content.domain.ContentPendingData;
 import turip.content.repository.ContentPendingRepository;
@@ -24,12 +27,12 @@ import turip.util.fixture.AccountFixture;
 import turip.util.fixture.ContentPendingFixture;
 import turip.util.helper.TestDataHelper;
 
-@ActiveProfiles("test")
+@ActiveProfiles("test-mysql")
 @SpringBootTest(
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         classes = turip.TuripAdminApplication.class
 )
-class AdminPendingContentApiTest {
+class AdminPendingContentApiTest extends TestContainerConfig {
 
     @LocalServerPort
     private int port;
@@ -38,12 +41,36 @@ class AdminPendingContentApiTest {
     private TestDataHelper testDataHelper;
 
     @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
     private ContentPendingRepository contentPendingRepository;
 
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
-        testDataHelper.cleanDatabase();
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0");
+
+        jdbcTemplate.execute("TRUNCATE TABLE place_category");
+        jdbcTemplate.execute("TRUNCATE TABLE content_place");
+        jdbcTemplate.execute("TRUNCATE TABLE place");
+        jdbcTemplate.execute("TRUNCATE TABLE category");
+        jdbcTemplate.execute("TRUNCATE TABLE favorite_folder_account");
+        jdbcTemplate.execute("TRUNCATE TABLE favorite_folder");
+        jdbcTemplate.execute("TRUNCATE TABLE favorite_content");
+        jdbcTemplate.execute("TRUNCATE TABLE content_pending");
+        jdbcTemplate.execute("TRUNCATE TABLE guest");
+        jdbcTemplate.execute("TRUNCATE TABLE turip_member");
+        jdbcTemplate.execute("TRUNCATE TABLE social_member");
+        jdbcTemplate.execute("TRUNCATE TABLE member");
+        jdbcTemplate.execute("TRUNCATE TABLE account");
+        jdbcTemplate.execute("TRUNCATE TABLE content");
+        jdbcTemplate.execute("TRUNCATE TABLE creator");
+        jdbcTemplate.execute("TRUNCATE TABLE city");
+        jdbcTemplate.execute("TRUNCATE TABLE country");
+        jdbcTemplate.execute("TRUNCATE TABLE province");
+
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1");
     }
 
     @Nested
@@ -299,6 +326,197 @@ class AdminPendingContentApiTest {
                     .then()
                     .log().all()
                     .statusCode(400);
+        }
+    }
+
+    @DisplayName("/api/v1/admin/content-pendings POST 펜딩 콘텐츠 등록 테스트")
+    @Nested
+    class PendingContentTest {
+
+        @DisplayName("관리자가 콘텐츠를 pending 상태로 등록하면 201 CREATED와 contentPendingId를 응답한다")
+        @Test
+        void pending_Success() {
+            // given
+            Long adminAccountId = testDataHelper.insertAccount(Role.ADMIN);
+            testDataHelper.insertTuripMember(adminAccountId, "admin@turip.com", false, "admin", "password123!");
+            String adminAccessToken = testDataHelper.createAccessToken(adminAccountId, Role.ADMIN);
+
+            // validator로 지정될 다른 admin 계정 생성
+            Long validatorAccountId = testDataHelper.insertAccount(Role.ADMIN);
+            testDataHelper.insertTuripMember(validatorAccountId, "validator@turip.com", false, "validator", "password123!");
+
+            ContentPendingData contentData = ContentPendingFixture.createTestContentData("서울");
+
+            // when & then
+            RestAssured.given().port(port)
+                    .contentType(ContentType.JSON)
+                    .header("Authorization", "Bearer " + adminAccessToken)
+                    .body(contentData)
+                    .when().post("/api/v1/admin/content-pendings")
+                    .then()
+                    .log().all()
+                    .statusCode(201)
+                    .body(notNullValue());
+        }
+
+        @DisplayName("관리자가 아닌 사용자가 콘텐츠를 등록하려 하면 403 Forbidden을 응답한다")
+        @Test
+        void pending_Forbidden() {
+            // given
+            Long userAccountId = testDataHelper.insertAccount(Role.USER);
+            String userAccessToken = testDataHelper.createAccessToken(userAccountId, Role.USER);
+
+            ContentPendingData contentData = ContentPendingFixture.createTestContentData("서울");
+
+            // when & then
+            RestAssured.given().port(port)
+                    .contentType(ContentType.JSON)
+                    .header("Authorization", "Bearer " + userAccessToken)
+                    .body(contentData)
+                    .when().post("/api/v1/admin/content-pendings")
+                    .then()
+                    .statusCode(403);
+        }
+
+        @DisplayName("이미 PENDING 상태인 동일 영상을 등록하려 하면 409 Conflict를 응답한다")
+        @Test
+        void pending_Conflict() {
+            // given
+            Long adminAccountId = testDataHelper.insertAccount(Role.ADMIN);
+            testDataHelper.insertTuripMember(adminAccountId, "admin@turip.com", false, "admin", "password123!");
+            String adminAccessToken = testDataHelper.createAccessToken(adminAccountId, Role.ADMIN);
+
+            // validator로 지정될 다른 admin 계정 생성
+            Long validatorAccountId = testDataHelper.insertAccount(Role.ADMIN);
+            testDataHelper.insertTuripMember(validatorAccountId, "validator@turip.com", false, "validator", "password123!");
+
+            Account collectorAccount = AccountFixture.createCustomAccount(1L, Role.ADMIN);
+            Long collectorAccountId = testDataHelper.insertAccount(collectorAccount);
+            ReflectionTestUtils.setField(collectorAccount, "id", collectorAccountId);
+
+            ContentPendingData contentData = ContentPendingFixture.createTestContentData("서울");
+            ContentPending contentPending = new ContentPending(contentData, collectorAccount, null, null, null);
+            contentPendingRepository.save(contentPending);
+
+            // when & then
+            RestAssured.given().port(port)
+                    .contentType(ContentType.JSON)
+                    .header("Authorization", "Bearer " + adminAccessToken)
+                    .body(contentData)
+                    .when().post("/api/v1/admin/content-pendings")
+                    .then()
+                    .statusCode(409);
+        }
+    }
+
+    @DisplayName("/api/v1/admin/content-pendings/list GET 펜딩 콘텐츠 목록 조회 테스트")
+    @Nested
+    class FindAllContentPendingTest {
+
+        @DisplayName("관리자가 펜딩 콘텐츠 목록을 조회하면 200 OK와 PENDING 상태의 콘텐츠 리스트를 응답한다")
+        @Test
+        void findAll_Success() {
+            // given
+            Long adminAccountId = testDataHelper.insertAccount(Role.ADMIN);
+            testDataHelper.insertTuripMember(adminAccountId, "admin@turip.com", false, "admin", "password123!");
+            String adminAccessToken = testDataHelper.createAccessToken(adminAccountId, Role.ADMIN);
+
+            Account collectorAccount1 = AccountFixture.createCustomAccount(1L, Role.ADMIN);
+            Long collectorAccountId1 = testDataHelper.insertAccount(collectorAccount1);
+            ReflectionTestUtils.setField(collectorAccount1, "id", collectorAccountId1);
+
+            Account collectorAccount2 = AccountFixture.createCustomAccount(2L, Role.ADMIN);
+            Long collectorAccountId2 = testDataHelper.insertAccount(collectorAccount2);
+            ReflectionTestUtils.setField(collectorAccount2, "id", collectorAccountId2);
+
+            ContentPendingData contentData1 = ContentPendingFixture.createTestContentData("서울");
+            ContentPending contentPending1 = new ContentPending(contentData1, collectorAccount1, null, null, null);
+            contentPendingRepository.save(contentPending1);
+
+            ContentPendingData contentData2 = ContentPendingFixture.createTestContentData("부산");
+            ContentPending contentPending2 = new ContentPending(contentData2, collectorAccount2, null, null, null);
+            contentPendingRepository.save(contentPending2);
+
+            // when & then
+            RestAssured.given().port(port)
+                    .header("Authorization", "Bearer " + adminAccessToken)
+                    .when().get("/api/v1/admin/content-pendings/list")
+                    .then()
+                    .statusCode(200)
+                    .body("$", hasSize(2))
+                    .body("[0].id", notNullValue())
+                    .body("[0].videoTitle", is("테스트 비디오"))
+                    .body("[0].channelName", is("테스트 채널"))
+                    .body("[0].collectorNickname", notNullValue())
+                    .body("[0].createdAt", notNullValue())
+                    .body("[1].id", notNullValue())
+                    .body("[1].videoTitle", is("테스트 비디오"))
+                    .body("[1].channelName", is("테스트 채널"));
+        }
+
+        @DisplayName("펜딩 콘텐츠가 없는 경우 빈 리스트를 응답한다")
+        @Test
+        void findAll_EmptyList() {
+            // given
+            Long adminAccountId = testDataHelper.insertAccount(Role.ADMIN);
+            testDataHelper.insertTuripMember(adminAccountId, "admin@turip.com", false, "admin", "password123!");
+            String adminAccessToken = testDataHelper.createAccessToken(adminAccountId, Role.ADMIN);
+
+            // when & then
+            RestAssured.given().port(port)
+                    .header("Authorization", "Bearer " + adminAccessToken)
+                    .when().get("/api/v1/admin/content-pendings/list")
+                    .then()
+                    .statusCode(200)
+                    .body("$", hasSize(0));
+        }
+
+        @DisplayName("PENDING 상태가 아닌 콘텐츠는 목록에 포함되지 않는다")
+        @Test
+        void findAll_OnlyPendingStatus() {
+            // given
+            Long adminAccountId = testDataHelper.insertAccount(Role.ADMIN);
+            testDataHelper.insertTuripMember(adminAccountId, "admin@turip.com", false, "admin", "password123!");
+            String adminAccessToken = testDataHelper.createAccessToken(adminAccountId, Role.ADMIN);
+
+            Account collectorAccount = AccountFixture.createCustomAccount(1L, Role.ADMIN);
+            Long collectorAccountId = testDataHelper.insertAccount(collectorAccount);
+            ReflectionTestUtils.setField(collectorAccount, "id", collectorAccountId);
+
+            // PENDING 콘텐츠
+            ContentPendingData contentData1 = ContentPendingFixture.createTestContentData("서울");
+            ContentPending contentPending1 = new ContentPending(contentData1, collectorAccount, null, null, null);
+            contentPendingRepository.save(contentPending1);
+
+            // REJECTED 콘텐츠
+            ContentPendingData contentData2 = ContentPendingFixture.createTestContentData("부산");
+            ContentPending contentPending2 = new ContentPending(contentData2, collectorAccount, null, null, null);
+            contentPending2.reject(collectorAccount, "거절 사유");
+            contentPendingRepository.save(contentPending2);
+
+            // when & then
+            RestAssured.given().port(port)
+                    .header("Authorization", "Bearer " + adminAccessToken)
+                    .when().get("/api/v1/admin/content-pendings/list")
+                    .then()
+                    .statusCode(200)
+                    .body("$", hasSize(1))
+                    .body("[0].id", is(1));
+        }
+
+        @DisplayName("관리자가 아닌 사용자가 목록을 조회하면 403 Forbidden을 응답한다")
+        @Test
+        void findAll_Forbidden() {
+            // given
+            Long userAccountId = testDataHelper.insertAccount(Role.USER);
+            String userAccessToken = testDataHelper.createAccessToken(userAccountId, Role.USER);
+
+            // when & then
+            RestAssured.given().port(port)
+                    .header("Authorization", "Bearer " + userAccessToken)
+                    .when().get("/api/v1/admin/content-pendings/list")
+                    .then()
+                    .statusCode(403);
         }
     }
 }

--- a/backend/turip-admin/src/test/java/turip/controller/AdminPendingContentApiTest.java
+++ b/backend/turip-admin/src/test/java/turip/controller/AdminPendingContentApiTest.java
@@ -173,6 +173,30 @@ class AdminPendingContentApiTest {
                     .then()
                     .statusCode(404);
         }
+
+        @Test
+        @DisplayName("자신이 수집한 콘텐츠를 승인하려 할 때 400 Bad Request를 응답한다")
+        void approveContentPending_ValidatorNotValid() {
+            // given
+            Account collectorAccount = AccountFixture.createCustomAccount(1L, Role.ADMIN);
+            Long collectorAccountId = testDataHelper.insertAccount(collectorAccount);
+            ReflectionTestUtils.setField(collectorAccount, "id", collectorAccountId);
+
+            testDataHelper.insertTuripMember(collectorAccountId, "admin@turip.com", false, "admin", "password123!");
+            String collectorAccessToken = testDataHelper.createAccessToken(collectorAccountId, Role.ADMIN);
+
+            testDataHelper.insertCity("서울");
+            ContentPendingData contentData = ContentPendingFixture.createTestContentData("서울");
+            ContentPending contentPending = new ContentPending(contentData, collectorAccount, null, null, null);
+            contentPendingRepository.save(contentPending);
+
+            // when & then
+            RestAssured.given().port(port)
+                    .header("Authorization", "Bearer " + collectorAccessToken)
+                    .when().post("/api/v1/admin/content-pendings/{id}/approve", 1)
+                    .then()
+                    .statusCode(400);
+        }
     }
 
     @DisplayName("/api/v1/admin/content-pendings/{id}/reject POST 펜딩 콘텐츠 거절 테스트")

--- a/backend/turip-admin/src/test/java/turip/service/AdminContentPendingServiceTest.java
+++ b/backend/turip-admin/src/test/java/turip/service/AdminContentPendingServiceTest.java
@@ -21,7 +21,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import turip.account.domain.Account;
 import turip.account.domain.Role;
+import turip.account.repository.AccountRepository;
 import turip.common.exception.ErrorTag;
+import turip.common.exception.custom.ConflictException;
 import turip.common.exception.custom.NotFoundException;
 import turip.content.domain.Content;
 import turip.content.domain.ContentPending;
@@ -33,6 +35,8 @@ import turip.controller.dto.request.AdminContentSaveRequest;
 import turip.controller.dto.request.ContentPendingRejectRequest;
 import turip.controller.dto.response.ContentPendingApprovalResponse;
 import turip.controller.dto.response.ContentPendingResponse;
+import turip.controller.dto.response.MyCollectContentResponse;
+import turip.controller.dto.response.PendingListResponse;
 import turip.util.fixture.AccountFixture;
 import turip.util.fixture.ContentFixture;
 
@@ -50,6 +54,9 @@ class AdminContentPendingServiceTest {
 
     @Mock
     private AdminContentService adminContentService;
+
+    @Mock
+    private AccountRepository accountRepository;
 
     private ContentPending contentPending;
     private Account validatorAccount;
@@ -231,6 +238,277 @@ class AdminContentPendingServiceTest {
             assertThatThrownBy(() -> adminContentPendingService.reject(invalidId, validatorAccount, request))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage(ErrorTag.CONTENT_PENDING_NOT_FOUND.getMessage());
+        }
+    }
+
+    @DisplayName("getMyHistory() 테스트")
+    @Nested
+    class GetMyHistory {
+
+        @DisplayName("관리자 자신이 수집한 콘텐츠 내역을 조회할 수 있다")
+        @Test
+        void getMyHistory1() {
+            // given
+            ContentPending pending1 = new ContentPending(contentData, collectorAccount, validatorAccount, null, null);
+            ReflectionTestUtils.setField(pending1, "id", 1L);
+
+            ContentPendingData.VideoData videoData2 = new ContentPendingData.VideoData(
+                    "videoId456",
+                    "Test Title 2",
+                    "http://test2.url",
+                    "Test Channel 2",
+                    "http://channel2.image",
+                    LocalDate.now()
+            );
+            ContentPendingData contentData2 = new ContentPendingData(
+                    "Busan",
+                    videoData2,
+                    contentData.contentPlaces()
+            );
+            ContentPending pending2 = new ContentPending(contentData2, collectorAccount, validatorAccount, null, null);
+            ReflectionTestUtils.setField(pending2, "id", 2L);
+            ReflectionTestUtils.setField(pending2, "status", ContentPendingStatus.APPROVED);
+
+            given(contentPendingRepository.findAllByCollectorAccountOrderByIdDesc(collectorAccount))
+                    .willReturn(List.of(pending2, pending1));
+
+            // when
+            List<MyCollectContentResponse> responses = adminContentPendingService.getMyHistory(collectorAccount);
+
+            // then
+            assertAll(
+                    () -> assertThat(responses).hasSize(2),
+                    () -> assertThat(responses.get(0).id()).isEqualTo(2L),
+                    () -> assertThat(responses.get(0).videoTitle()).isEqualTo("Test Title 2"),
+                    () -> assertThat(responses.get(0).cityName()).isEqualTo("Busan"),
+                    () -> assertThat(responses.get(0).status()).isEqualTo("APPROVED"),
+                    () -> assertThat(responses.get(1).id()).isEqualTo(1L),
+                    () -> assertThat(responses.get(1).videoTitle()).isEqualTo("Test Title"),
+                    () -> assertThat(responses.get(1).cityName()).isEqualTo("Seoul"),
+                    () -> assertThat(responses.get(1).status()).isEqualTo("PENDING"),
+                    () -> verify(contentPendingRepository).findAllByCollectorAccountOrderByIdDesc(collectorAccount)
+            );
+        }
+
+        @DisplayName("수집한 콘텐츠 내역이 없는 경우 빈 리스트를 반환한다")
+        @Test
+        void getMyHistory2() {
+            // given
+            given(contentPendingRepository.findAllByCollectorAccountOrderByIdDesc(collectorAccount))
+                    .willReturn(List.of());
+
+            // when
+            List<MyCollectContentResponse> responses = adminContentPendingService.getMyHistory(collectorAccount);
+
+            // then
+            assertAll(
+                    () -> assertThat(responses).isEmpty(),
+                    () -> verify(contentPendingRepository).findAllByCollectorAccountOrderByIdDesc(collectorAccount)
+            );
+        }
+
+        @DisplayName("거절된 콘텐츠의 경우 거절 사유를 포함하여 반환한다")
+        @Test
+        void getMyHistory3() {
+            // given
+            ContentPending rejectedPending = new ContentPending(contentData, collectorAccount, validatorAccount, null, null);
+            ReflectionTestUtils.setField(rejectedPending, "id", 3L);
+            ReflectionTestUtils.setField(rejectedPending, "status", ContentPendingStatus.REJECTED);
+            ReflectionTestUtils.setField(rejectedPending, "rejectReason", "부적절한 콘텐츠");
+
+            given(contentPendingRepository.findAllByCollectorAccountOrderByIdDesc(collectorAccount))
+                    .willReturn(List.of(rejectedPending));
+
+            // when
+            List<MyCollectContentResponse> responses = adminContentPendingService.getMyHistory(collectorAccount);
+
+            // then
+            assertAll(
+                    () -> assertThat(responses).hasSize(1),
+                    () -> assertThat(responses.get(0).id()).isEqualTo(3L),
+                    () -> assertThat(responses.get(0).status()).isEqualTo("REJECTED"),
+                    () -> assertThat(responses.get(0).rejectReason()).isEqualTo("부적절한 콘텐츠")
+            );
+        }
+    }
+
+    @DisplayName("findAll() 테스트")
+    @Nested
+    class FindAll {
+
+        @DisplayName("PENDING 상태의 모든 콘텐츠를 ID 내림차순으로 조회할 수 있다")
+        @Test
+        void findAll1() {
+            // given
+            ContentPending pending1 = new ContentPending(contentData, collectorAccount, validatorAccount, null, null);
+            ReflectionTestUtils.setField(pending1, "id", 1L);
+
+            ContentPendingData.VideoData videoData2 = new ContentPendingData.VideoData(
+                    "videoId456",
+                    "Test Title 2",
+                    "http://test2.url",
+                    "Test Channel 2",
+                    "http://channel2.image",
+                    LocalDate.now()
+            );
+            ContentPendingData contentData2 = new ContentPendingData(
+                    "Busan",
+                    videoData2,
+                    contentData.contentPlaces()
+            );
+            ContentPending pending2 = new ContentPending(contentData2, collectorAccount, validatorAccount, null, null);
+            ReflectionTestUtils.setField(pending2, "id", 2L);
+
+            given(contentPendingRepository.findAllByStatusOrderByIdDesc(ContentPendingStatus.PENDING))
+                    .willReturn(List.of(pending2, pending1));
+
+            // when
+            List<PendingListResponse> responses = adminContentPendingService.findAll();
+
+            // then
+            assertAll(
+                    () -> assertThat(responses).hasSize(2),
+                    () -> assertThat(responses.get(0).id()).isEqualTo(2L),
+                    () -> assertThat(responses.get(0).videoTitle()).isEqualTo("Test Title 2"),
+                    () -> assertThat(responses.get(1).id()).isEqualTo(1L),
+                    () -> assertThat(responses.get(1).videoTitle()).isEqualTo("Test Title"),
+                    () -> verify(contentPendingRepository).findAllByStatusOrderByIdDesc(ContentPendingStatus.PENDING)
+            );
+        }
+    }
+
+    @DisplayName("pending() 테스트")
+    @Nested
+    class Pending {
+
+        @DisplayName("새로운 콘텐츠 검증 요청을 생성하고 ID를 반환한다")
+        @Test
+        void pending1() {
+            // given
+            Account admin2 = AccountFixture.createCustomAccount(2L, Role.ADMIN);
+            Account admin3 = AccountFixture.createCustomAccount(3L, Role.ADMIN);
+
+            given(contentPendingRepository.existsByVideoUrlAndStatus(contentData.video().url(),
+                    ContentPendingStatus.PENDING))
+                    .willReturn(false);
+            given(accountRepository.findAllByRole(Role.ADMIN))
+                    .willReturn(List.of(collectorAccount, admin2, admin3));
+            given(contentPendingRepository.findTopByOrderByIdDesc())
+                    .willReturn(Optional.empty());
+            given(contentPendingRepository.save(any(ContentPending.class)))
+                    .willAnswer(invocation -> {
+                        ContentPending saved = invocation.getArgument(0);
+                        ReflectionTestUtils.setField(saved, "id", 1L);
+                        return saved;
+                    });
+
+            // when
+            Long savedId = adminContentPendingService.pending(collectorAccount, contentData);
+
+            // then
+            assertAll(
+                    () -> assertThat(savedId).isEqualTo(1L),
+                    () -> verify(contentPendingRepository).existsByVideoUrlAndStatus(contentData.video().url(),
+                            ContentPendingStatus.PENDING),
+                    () -> verify(accountRepository).findAllByRole(Role.ADMIN),
+                    () -> verify(contentPendingRepository).save(any(ContentPending.class))
+            );
+        }
+
+        @DisplayName("이미 PENDING 상태로 존재하는 비디오 URL인 경우 ConflictException을 발생시킨다")
+        @Test
+        void pending2() {
+            // given
+            given(contentPendingRepository.existsByVideoUrlAndStatus(contentData.video().url(),
+                    ContentPendingStatus.PENDING))
+                    .willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> adminContentPendingService.pending(collectorAccount, contentData))
+                    .isInstanceOf(ConflictException.class)
+                    .hasMessage(ErrorTag.DUPLICATE_PENDING_CONTENT.getMessage());
+        }
+
+        @DisplayName("validator 후보가 없는 경우 NotFoundException을 발생시킨다")
+        @Test
+        void pending3() {
+            // given
+            given(contentPendingRepository.existsByVideoUrlAndStatus(contentData.video().url(),
+                    ContentPendingStatus.PENDING))
+                    .willReturn(false);
+            given(accountRepository.findAllByRole(Role.ADMIN))
+                    .willReturn(List.of(collectorAccount));
+
+            // when & then
+            assertThatThrownBy(() -> adminContentPendingService.pending(collectorAccount, contentData))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage(ErrorTag.NO_AVAILABLE_VALIDATOR.getMessage());
+        }
+
+        @DisplayName("이전 validator가 있으면 다음 순서의 validator를 할당한다")
+        @Test
+        void pending4() {
+            // given
+            Account admin2 = AccountFixture.createCustomAccount(2L, Role.ADMIN);
+            Account admin3 = AccountFixture.createCustomAccount(3L, Role.ADMIN);
+
+            ContentPending lastPending = new ContentPending(contentData, collectorAccount, admin2, null, null);
+
+            given(contentPendingRepository.existsByVideoUrlAndStatus(contentData.video().url(),
+                    ContentPendingStatus.PENDING))
+                    .willReturn(false);
+            given(accountRepository.findAllByRole(Role.ADMIN))
+                    .willReturn(List.of(collectorAccount, admin2, admin3));
+            given(contentPendingRepository.findTopByOrderByIdDesc())
+                    .willReturn(Optional.of(lastPending));
+            given(contentPendingRepository.save(any(ContentPending.class)))
+                    .willAnswer(invocation -> {
+                        ContentPending saved = invocation.getArgument(0);
+                        ReflectionTestUtils.setField(saved, "id", 2L);
+                        return saved;
+                    });
+
+            // when
+            Long savedId = adminContentPendingService.pending(collectorAccount, contentData);
+
+            // then
+            assertAll(
+                    () -> assertThat(savedId).isEqualTo(2L),
+                    () -> verify(contentPendingRepository).save(any(ContentPending.class))
+            );
+        }
+
+        @DisplayName("마지막 validator가 리스트의 끝이면 처음부터 다시 할당한다")
+        @Test
+        void pending5() {
+            // given
+            Account admin2 = AccountFixture.createCustomAccount(2L, Role.ADMIN);
+            Account admin3 = AccountFixture.createCustomAccount(3L, Role.ADMIN);
+
+            ContentPending lastPending = new ContentPending(contentData, collectorAccount, admin3, null, null);
+
+            given(contentPendingRepository.existsByVideoUrlAndStatus(contentData.video().url(),
+                    ContentPendingStatus.PENDING))
+                    .willReturn(false);
+            given(accountRepository.findAllByRole(Role.ADMIN))
+                    .willReturn(List.of(collectorAccount, admin2, admin3));
+            given(contentPendingRepository.findTopByOrderByIdDesc())
+                    .willReturn(Optional.of(lastPending));
+            given(contentPendingRepository.save(any(ContentPending.class)))
+                    .willAnswer(invocation -> {
+                        ContentPending saved = invocation.getArgument(0);
+                        ReflectionTestUtils.setField(saved, "id", 2L);
+                        return saved;
+                    });
+
+            // when
+            Long savedId = adminContentPendingService.pending(collectorAccount, contentData);
+
+            // then
+            assertAll(
+                    () -> assertThat(savedId).isEqualTo(2L),
+                    () -> verify(contentPendingRepository).save(any(ContentPending.class))
+            );
         }
     }
 }

--- a/backend/turip-admin/src/test/resources/application-test-mysql.yml
+++ b/backend/turip-admin/src/test/resources/application-test-mysql.yml
@@ -1,0 +1,66 @@
+spring:
+  sql:
+    init:
+      mode: always
+      schema-locations: classpath:init-test-db.sql
+      data-locations: [ ]
+      continue-on-error: false
+  jpa:
+    defer-datasource-initialization: true
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+
+  # 테스트 환경에서 Flyway 비활성화
+  flyway:
+    enabled: false
+
+# JWT 설정 (테스트용)
+jwt:
+  secret-key: turip-test-jwt-secret-key-for-testing-purposes-only-32bytes
+  access-token-expiration-ms: 3600000  # 1시간
+  refresh-token-expiration-ms: 604800000  # 7일
+
+# Google OAuth 설정 (테스트용)
+google:
+  client-id: test-google-client-id.apps.googleusercontent.com
+  api:
+    key: test-google-api-key
+    url: https://test.google.com
+
+kakao:
+  api:
+    key: test-kakao-api-key
+    url: https://test.kakao.com
+
+youtube:
+  api:
+    key: test-youtube-api-key
+    url: https://test.youtube.com
+
+# CSV Import 설정
+csv:
+  import:
+    password: test_password_123
+
+# Region Category 기타 이미지 설정 (테스트용 더미 값)
+region:
+  category:
+    domestic:
+      etc:
+        image-url: https://test.example.com/domestic-etc.jpg
+    overseas:
+      etc:
+        image-url: https://test.example.com/overseas-etc.jpg
+
+invitation:
+  jwt:
+    secret-key: turip-test-invitation-jwt-secret-key-for-testing-purposes
+    token-expiration: 1h
+
+# SSE 설정 (테스트용 - 빠른 하트비트)
+sse:
+  heartbeat:
+    interval: 2  # 2초

--- a/backend/turip-app/src/main/java/turip/account/repository/AccountRepository.java
+++ b/backend/turip-app/src/main/java/turip/account/repository/AccountRepository.java
@@ -1,9 +1,13 @@
 package turip.account.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import turip.account.domain.Account;
+import turip.account.domain.Role;
 
 public interface AccountRepository extends JpaRepository<Account, Long> {
 
     boolean existsByNickname(String nickname);
+
+    List<Account> findAllByRole(Role role);
 }

--- a/backend/turip-app/src/main/java/turip/common/exception/ErrorTag.java
+++ b/backend/turip-app/src/main/java/turip/common/exception/ErrorTag.java
@@ -70,6 +70,7 @@ public enum ErrorTag {
     IS_ALREADY_APPROVED("이미 승인된 콘텐츠입니다."),
     CONTENT_PENDING_NOT_FOUND("펜딩 콘텐츠를 찾을 수 없습니다."),
     REJECT_REASON_REQUIRED("거절 사유를 입력해주세요."),
+    VALIDATOR_NOT_VALID("해당 콘텐츠를 검증할 권한이 없습니다."),
 
     // 404 Not Found
     YOUTUBE_VIDEO_NOT_FOUND("유튜브 영상을 찾을 수 없습니다."),

--- a/backend/turip-app/src/main/java/turip/common/exception/ErrorTag.java
+++ b/backend/turip-app/src/main/java/turip/common/exception/ErrorTag.java
@@ -74,6 +74,11 @@ public enum ErrorTag {
     // 404 Not Found
     YOUTUBE_VIDEO_NOT_FOUND("유튜브 영상을 찾을 수 없습니다."),
     CITY_NOT_FOUND("도시를 찾을 수 없습니다."),
+    ADMIN_NOT_FOUND("관리자 계정을 찾을 수 없습니다."),
+    NO_AVAILABLE_VALIDATOR("검수를 담당할 수 있는 다른 관리자가 없습니다. 관리자를 추가한 후 다시 시도해주세요."),
+
+    // 409 Conflict
+    DUPLICATE_PENDING_CONTENT("이미 검수 대기 중인 콘텐츠입니다."),
 
     // 500 Internal Server Error
     YOUTUBE_API_SERVER_ERROR("유튜브 API 서버에 에러가 발생했습니다.");

--- a/backend/turip-app/src/main/java/turip/content/domain/ContentPending.java
+++ b/backend/turip-app/src/main/java/turip/content/domain/ContentPending.java
@@ -81,6 +81,9 @@ public class ContentPending extends BaseTimeEntity {
 
     public void approve(Account validatorAccount, Content content) {
         validateStatusNotApproved();
+        if (validatorAccount.equals(collectorAccount)) {
+            throw new IllegalArgumentException(ErrorTag.VALIDATOR_NOT_VALID);
+        }
 
         this.status = ContentPendingStatus.APPROVED;
         this.validatorAccount = validatorAccount;

--- a/backend/turip-app/src/main/java/turip/content/repository/ContentPendingRepository.java
+++ b/backend/turip-app/src/main/java/turip/content/repository/ContentPendingRepository.java
@@ -1,8 +1,30 @@
 package turip.content.repository;
 
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import turip.account.domain.Account;
 import turip.content.domain.ContentPending;
+import turip.content.domain.ContentPendingStatus;
 
 public interface ContentPendingRepository extends JpaRepository<ContentPending, Long> {
 
+    Optional<ContentPending> findTopByOrderByIdDesc();
+
+    @Query(value = "SELECT COUNT(*) FROM content_pending " +
+            "WHERE JSON_UNQUOTE(JSON_EXTRACT(content_data, '$.video.url')) = :url " +
+            "AND status = :status", nativeQuery = true)
+    long countByVideoUrlAndStatus(@Param("url") String url, @Param("status") String status);
+
+    long countByStatus(ContentPendingStatus status);
+
+    List<ContentPending> findAllByStatusOrderByIdDesc(ContentPendingStatus status);
+
+    List<ContentPending> findAllByCollectorAccountOrderByIdDesc(Account collectorAccount);
+
+    default boolean existsByVideoUrlAndStatus(String url, ContentPendingStatus status) {
+        return countByVideoUrlAndStatus(url, status.name()) > 0;
+    }
 }

--- a/backend/turip-app/src/test/java/turip/content/domain/ContentPendingTest.java
+++ b/backend/turip-app/src/test/java/turip/content/domain/ContentPendingTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import turip.account.domain.Account;
+import turip.account.domain.Role;
 import turip.common.exception.ErrorTag;
 import turip.common.exception.custom.IllegalArgumentException;
 import turip.common.exception.custom.IllegalStateException;
@@ -29,8 +30,8 @@ class ContentPendingTest {
             @Test
             void approve1() {
                 // given
-                Account collector = AccountFixture.createAdmin();
-                Account validator = AccountFixture.createAdmin();
+                Account collector = AccountFixture.createCustomAccount(1L, Role.ADMIN);
+                Account validator = AccountFixture.createCustomAccount(2L, Role.ADMIN);
                 ContentPending pendingContent = ContentPendingFixture.createPending(collector);
                 Content content = null;
 

--- a/backend/turip-app/src/test/java/turip/content/domain/ContentPendingTest.java
+++ b/backend/turip-app/src/test/java/turip/content/domain/ContentPendingTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import turip.account.domain.Account;
+import turip.common.exception.ErrorTag;
 import turip.common.exception.custom.IllegalArgumentException;
 import turip.common.exception.custom.IllegalStateException;
 import turip.util.fixture.AccountFixture;
@@ -54,6 +55,20 @@ class ContentPendingTest {
                 // when & then
                 assertThatThrownBy(() -> pendingContent.approve(validator, content))
                         .isInstanceOf(IllegalStateException.class);
+            }
+
+            @DisplayName("자신이 수집한 콘텐츠는 승인할 수 없다.")
+            @Test
+            void approve3() {
+                // given
+                Account collector = AccountFixture.createAdmin();
+                ContentPending pendingContent = ContentPendingFixture.createPending(collector);
+                Content content = null;
+
+                // when & then
+                assertThatThrownBy(() -> pendingContent.approve(collector, content))
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessage(ErrorTag.VALIDATOR_NOT_VALID.getMessage());
             }
         }
 

--- a/backend/turip-app/src/test/java/turip/content/repository/ContentPendingRepositoryTest.java
+++ b/backend/turip-app/src/test/java/turip/content/repository/ContentPendingRepositoryTest.java
@@ -1,0 +1,182 @@
+package turip.content.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import turip.account.domain.Account;
+import turip.account.domain.Role;
+import turip.container.TestContainerConfig;
+import turip.content.domain.ContentPending;
+import turip.content.domain.ContentPendingData;
+import turip.content.domain.ContentPendingStatus;
+
+@DataJpaTest
+@EnableJpaAuditing
+@ActiveProfiles("test-mysql")
+class ContentPendingRepositoryTest extends TestContainerConfig {
+
+    @Autowired
+    private ContentPendingRepository contentPendingRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void clear() {
+        jdbcTemplate.execute("DELETE FROM content_pending");
+        jdbcTemplate.execute("DELETE FROM account");
+    }
+
+    @DisplayName("동일한 URL과 상태를 가진 콘텐츠가 존재하는지 확인한다")
+    @Test
+    void existsByVideoUrlAndStatus() {
+        // given
+        Account account = createAccount(Role.ADMIN);
+        String videoUrl = "https://example.com/video1";
+        ContentPendingData contentData = createContentData(videoUrl);
+        ContentPending contentPending = new ContentPending(contentData, account, null, null, null);
+        contentPendingRepository.save(contentPending);
+
+        // when
+        boolean exists = contentPendingRepository.existsByVideoUrlAndStatus(videoUrl, ContentPendingStatus.PENDING);
+
+        // then
+        assertThat(exists).isTrue();
+    }
+
+    @DisplayName("특정 상태의 콘텐츠 목록을 ID 내림차순으로 조회한다")
+    @Test
+    void findAllByStatusOrderByIdDesc() {
+        // given
+        Account account = createAccount(Role.ADMIN);
+
+        ContentPending pending1 = new ContentPending(createContentData("url1"), account, null, null, null);
+        ContentPending pending2 = new ContentPending(createContentData("url2"), account, null, null, null);
+        ContentPending rejected = new ContentPending(createContentData("url3"), account, null, null, null);
+        rejected.reject(account, "거절");
+
+        contentPendingRepository.save(pending1);
+        contentPendingRepository.save(pending2);
+        contentPendingRepository.save(rejected);
+
+        // when
+        List<ContentPending> results = contentPendingRepository.findAllByStatusOrderByIdDesc(
+                ContentPendingStatus.PENDING);
+
+        // then
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0).getId()).isGreaterThan(results.get(1).getId());
+    }
+
+    @DisplayName("수집자 계정으로 콘텐츠 목록을 ID 내림차순으로 조회한다")
+    @Test
+    void findAllByCollectorAccountOrderByIdDesc() {
+        // given
+        Account collector1 = createAccount(Role.ADMIN, "test-user1");
+        Account collector2 = createAccount(Role.ADMIN, "test-user2");
+
+        ContentPending cp1 = new ContentPending(createContentData("url1"), collector1, null, null, null);
+        ContentPending cp2 = new ContentPending(createContentData("url2"), collector1, null, null, null);
+        ContentPending cp3 = new ContentPending(createContentData("url3"), collector2, null, null, null);
+
+        contentPendingRepository.save(cp1);
+        contentPendingRepository.save(cp2);
+        contentPendingRepository.save(cp3);
+
+        // when
+        List<ContentPending> results = contentPendingRepository.findAllByCollectorAccountOrderByIdDesc(collector1);
+
+        // then
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0).getId()).isGreaterThan(results.get(1).getId());
+    }
+
+    @DisplayName("특정 상태의 콘텐츠 개수를 조회한다")
+    @Test
+    void countByStatus() {
+        // given
+        Account account = createAccount(Role.ADMIN);
+
+        ContentPending pending1 = new ContentPending(createContentData("url1"), account, null, null, null);
+        ContentPending pending2 = new ContentPending(createContentData("url2"), account, null, null, null);
+        ContentPending rejected = new ContentPending(createContentData("url3"), account, null, null, null);
+        rejected.reject(account, "거절");
+
+        contentPendingRepository.save(pending1);
+        contentPendingRepository.save(pending2);
+        contentPendingRepository.save(rejected);
+
+        // when
+        long pendingCount = contentPendingRepository.countByStatus(ContentPendingStatus.PENDING);
+        long rejectedCount = contentPendingRepository.countByStatus(ContentPendingStatus.REJECTED);
+
+        // then
+        assertThat(pendingCount).isEqualTo(2);
+        assertThat(rejectedCount).isEqualTo(1);
+    }
+
+    private Account createAccount(Role role) {
+        return createAccount(role, "test_user");
+    }
+
+    private Account createAccount(Role role, String nickName) {
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+
+        jdbcTemplate.update(connection -> {
+            PreparedStatement ps = connection.prepareStatement(
+                    "INSERT INTO account (role, nickname) VALUES (?, ?)",
+                    Statement.RETURN_GENERATED_KEYS);
+            ps.setString(1, role.name());
+            ps.setString(2, nickName);
+            return ps;
+        }, keyHolder);
+
+        Long id = keyHolder.getKey().longValue();
+        Account account = new Account(role, "test_user");
+        ReflectionTestUtils.setField(account, "id", id);
+        return account;
+    }
+
+    private ContentPendingData createContentData(String videoUrl) {
+        ContentPendingData.VideoData videoData = new ContentPendingData.VideoData(
+                "videoId",
+                "Test Video",
+                videoUrl,
+                "Test Channel",
+                "http://image.url",
+                LocalDate.now()
+        );
+
+        ContentPendingData.PlaceData placeData = new ContentPendingData.PlaceData(
+                "Test Place",
+                "http://place.url",
+                "Test Address",
+                37.5665,
+                126.9780,
+                "CAFE"
+        );
+
+        ContentPendingData.ContentPlaceData contentPlaceData = new ContentPendingData.ContentPlaceData(
+                1,
+                1,
+                "09:00",
+                placeData
+        );
+
+        return new ContentPendingData("Seoul", videoData, List.of(contentPlaceData));
+    }
+}


### PR DESCRIPTION
## Issues
- closed #652 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description

 어드민 페이지에서 콘텐츠 수집 → 검수 → 승인/반려로 이어지는 전체 플로우를 구현합니다.                                                                                  
                                                                                                                                                                       
배경                                                                                                                                                                                                                                                                                                                                      
- 기존에는 관리자가 직접 콘텐츠를 등록하는 방식만 존재했습니다. 이번 작업으로 수집자가 콘텐츠를 제출하면 별도의 검수자가 승인/반려를 처리하는 구조를 추가합니다.       
                                                                                                                                                                       
추가된 기능                                                                                                                                                          
                                                                                                                                                                       
  - 콘텐츠 검수 요청                                                                                                                                                     
    - 수집자가 콘텐츠 수집 데이터를 작성하고 제출하면, ContentPendin이 생성되고 검수자가 자동으로 배정됩니다. 검수자는 수집자 본인을 제외한 관리자 중 라운드로빈 방식으로 지정됩니다. 관리자가 1명이라 배정이 불가한 경우 화면에 에러 메시지를 띄웁니다.                                                                        
                                                                                                                                                                       
- 검수 대기 목록 및 상세 검수                                                                                                                                          
   - 검수자는 /admin/contents/pending에서 검수 대기 중인 콘텐츠 목록을 확인합니다. 항목을 클릭하면 상세 검수 페이지로 이동하여 영상과 수집된 장소 경로를 확인한 뒤 승인  또는 반려를 처리합니다.                                                                                                                                              
                                                                                                                                                                       
-  마이페이지 및 재검수 요청                                                                                                                                            
    - 수집자는 /admin/my에서 본인이 제출한 콘텐츠의 현황(검수 중 / 승인 완료 / 반려됨)과 반려 사유를 확인할 수 있습니다. 반려된 경우 "수정하기"를 클릭하면 기존 데이터가 수집 폼에 로드되며, 수정 후 재제출하면 새로운 검수 요청이 생성됩니다.                                                                                                
                                                                                                                                                                       
 - 홈 알림                                                                                                                                                              
   - 홈 헤더의 벨 아이콘에 현재 검수 대기 건수가 배지로 표시됩니다. 벨 아이콘을 클릭하면 최근 대기 목록을 드롭다운으로 확인할 수 있으며, 60초마다 자동으로 갱신됩니다. 
## 📷 Screenshot

## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자 UI 재설계: 고정 헤더, 알림 벨(카운트/드롭다운) 및 마이페이지 바로가기 추가
  * 펜딩 관리 추가: 대기 목록, 상세 검수 페이지, 승인/거절 워크플로우 제공
  * 관리자 제출(마이페이지) 추가: 제출 이력 조회, 상태·거절사유 표시, 수정 가능한 항목 편집 모드
  * 클라이언트 UX 개선: 토스트 오류 표시, 편집 초기화 및 동적 목록 렌더링

* **버그 수정 / 동작 개선**
  * 중복 제출 방지 및 유효성 검증 강화
  * 로그아웃 확인 흐름 개선

* **테스트**
  * 통합/레포지토리 테스트 확장 및 테스트 환경 설정 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->