### PR TITLE
[feat] 애플 로그인 구현

### DIFF
--- a/.github/workflows/backend-dev-admin-deploy.yml
+++ b/.github/workflows/backend-dev-admin-deploy.yml
@@ -133,6 +133,8 @@ jobs:
           CSV_IMPORT_PASSWORD=${{ secrets.CSV_IMPORT_PASSWORD }}
           JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
           GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_IOS_CLIENT_ID=${{ secrets.GOOGLE_IOS_CLIENT_ID }}
+          APPLE_CLIENT_ID=${{ secrets.APPLE_CLIENT_ID }}
           KAKAO_API_KEY=${{ secrets.KAKAO_API_KEY }}
           GOOGLE_API_KEY=${{ secrets.GOOGLE_API_KEY }}
           YOUTUBE_API_KEY=${{ secrets.YOUTUBE_API_KEY }}

--- a/.github/workflows/backend-dev-app-deploy.yml
+++ b/.github/workflows/backend-dev-app-deploy.yml
@@ -134,6 +134,7 @@ jobs:
           JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
           GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_IOS_CLIENT_ID=${{ secrets.GOOGLE_IOS_CLIENT_ID }}
+          APPLE_CLIENT_ID=${{ secrets.APPLE_CLIENT_ID }}
           KAKAO_API_KEY=${{ secrets.KAKAO_API_KEY }}
           GOOGLE_API_KEY=${{ secrets.GOOGLE_API_KEY }}
           YOUTUBE_API_KEY=${{ secrets.YOUTUBE_API_KEY }}

--- a/.github/workflows/backend-dev-app-deploy.yml
+++ b/.github/workflows/backend-dev-app-deploy.yml
@@ -133,6 +133,7 @@ jobs:
           CSV_IMPORT_PASSWORD=${{ secrets.CSV_IMPORT_PASSWORD }}
           JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
           GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_IOS_CLIENT_ID=${{ secrets.GOOGLE_IOS_CLIENT_ID }}
           KAKAO_API_KEY=${{ secrets.KAKAO_API_KEY }}
           GOOGLE_API_KEY=${{ secrets.GOOGLE_API_KEY }}
           YOUTUBE_API_KEY=${{ secrets.YOUTUBE_API_KEY }}

--- a/.github/workflows/backend-prod-admin-deploy.yml
+++ b/.github/workflows/backend-prod-admin-deploy.yml
@@ -127,6 +127,8 @@ jobs:
           CSV_IMPORT_PASSWORD=${{ secrets.CSV_IMPORT_PASSWORD }}
           JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
           GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_IOS_CLIENT_ID=${{ secrets.GOOGLE_IOS_CLIENT_ID }}
+          APPLE_CLIENT_ID=${{ secrets.APPLE_CLIENT_ID }}
           KAKAO_API_KEY=${{ secrets.KAKAO_API_KEY }}
           GOOGLE_API_KEY=${{ secrets.GOOGLE_API_KEY }}
           YOUTUBE_API_KEY=${{ secrets.YOUTUBE_API_KEY }}

--- a/.github/workflows/backend-prod-app-deploy.yml
+++ b/.github/workflows/backend-prod-app-deploy.yml
@@ -127,6 +127,7 @@ jobs:
           CSV_IMPORT_PASSWORD=${{ secrets.CSV_IMPORT_PASSWORD }}
           JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
           GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_IOS_CLIENT_ID=${{ secrets.GOOGLE_IOS_CLIENT_ID }}
           KAKAO_API_KEY=${{ secrets.KAKAO_API_KEY }}
           GOOGLE_API_KEY=${{ secrets.GOOGLE_API_KEY }}
           YOUTUBE_API_KEY=${{ secrets.YOUTUBE_API_KEY }}

--- a/.github/workflows/backend-prod-app-deploy.yml
+++ b/.github/workflows/backend-prod-app-deploy.yml
@@ -128,6 +128,7 @@ jobs:
           JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
           GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_IOS_CLIENT_ID=${{ secrets.GOOGLE_IOS_CLIENT_ID }}
+          APPLE_CLIENT_ID=${{ secrets.APPLE_CLIENT_ID }}
           KAKAO_API_KEY=${{ secrets.KAKAO_API_KEY }}
           GOOGLE_API_KEY=${{ secrets.GOOGLE_API_KEY }}
           YOUTUBE_API_KEY=${{ secrets.YOUTUBE_API_KEY }}

--- a/backend/turip-admin/src/main/resources/application.yml
+++ b/backend/turip-admin/src/main/resources/application.yml
@@ -53,6 +53,9 @@ youtube:
     key: ${YOUTUBE_API_KEY}
     url: https://www.googleapis.com/youtube/v3/videos
 
+apple:
+  client-id: ${APPLE_CLIENT_ID}
+
 invitation:
   jwt:
     secret-key: ${INVITATION_JWT_SECRET_KEY}

--- a/backend/turip-admin/src/main/resources/application.yml
+++ b/backend/turip-admin/src/main/resources/application.yml
@@ -43,6 +43,7 @@ kakao:
 
 google:
   client-id: ${GOOGLE_CLIENT_ID}
+  ios-client-id: ${GOOGLE_IOS_CLIENT_ID}
   api:
     key: ${GOOGLE_API_KEY}
     url: https://maps.googleapis.com/maps/api/place/textsearch/json

--- a/backend/turip-admin/src/test/resources/application-test-mysql.yml
+++ b/backend/turip-admin/src/test/resources/application-test-mysql.yml
@@ -26,6 +26,7 @@ jwt:
 # Google OAuth 설정 (테스트용)
 google:
   client-id: test-google-client-id.apps.googleusercontent.com
+  ios-client-id: test-google-ios-client-id.apps.googleusercontent.com
   api:
     key: test-google-api-key
     url: https://test.google.com
@@ -39,6 +40,9 @@ youtube:
   api:
     key: test-youtube-api-key
     url: https://test.youtube.com
+
+apple:
+  client-id: com.teamturip.test
 
 # CSV Import 설정
 csv:

--- a/backend/turip-admin/src/test/resources/application-test.yml
+++ b/backend/turip-admin/src/test/resources/application-test.yml
@@ -35,6 +35,7 @@ jwt:
 # Google OAuth 설정 (테스트용)
 google:
   client-id: test-google-client-id.apps.googleusercontent.com
+  ios-client-id: test-google-ios-client-id.apps.googleusercontent.com
   api:
     key: test-google-api-key
     url: https://test.google.com
@@ -48,6 +49,9 @@ youtube:
   api:
     key: test-youtube-api-key
     url: https://test.youtube.com
+
+apple:
+  client-id: com.teamturip.test
 
 # CSV Import 설정
 csv:

--- a/backend/turip-app/build.gradle
+++ b/backend/turip-app/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     implementation 'org.flywaydb:flyway-mysql'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     implementation 'com.google.api-client:google-api-client:2.2.0'
+    implementation 'com.nimbusds:nimbus-jose-jwt:9.40'
     implementation 'org.mindrot:jbcrypt:0.4'
 
     runtimeOnly 'com.h2database:h2'

--- a/backend/turip-app/src/main/java/turip/account/domain/Provider.java
+++ b/backend/turip-app/src/main/java/turip/account/domain/Provider.java
@@ -2,5 +2,5 @@ package turip.account.domain;
 
 public enum Provider {
 
-    GOOGLE, KAKAO;
+    GOOGLE, APPLE;
 }

--- a/backend/turip-app/src/main/java/turip/account/service/SocialMemberService.java
+++ b/backend/turip-app/src/main/java/turip/account/service/SocialMemberService.java
@@ -1,5 +1,6 @@
 package turip.account.service;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -7,6 +8,8 @@ import turip.account.domain.Member;
 import turip.account.domain.Provider;
 import turip.account.domain.SocialMember;
 import turip.account.repository.SocialMemberRepository;
+import turip.common.exception.ErrorTag;
+import turip.common.exception.custom.BadRequestException;
 
 @Service
 @RequiredArgsConstructor
@@ -16,10 +19,14 @@ public class SocialMemberService {
     private final SocialMemberRepository socialMemberRepository;
 
     @Transactional
-    public SocialMember findOrCreate(Provider provider, String providerId, String email) {
+    public SocialMember findOrCreate(Provider provider, String providerId, Optional<String> email) {
         return socialMemberRepository.findByProviderAndProviderId(provider, providerId)
                 .orElseGet(() -> {
-                    Member member = memberService.create(email);
+                    // 신규 회원 생성 시에는 email이 필수
+                    String emailValue = email.orElseThrow(
+                            () -> new BadRequestException(ErrorTag.ID_TOKEN_NOT_VALID)
+                    );
+                    Member member = memberService.create(emailValue);
                     return socialMemberRepository.save(new SocialMember(member, provider, providerId));
                 });
     }

--- a/backend/turip-app/src/main/java/turip/auth/controller/AuthController.java
+++ b/backend/turip-app/src/main/java/turip/auth/controller/AuthController.java
@@ -21,8 +21,8 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import turip.account.domain.Account;
 import turip.account.domain.Member;
 import turip.account.domain.Provider;
-import turip.auth.controller.dto.request.GoogleLoginRequest;
 import turip.auth.controller.dto.request.RefreshTokenRequest;
+import turip.auth.controller.dto.request.SocialLoginRequest;
 import turip.auth.controller.dto.request.TuripLoginRequest;
 import turip.auth.controller.dto.response.RefreshTokenResponse;
 import turip.auth.controller.dto.response.SocialLoginResponseV1;
@@ -189,7 +189,7 @@ public class AuthController {
     @PostMapping("/api/v1/auth/login/google")
     public ResponseEntity<SocialLoginResponseV1> loginWithGoogle(
             @Parameter(hidden = true) @RequestHeader("device-fid") String deviceFid,
-            @RequestBody GoogleLoginRequest request) {
+            @RequestBody SocialLoginRequest request) {
         SocialLoginResult result = authService.loginWithSocial(request, Provider.GOOGLE, deviceFid);
         SocialLoginResponseV1 response = SocialLoginResponseV1.of(result);
         return ResponseEntity.ok(response);
@@ -264,8 +264,83 @@ public class AuthController {
     @PostMapping("/api/v2/auth/login/google")
     public ResponseEntity<SocialLoginResponseV2> loginWithGoogleV2(
             @Parameter(hidden = true) @RequestHeader("device-fid") String deviceFid,
-            @RequestBody GoogleLoginRequest request) {
+            @RequestBody SocialLoginRequest request) {
         SocialLoginResult result = authService.loginWithSocial(request, Provider.GOOGLE, deviceFid);
+        SocialLoginResponseV2 response = SocialLoginResponseV2.of(result);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+            summary = "애플 로그인 api",
+            description = "id token 기반 애플 소셜 로그인을 진행한다. 마이그레이션 결정 여부를 응답에 포함한다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = SocialLoginResponseV2.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    summary = "로그인 성공",
+                                    value = """
+                                            {
+                                              "accessToken": "jwt-access",
+                                              "refreshToken": "jwt-refresh",
+                                              "nickname": "메이",
+                                              "isMigrationDecided": false
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "실패 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "invalid id token",
+                                            summary = "올바르지 않은 id token",
+                                            value = """
+                                                    {
+                                                    	"tag": "ID_TOKEN_NOT_VALID",
+                                                    	"message": "유효하지 않은 id token입니다."
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "실패 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "account creation error",
+                                            summary = "계정 생성 실패(재시도 5번에 모두 실패)",
+                                            value = """
+                                                    {
+                                                    	"tag": "ACCOUNT_CREATION_ERROR",
+                                                    	"message": "계정 생성에 실패했습니다."
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            )
+    })
+    @PostMapping("/api/v1/auth/login/apple")
+    public ResponseEntity<SocialLoginResponseV2> loginWithApple(
+            @Parameter(hidden = true) @RequestHeader("device-fid") String deviceFid,
+            @RequestBody SocialLoginRequest request) {
+        SocialLoginResult result = authService.loginWithSocial(request, Provider.APPLE, deviceFid);
         SocialLoginResponseV2 response = SocialLoginResponseV2.of(result);
         return ResponseEntity.ok(response);
     }

--- a/backend/turip-app/src/main/java/turip/auth/controller/dto/request/GoogleLoginRequest.java
+++ b/backend/turip-app/src/main/java/turip/auth/controller/dto/request/GoogleLoginRequest.java
@@ -1,4 +1,0 @@
-package turip.auth.controller.dto.request;
-
-public record GoogleLoginRequest(String idToken) {
-}

--- a/backend/turip-app/src/main/java/turip/auth/controller/dto/request/SocialLoginRequest.java
+++ b/backend/turip-app/src/main/java/turip/auth/controller/dto/request/SocialLoginRequest.java
@@ -1,0 +1,4 @@
+package turip.auth.controller.dto.request;
+
+public record SocialLoginRequest(String idToken) {
+}

--- a/backend/turip-app/src/main/java/turip/auth/service/AuthService.java
+++ b/backend/turip-app/src/main/java/turip/auth/service/AuthService.java
@@ -19,8 +19,8 @@ import turip.auth.domain.RefreshToken;
 import turip.auth.service.dto.SocialLoginResult;
 import turip.auth.service.dto.TokenResult;
 import turip.auth.service.dto.TuripLoginResult;
-import turip.auth.token.AppleTokenParser;
-import turip.auth.token.GoogleTokenParser;
+import turip.auth.token.IdTokenParser;
+import turip.auth.token.IdTokenParserResolver;
 import turip.auth.token.JwtProvider;
 import turip.common.exception.ErrorTag;
 import turip.common.exception.custom.BadRequestException;
@@ -32,8 +32,7 @@ import turip.common.exception.custom.UnauthorizedException;
 public class AuthService {
 
     private final JwtProvider jwtProvider;
-    private final GoogleTokenParser googleTokenParser;
-    private final AppleTokenParser appleTokenParser;
+    private final IdTokenParserResolver idTokenParserResolver;
     private final RefreshTokenService refreshTokenService;
     private final MemberService memberService;
     private final SocialMemberService socialMemberService;
@@ -61,13 +60,23 @@ public class AuthService {
 
     @Transactional
     public SocialLoginResult loginWithSocial(SocialLoginRequest request, Provider provider, String deviceFid) {
-        if (provider == Provider.GOOGLE) {
-            return loginWithGoogle(request, deviceFid);
+        String idToken = request.idToken();
+        validateIdToken(idToken);
+
+        IdTokenParser parser = idTokenParserResolver.resolve(provider);
+        String providerId = parser.getProviderId(idToken);
+        String email = parser.getEmail(idToken);
+
+        Member member = findOrCreateSocialMember(provider, providerId, email);
+
+        boolean isNewMember = false;
+        if (member.isFirstLogin()) {
+            member.completeFirstLogin();
+            isNewMember = true;
         }
-        if (provider == Provider.APPLE) {
-            return loginWithApple(request, deviceFid);
-        }
-        throw new UnauthorizedException(ErrorTag.UNAUTHORIZED);
+        TokenResult tokenResult = issueToken(deviceFid, member);
+
+        return SocialLoginResult.of(tokenResult, isNewMember, member);
     }
 
     @Transactional
@@ -115,26 +124,6 @@ public class AuthService {
         return TokenResult.of(accessToken, refreshToken);
     }
 
-    private SocialLoginResult loginWithGoogle(SocialLoginRequest request, String deviceFid) {
-        String idToken = request.idToken();
-        validateIdToken(idToken);
-
-        Provider provider = googleTokenParser.getProvider();
-        String providerId = googleTokenParser.getProviderId(idToken);
-        String email = googleTokenParser.getEmail(idToken);
-
-        Member member = findOrCreateSocialMember(provider, providerId, email);
-
-        boolean isNewMember = false;
-        if (member.isFirstLogin()) {
-            member.completeFirstLogin();
-            isNewMember = true;
-        }
-        TokenResult tokenResult = issueToken(deviceFid, member);
-
-        return SocialLoginResult.of(tokenResult, isNewMember, member);
-    }
-
     private Member findOrCreateSocialMember(Provider provider, String providerId, String email) {
         return socialMemberService.findOrCreate(provider, providerId, email).getMember();
     }
@@ -176,25 +165,5 @@ public class AuthService {
         if (idToken == null || idToken.isBlank()) {
             throw new BadRequestException(ErrorTag.ID_TOKEN_NOT_VALID);
         }
-    }
-
-    private SocialLoginResult loginWithApple(SocialLoginRequest request, String deviceFid) {
-        String idToken = request.idToken();
-        validateIdToken(idToken);
-
-        Provider provider = appleTokenParser.getProvider();
-        String providerId = appleTokenParser.getProviderId(idToken);
-        String email = appleTokenParser.getEmail(idToken);
-
-        Member member = findOrCreateSocialMember(provider, providerId, email);
-
-        boolean isNewMember = false;
-        if (member.isFirstLogin()) {
-            member.completeFirstLogin();
-            isNewMember = true;
-        }
-        TokenResult tokenResult = issueToken(deviceFid, member);
-
-        return SocialLoginResult.of(tokenResult, isNewMember, member);
     }
 }

--- a/backend/turip-app/src/main/java/turip/auth/service/AuthService.java
+++ b/backend/turip-app/src/main/java/turip/auth/service/AuthService.java
@@ -11,14 +11,15 @@ import turip.account.domain.Role;
 import turip.account.service.MemberService;
 import turip.account.service.SocialMemberService;
 import turip.account.service.TuripMemberService;
-import turip.auth.controller.dto.request.GoogleLoginRequest;
 import turip.auth.controller.dto.request.RefreshTokenRequest;
+import turip.auth.controller.dto.request.SocialLoginRequest;
 import turip.auth.controller.dto.request.TuripLoginRequest;
 import turip.auth.controller.dto.response.RefreshTokenResponse;
 import turip.auth.domain.RefreshToken;
 import turip.auth.service.dto.SocialLoginResult;
 import turip.auth.service.dto.TokenResult;
 import turip.auth.service.dto.TuripLoginResult;
+import turip.auth.token.AppleTokenParser;
 import turip.auth.token.GoogleTokenParser;
 import turip.auth.token.JwtProvider;
 import turip.common.exception.ErrorTag;
@@ -32,6 +33,7 @@ public class AuthService {
 
     private final JwtProvider jwtProvider;
     private final GoogleTokenParser googleTokenParser;
+    private final AppleTokenParser appleTokenParser;
     private final RefreshTokenService refreshTokenService;
     private final MemberService memberService;
     private final SocialMemberService socialMemberService;
@@ -58,9 +60,12 @@ public class AuthService {
     }
 
     @Transactional
-    public SocialLoginResult loginWithSocial(GoogleLoginRequest request, Provider provider, String deviceFid) {
+    public SocialLoginResult loginWithSocial(SocialLoginRequest request, Provider provider, String deviceFid) {
         if (provider == Provider.GOOGLE) {
             return loginWithGoogle(request, deviceFid);
+        }
+        if (provider == Provider.APPLE) {
+            return loginWithApple(request, deviceFid);
         }
         throw new UnauthorizedException(ErrorTag.UNAUTHORIZED);
     }
@@ -110,7 +115,7 @@ public class AuthService {
         return TokenResult.of(accessToken, refreshToken);
     }
 
-    private SocialLoginResult loginWithGoogle(GoogleLoginRequest request, String deviceFid) {
+    private SocialLoginResult loginWithGoogle(SocialLoginRequest request, String deviceFid) {
         String idToken = request.idToken();
         validateIdToken(idToken);
 
@@ -171,5 +176,25 @@ public class AuthService {
         if (idToken == null || idToken.isBlank()) {
             throw new BadRequestException(ErrorTag.ID_TOKEN_NOT_VALID);
         }
+    }
+
+    private SocialLoginResult loginWithApple(SocialLoginRequest request, String deviceFid) {
+        String idToken = request.idToken();
+        validateIdToken(idToken);
+
+        Provider provider = appleTokenParser.getProvider();
+        String providerId = appleTokenParser.getProviderId(idToken);
+        String email = appleTokenParser.getEmail(idToken);
+
+        Member member = findOrCreateSocialMember(provider, providerId, email);
+
+        boolean isNewMember = false;
+        if (member.isFirstLogin()) {
+            member.completeFirstLogin();
+            isNewMember = true;
+        }
+        TokenResult tokenResult = issueToken(deviceFid, member);
+
+        return SocialLoginResult.of(tokenResult, isNewMember, member);
     }
 }

--- a/backend/turip-app/src/main/java/turip/auth/service/AuthService.java
+++ b/backend/turip-app/src/main/java/turip/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package turip.auth.service;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -67,7 +68,7 @@ public class AuthService {
         String providerId = parser.getProviderId(idToken);
         String email = parser.getEmail(idToken);
 
-        Member member = findOrCreateSocialMember(provider, providerId, email);
+        Member member = findOrCreateSocialMember(provider, providerId, Optional.ofNullable(email));
 
         boolean isNewMember = false;
         if (member.isFirstLogin()) {
@@ -124,7 +125,7 @@ public class AuthService {
         return TokenResult.of(accessToken, refreshToken);
     }
 
-    private Member findOrCreateSocialMember(Provider provider, String providerId, String email) {
+    private Member findOrCreateSocialMember(Provider provider, String providerId, Optional<String> email) {
         return socialMemberService.findOrCreate(provider, providerId, email).getMember();
     }
 

--- a/backend/turip-app/src/main/java/turip/auth/token/AppleTokenParser.java
+++ b/backend/turip-app/src/main/java/turip/auth/token/AppleTokenParser.java
@@ -8,9 +8,13 @@ import com.nimbusds.jose.proc.JWSVerificationKeySelector;
 import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
+import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
 import com.nimbusds.jwt.proc.DefaultJWTProcessor;
 import java.net.URL;
+import java.util.Arrays;
+import java.util.HashSet;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import turip.account.domain.Provider;
 import turip.common.exception.ErrorTag;
@@ -21,21 +25,39 @@ import turip.common.exception.custom.UnauthorizedException;
 public class AppleTokenParser implements IdTokenParser {
 
     private static final String APPLE_JWKS_URL = "https://appleid.apple.com/auth/keys";
+    private static final String APPLE_ISS = "https://appleid.apple.com";
     private final ConfigurableJWTProcessor<SecurityContext> jwtProcessor;
+    private final String clientId;
 
-    public AppleTokenParser() {
+    public AppleTokenParser(@Value("${apple.client-id}") String clientId) {
+        this.clientId = clientId;
         try {
             this.jwtProcessor = createJwtProcessor();
         } catch (Exception e) {
-            throw new IllegalStateException("AppleTokenParser 초기화 실패");
+            throw new IllegalStateException("AppleTokenParser 초기화 실패", e);
         }
     }
 
     private ConfigurableJWTProcessor<SecurityContext> createJwtProcessor() throws Exception {
         ConfigurableJWTProcessor<SecurityContext> processor = new DefaultJWTProcessor<>();
+
+        // JWS signature 검증 설정 (RS256 알고리즘 사용)
         JWKSource<SecurityContext> keySource = new RemoteJWKSet<>(new URL(APPLE_JWKS_URL));
         JWSKeySelector<SecurityContext> keySelector = new JWSVerificationKeySelector<>(JWSAlgorithm.RS256, keySource);
         processor.setJWSKeySelector(keySelector);
+
+        // Claims 검증 설정 (iss, aud, exp 검증)
+        JWTClaimsSet exactMatchClaims = new JWTClaimsSet.Builder()
+                .issuer(APPLE_ISS)
+                .audience(clientId)
+                .build();
+
+        DefaultJWTClaimsVerifier<SecurityContext> claimsVerifier = new DefaultJWTClaimsVerifier<>(
+                exactMatchClaims,
+                new HashSet<>(Arrays.asList("sub", "email", "exp"))
+        );
+        processor.setJWTClaimsSetVerifier(claimsVerifier);
+
         return processor;
     }
 

--- a/backend/turip-app/src/main/java/turip/auth/token/AppleTokenParser.java
+++ b/backend/turip-app/src/main/java/turip/auth/token/AppleTokenParser.java
@@ -54,7 +54,7 @@ public class AppleTokenParser implements IdTokenParser {
 
         DefaultJWTClaimsVerifier<SecurityContext> claimsVerifier = new DefaultJWTClaimsVerifier<>(
                 exactMatchClaims,
-                new HashSet<>(Arrays.asList("sub", "email", "exp"))
+                new HashSet<>(Arrays.asList("sub", "exp"))
         );
         processor.setJWTClaimsSetVerifier(claimsVerifier);
 

--- a/backend/turip-app/src/main/java/turip/auth/token/AppleTokenParser.java
+++ b/backend/turip-app/src/main/java/turip/auth/token/AppleTokenParser.java
@@ -1,0 +1,71 @@
+package turip.auth.token;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.jwk.source.RemoteJWKSet;
+import com.nimbusds.jose.proc.JWSKeySelector;
+import com.nimbusds.jose.proc.JWSVerificationKeySelector;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+import java.net.URL;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import turip.account.domain.Provider;
+import turip.common.exception.ErrorTag;
+import turip.common.exception.custom.UnauthorizedException;
+
+@Slf4j
+@Component
+public class AppleTokenParser implements IdTokenParser {
+
+    private static final String APPLE_JWKS_URL = "https://appleid.apple.com/auth/keys";
+    private final ConfigurableJWTProcessor<SecurityContext> jwtProcessor;
+
+    public AppleTokenParser() {
+        try {
+            this.jwtProcessor = createJwtProcessor();
+        } catch (Exception e) {
+            throw new IllegalStateException("AppleTokenParser 초기화 실패");
+        }
+    }
+
+    private ConfigurableJWTProcessor<SecurityContext> createJwtProcessor() throws Exception {
+        ConfigurableJWTProcessor<SecurityContext> processor = new DefaultJWTProcessor<>();
+        JWKSource<SecurityContext> keySource = new RemoteJWKSet<>(new URL(APPLE_JWKS_URL));
+        JWSKeySelector<SecurityContext> keySelector = new JWSVerificationKeySelector<>(JWSAlgorithm.RS256, keySource);
+        processor.setJWSKeySelector(keySelector);
+        return processor;
+    }
+
+    @Override
+    public Provider getProvider() {
+        return Provider.APPLE;
+    }
+
+    @Override
+    public String getProviderId(String idToken) {
+        JWTClaimsSet claimsSet = parseIdToken(idToken);
+        return claimsSet.getSubject();
+    }
+
+    @Override
+    public String getEmail(String idToken) {
+        JWTClaimsSet claimsSet = parseIdToken(idToken);
+        try {
+            return claimsSet.getStringClaim("email");
+        } catch (Exception e) {
+            throw new UnauthorizedException(ErrorTag.ID_TOKEN_NOT_VALID, e);
+        }
+    }
+
+    private JWTClaimsSet parseIdToken(String idToken) {
+        try {
+            return jwtProcessor.process(idToken, null);
+        } catch (Exception e) {
+            log.error("Failed to parse Apple ID token", e);
+            throw new UnauthorizedException(ErrorTag.ID_TOKEN_NOT_VALID, e);
+        }
+    }
+}

--- a/backend/turip-app/src/main/java/turip/auth/token/GoogleTokenParser.java
+++ b/backend/turip-app/src/main/java/turip/auth/token/GoogleTokenParser.java
@@ -5,7 +5,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
-import java.util.Collections;
+import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -19,9 +19,11 @@ public class GoogleTokenParser implements IdTokenParser {
 
     private final GoogleIdTokenVerifier verifier;
 
-    public GoogleTokenParser(@Value("${google.client-id}") String clientId) {
+    public GoogleTokenParser(
+            @Value("${google.client-id}") String clientId,
+            @Value("${google.ios-client-id}") String iosClientId) {
         this.verifier = new GoogleIdTokenVerifier.Builder(new NetHttpTransport(), new GsonFactory())
-                .setAudience(Collections.singletonList(clientId))
+                .setAudience(Arrays.asList(clientId, iosClientId))
                 .build();
     }
 

--- a/backend/turip-app/src/main/java/turip/auth/token/IdTokenParserResolver.java
+++ b/backend/turip-app/src/main/java/turip/auth/token/IdTokenParserResolver.java
@@ -1,0 +1,29 @@
+package turip.auth.token;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+import turip.account.domain.Provider;
+import turip.common.exception.ErrorTag;
+import turip.common.exception.custom.UnauthorizedException;
+
+@Component
+public class IdTokenParserResolver {
+
+    private final Map<Provider, IdTokenParser> parsers;
+
+    public IdTokenParserResolver(List<IdTokenParser> parserList) {
+        this.parsers = parserList.stream()
+                .collect(Collectors.toMap(IdTokenParser::getProvider, Function.identity()));
+    }
+
+    public IdTokenParser resolve(Provider provider) {
+        IdTokenParser parser = parsers.get(provider);
+        if (parser == null) {
+            throw new UnauthorizedException(ErrorTag.UNAUTHORIZED);
+        }
+        return parser;
+    }
+}

--- a/backend/turip-app/src/main/resources/application.yml
+++ b/backend/turip-app/src/main/resources/application.yml
@@ -49,6 +49,7 @@ kakao:
 
 google:
   client-id: ${GOOGLE_CLIENT_ID}
+  ios-client-id: ${GOOGLE_IOS_CLIENT_ID}
   api:
     key: ${GOOGLE_API_KEY}
     url: https://maps.googleapis.com/maps/api/place/textsearch/json

--- a/backend/turip-app/src/main/resources/application.yml
+++ b/backend/turip-app/src/main/resources/application.yml
@@ -59,6 +59,9 @@ youtube:
     key: ${YOUTUBE_API_KEY}
     url: https://www.googleapis.com/youtube/v3/videos
 
+apple:
+  client-id: ${APPLE_CLIENT_ID}
+
 invitation:
   jwt:
     secret-key: ${INVITATION_JWT_SECRET_KEY}

--- a/backend/turip-app/src/test/java/turip/auth/api/AuthApiTest.java
+++ b/backend/turip-app/src/test/java/turip/auth/api/AuthApiTest.java
@@ -448,6 +448,40 @@ class AuthApiTest {
         }
 
         @Test
+        @DisplayName("애플 재로그인 시 email이 없어도 로그인에 성공한다")
+        void loginExistingMemberWithoutEmail() {
+            // given - 첫 로그인 시 email로 회원가입된 상태
+            String email = "existing@icloud.com";
+            Provider provider = Provider.APPLE;
+            String providerId = "apple-user-relogin";
+            testDataHelper.insertSocialMember(email, false, provider, providerId);
+
+            String idToken = "valid-apple-id-token-relogin";
+            String deviceFid = "device-relogin-456";
+
+            // 애플 재로그인 시에는 email이 null
+            when(appleTokenParserMock.getProviderId(idToken)).thenReturn(providerId);
+            when(appleTokenParserMock.getEmail(idToken)).thenReturn(null);
+
+            Map<String, String> requestBody = new HashMap<>();
+            requestBody.put("idToken", idToken);
+
+            // when & then
+            RestAssured
+                    .given().log().all()
+                    .contentType(ContentType.JSON)
+                    .header("device-fid", deviceFid)
+                    .body(requestBody)
+                    .when().post("/api/v1/auth/login/apple")
+                    .then().log().all()
+                    .statusCode(200)
+                    .body("accessToken", notNullValue())
+                    .body("refreshToken", notNullValue())
+                    .body("nickname", notNullValue())
+                    .body("isMigrationDecided", is(false));
+        }
+
+        @Test
         @DisplayName("유효하지 않은 ID 토큰인 경우 401 Unauthorized를 응답한다")
         void loginWithInvalidIdToken() {
             // given

--- a/backend/turip-app/src/test/java/turip/auth/api/AuthApiTest.java
+++ b/backend/turip-app/src/test/java/turip/auth/api/AuthApiTest.java
@@ -7,6 +7,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+import static turip.common.exception.ErrorTag.ACCOUNT_CREATION_ERROR;
+import static turip.common.exception.ErrorTag.ID_TOKEN_NOT_VALID;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -16,24 +18,50 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import turip.account.domain.Provider;
 import turip.account.domain.Role;
 import turip.account.service.AccountService;
+import turip.auth.token.AppleTokenParser;
 import turip.auth.token.GoogleTokenParser;
-import turip.common.exception.ErrorTag;
 import turip.common.exception.custom.InternalServerException;
+import turip.common.exception.custom.UnauthorizedException;
 import turip.util.helper.TestDataHelper;
 
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class AuthApiTest {
+
+    private static GoogleTokenParser googleTokenParserMock;
+    private static AppleTokenParser appleTokenParserMock;
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        @Primary
+        public GoogleTokenParser googleTokenParser() {
+            googleTokenParserMock = Mockito.mock(GoogleTokenParser.class);
+            Mockito.when(googleTokenParserMock.getProvider()).thenReturn(Provider.GOOGLE);
+            return googleTokenParserMock;
+        }
+
+        @Bean
+        @Primary
+        public AppleTokenParser appleTokenParser() {
+            appleTokenParserMock = Mockito.mock(AppleTokenParser.class);
+            Mockito.when(appleTokenParserMock.getProvider()).thenReturn(Provider.APPLE);
+            return appleTokenParserMock;
+        }
+    }
 
     @LocalServerPort
     private int port;
@@ -44,9 +72,6 @@ class AuthApiTest {
     @Autowired
     private TestDataHelper testDataHelper;
 
-    @MockitoBean
-    private GoogleTokenParser googleTokenParser;
-
     @MockitoSpyBean
     private AccountService accountService;
 
@@ -54,6 +79,11 @@ class AuthApiTest {
     void setUp() {
         RestAssured.port = port;
         testDataHelper.cleanDatabase();
+
+        // Mock 리셋
+        Mockito.reset(googleTokenParserMock, appleTokenParserMock, accountService);
+        Mockito.when(googleTokenParserMock.getProvider()).thenReturn(Provider.GOOGLE);
+        Mockito.when(appleTokenParserMock.getProvider()).thenReturn(Provider.APPLE);
     }
 
     @Nested
@@ -147,9 +177,9 @@ class AuthApiTest {
             String idToken = "valid-google-id-token";
             String deviceFid = "device-123";
 
-            when(googleTokenParser.getProvider()).thenReturn(Provider.GOOGLE);
-            when(googleTokenParser.getProviderId(idToken)).thenReturn("google-user-123");
-            when(googleTokenParser.getEmail(idToken)).thenReturn("newuser@gmail.com");
+            when(googleTokenParserMock.getProvider()).thenReturn(Provider.GOOGLE);
+            when(googleTokenParserMock.getProviderId(idToken)).thenReturn("google-user-123");
+            when(googleTokenParserMock.getEmail(idToken)).thenReturn("newuser@gmail.com");
 
             Map<String, String> requestBody = new HashMap<>();
             requestBody.put("idToken", idToken);
@@ -180,9 +210,9 @@ class AuthApiTest {
             String idToken = "valid-google-id-token";
             String deviceFid = "device-456";
 
-            when(googleTokenParser.getProvider()).thenReturn(provider);
-            when(googleTokenParser.getProviderId(idToken)).thenReturn(providerId);
-            when(googleTokenParser.getEmail(idToken)).thenReturn(email);
+            when(googleTokenParserMock.getProvider()).thenReturn(provider);
+            when(googleTokenParserMock.getProviderId(idToken)).thenReturn(providerId);
+            when(googleTokenParserMock.getEmail(idToken)).thenReturn(email);
 
             Map<String, String> requestBody = new HashMap<>();
             requestBody.put("idToken", idToken);
@@ -208,10 +238,10 @@ class AuthApiTest {
             String invalidIdToken = "invalid-token";
             String deviceFid = "device-123";
 
-            when(googleTokenParser.getProvider()).thenReturn(Provider.GOOGLE);
-            when(googleTokenParser.getProviderId(anyString()))
-                    .thenThrow(new turip.common.exception.custom.UnauthorizedException(
-                            turip.common.exception.ErrorTag.ID_TOKEN_NOT_VALID));
+            when(googleTokenParserMock.getProvider()).thenReturn(Provider.GOOGLE);
+            when(googleTokenParserMock.getProviderId(anyString()))
+                    .thenThrow(new UnauthorizedException(
+                            ID_TOKEN_NOT_VALID));
 
             Map<String, String> requestBody = new HashMap<>();
             requestBody.put("idToken", invalidIdToken);
@@ -239,10 +269,10 @@ class AuthApiTest {
             String idToken = "valid-google-id-token";
             String deviceFid = "device-456";
 
-            when(googleTokenParser.getProvider()).thenReturn(provider);
-            when(googleTokenParser.getProviderId(idToken)).thenReturn(providerId);
-            when(googleTokenParser.getEmail(idToken)).thenReturn(email);
-            doThrow(new InternalServerException(ErrorTag.ACCOUNT_CREATION_ERROR))
+            when(googleTokenParserMock.getProvider()).thenReturn(provider);
+            when(googleTokenParserMock.getProviderId(idToken)).thenReturn(providerId);
+            when(googleTokenParserMock.getEmail(idToken)).thenReturn(email);
+            doThrow(new InternalServerException(ACCOUNT_CREATION_ERROR))
                     .when(accountService)
                     .create(any());
             Map<String, String> requestBody = new HashMap<>();
@@ -272,9 +302,9 @@ class AuthApiTest {
             String idToken = "valid-google-id-token";
             String deviceFid = "device-123";
 
-            when(googleTokenParser.getProvider()).thenReturn(Provider.GOOGLE);
-            when(googleTokenParser.getProviderId(idToken)).thenReturn("google-user-123");
-            when(googleTokenParser.getEmail(idToken)).thenReturn("newuser@gmail.com");
+            when(googleTokenParserMock.getProvider()).thenReturn(Provider.GOOGLE);
+            when(googleTokenParserMock.getProviderId(idToken)).thenReturn("google-user-123");
+            when(googleTokenParserMock.getEmail(idToken)).thenReturn("newuser@gmail.com");
 
             Map<String, String> requestBody = new HashMap<>();
             requestBody.put("idToken", idToken);
@@ -300,10 +330,9 @@ class AuthApiTest {
             String invalidIdToken = "invalid-token";
             String deviceFid = "device-123";
 
-            when(googleTokenParser.getProvider()).thenReturn(Provider.GOOGLE);
-            when(googleTokenParser.getProviderId(anyString()))
-                    .thenThrow(new turip.common.exception.custom.UnauthorizedException(
-                            turip.common.exception.ErrorTag.ID_TOKEN_NOT_VALID));
+            when(googleTokenParserMock.getProvider()).thenReturn(Provider.GOOGLE);
+            when(googleTokenParserMock.getProviderId(anyString()))
+                    .thenThrow(new UnauthorizedException(ID_TOKEN_NOT_VALID));
 
             Map<String, String> requestBody = new HashMap<>();
             requestBody.put("idToken", invalidIdToken);
@@ -331,10 +360,10 @@ class AuthApiTest {
             String idToken = "valid-google-id-token";
             String deviceFid = "device-456";
 
-            when(googleTokenParser.getProvider()).thenReturn(provider);
-            when(googleTokenParser.getProviderId(idToken)).thenReturn(providerId);
-            when(googleTokenParser.getEmail(idToken)).thenReturn(email);
-            doThrow(new InternalServerException(ErrorTag.ACCOUNT_CREATION_ERROR))
+            when(googleTokenParserMock.getProvider()).thenReturn(provider);
+            when(googleTokenParserMock.getProviderId(idToken)).thenReturn(providerId);
+            when(googleTokenParserMock.getEmail(idToken)).thenReturn(email);
+            doThrow(new InternalServerException(ACCOUNT_CREATION_ERROR))
                     .when(accountService)
                     .create(any());
             Map<String, String> requestBody = new HashMap<>();
@@ -347,6 +376,128 @@ class AuthApiTest {
                     .header("device-fid", deviceFid)
                     .body(requestBody)
                     .when().post("/api/v2/auth/login/google")
+                    .then().log().all()
+                    .statusCode(500)
+                    .body("tag", is("ACCOUNT_CREATION_ERROR"));
+        }
+    }
+
+    @Nested
+    @DisplayName("/api/v1/auth/login/apple POST 애플 로그인 테스트")
+    class LoginWithAppleTest {
+
+        @Test
+        @DisplayName("신규 소셜 회원 로그인 성공 시 200 Ok와 토큰을 응답한다")
+        void loginNewMemberSuccess() {
+            // given
+            String idToken = "valid-apple-id-token";
+            String deviceFid = "device-123";
+
+            when(appleTokenParserMock.getProviderId(idToken)).thenReturn("apple-user-123");
+            when(appleTokenParserMock.getEmail(idToken)).thenReturn("newuser@icloud.com");
+
+            Map<String, String> requestBody = new HashMap<>();
+            requestBody.put("idToken", idToken);
+
+            // when & then
+            RestAssured
+                    .given().log().all()
+                    .contentType(ContentType.JSON)
+                    .header("device-fid", deviceFid)
+                    .body(requestBody)
+                    .when().post("/api/v1/auth/login/apple")
+                    .then().log().all()
+                    .statusCode(200)
+                    .body("accessToken", notNullValue())
+                    .body("refreshToken", notNullValue())
+                    .body("nickname", notNullValue())
+                    .body("isMigrationDecided", is(false));
+        }
+
+        @Test
+        @DisplayName("기존 소셜 회원 로그인 성공 시 200 OK와 토큰을 응답한다")
+        void loginExistingMemberSuccess() {
+            // given
+            String email = "existing@icloud.com";
+            Provider provider = Provider.APPLE;
+            String providerId = "apple-user-existing";
+            testDataHelper.insertSocialMember(email, false, provider, providerId);
+
+            String idToken = "valid-apple-id-token";
+            String deviceFid = "device-456";
+
+            when(appleTokenParserMock.getProviderId(idToken)).thenReturn(providerId);
+            when(appleTokenParserMock.getEmail(idToken)).thenReturn(email);
+
+            Map<String, String> requestBody = new HashMap<>();
+            requestBody.put("idToken", idToken);
+
+            // when & then
+            RestAssured
+                    .given().log().all()
+                    .contentType(ContentType.JSON)
+                    .header("device-fid", deviceFid)
+                    .body(requestBody)
+                    .when().post("/api/v1/auth/login/apple")
+                    .then().log().all()
+                    .statusCode(200)
+                    .body("accessToken", notNullValue())
+                    .body("refreshToken", notNullValue())
+                    .body("nickname", notNullValue())
+                    .body("isMigrationDecided", is(false));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 ID 토큰인 경우 401 Unauthorized를 응답한다")
+        void loginWithInvalidIdToken() {
+            // given
+            String invalidIdToken = "invalid-token";
+            String deviceFid = "device-123";
+
+            when(appleTokenParserMock.getProviderId(anyString()))
+                    .thenThrow(new UnauthorizedException(
+                            ID_TOKEN_NOT_VALID));
+
+            Map<String, String> requestBody = new HashMap<>();
+            requestBody.put("idToken", invalidIdToken);
+
+            // when & then
+            RestAssured
+                    .given().log().all()
+                    .contentType(ContentType.JSON)
+                    .header("device-fid", deviceFid)
+                    .body(requestBody)
+                    .when().post("/api/v1/auth/login/apple")
+                    .then().log().all()
+                    .statusCode(401)
+                    .body("tag", is("ID_TOKEN_NOT_VALID"));
+        }
+
+        @Test
+        @DisplayName("계정 생성에 실패한 경우 500 Internal Server Error를 응답한다")
+        void accountCreationFailed() {
+            // given
+            String email = "newuser@icloud.com";
+            String providerId = "apple-user-new";
+
+            String idToken = "valid-apple-id-token";
+            String deviceFid = "device-456";
+
+            when(appleTokenParserMock.getProviderId(idToken)).thenReturn(providerId);
+            when(appleTokenParserMock.getEmail(idToken)).thenReturn(email);
+            doThrow(new InternalServerException(ACCOUNT_CREATION_ERROR))
+                    .when(accountService)
+                    .create(any());
+            Map<String, String> requestBody = new HashMap<>();
+            requestBody.put("idToken", idToken);
+
+            // when & then
+            RestAssured
+                    .given().log().all()
+                    .contentType(ContentType.JSON)
+                    .header("device-fid", deviceFid)
+                    .body(requestBody)
+                    .when().post("/api/v1/auth/login/apple")
                     .then().log().all()
                     .statusCode(500)
                     .body("tag", is("ACCOUNT_CREATION_ERROR"));
@@ -370,9 +521,9 @@ class AuthApiTest {
             String idToken = "valid-google-id-token";
             String deviceFid = "device-refresh-123";
 
-            when(googleTokenParser.getProvider()).thenReturn(provider);
-            when(googleTokenParser.getProviderId(idToken)).thenReturn(providerId);
-            when(googleTokenParser.getEmail(idToken)).thenReturn(email);
+            when(googleTokenParserMock.getProvider()).thenReturn(provider);
+            when(googleTokenParserMock.getProviderId(idToken)).thenReturn(providerId);
+            when(googleTokenParserMock.getEmail(idToken)).thenReturn(email);
 
             Map<String, String> loginRequest = new HashMap<>();
             loginRequest.put("idToken", idToken);
@@ -437,9 +588,9 @@ class AuthApiTest {
             String idToken = "valid-google-id-token";
             String deviceFid = "device-mismatch-123";
 
-            when(googleTokenParser.getProvider()).thenReturn(provider);
-            when(googleTokenParser.getProviderId(idToken)).thenReturn(providerId);
-            when(googleTokenParser.getEmail(idToken)).thenReturn(email);
+            when(googleTokenParserMock.getProvider()).thenReturn(provider);
+            when(googleTokenParserMock.getProviderId(idToken)).thenReturn(providerId);
+            when(googleTokenParserMock.getEmail(idToken)).thenReturn(email);
 
             Map<String, String> loginRequest = new HashMap<>();
             loginRequest.put("idToken", idToken);
@@ -462,8 +613,8 @@ class AuthApiTest {
             String otherIdToken = "other-valid-google-id-token";
             String otherDeviceFid = "device-other-123";
 
-            when(googleTokenParser.getProviderId(otherIdToken)).thenReturn(providerId2);
-            when(googleTokenParser.getEmail(otherIdToken)).thenReturn(email2);
+            when(googleTokenParserMock.getProviderId(otherIdToken)).thenReturn(providerId2);
+            when(googleTokenParserMock.getEmail(otherIdToken)).thenReturn(email2);
 
             Map<String, String> otherLoginRequest = new HashMap<>();
             otherLoginRequest.put("idToken", otherIdToken);
@@ -510,9 +661,9 @@ class AuthApiTest {
             String idToken = "valid-google-id-token";
             String deviceFid = "device-logout-123";
 
-            when(googleTokenParser.getProvider()).thenReturn(provider);
-            when(googleTokenParser.getProviderId(idToken)).thenReturn(providerId);
-            when(googleTokenParser.getEmail(idToken)).thenReturn(email);
+            when(googleTokenParserMock.getProvider()).thenReturn(provider);
+            when(googleTokenParserMock.getProviderId(idToken)).thenReturn(providerId);
+            when(googleTokenParserMock.getEmail(idToken)).thenReturn(email);
 
             Map<String, String> loginRequest = new HashMap<>();
             loginRequest.put("idToken", idToken);
@@ -551,9 +702,9 @@ class AuthApiTest {
             String idToken = "valid-google-id-token";
             String deviceFid = "device-logout-delete-123";
 
-            when(googleTokenParser.getProvider()).thenReturn(provider);
-            when(googleTokenParser.getProviderId(idToken)).thenReturn(providerId);
-            when(googleTokenParser.getEmail(idToken)).thenReturn(email);
+            when(googleTokenParserMock.getProvider()).thenReturn(provider);
+            when(googleTokenParserMock.getProviderId(idToken)).thenReturn(providerId);
+            when(googleTokenParserMock.getEmail(idToken)).thenReturn(email);
 
             Map<String, String> loginRequest = new HashMap<>();
             loginRequest.put("idToken", idToken);

--- a/backend/turip-app/src/test/java/turip/auth/service/AuthServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/auth/service/AuthServiceTest.java
@@ -13,6 +13,7 @@ import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.Date;
+import java.util.Optional;
 import javax.crypto.SecretKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -151,7 +152,7 @@ class AuthServiceTest {
             when(idTokenParserResolver.resolve(provider)).thenReturn(idTokenParser);
             when(idTokenParser.getProviderId(idToken)).thenReturn(providerId);
             when(idTokenParser.getEmail(idToken)).thenReturn(email);
-            when(socialMemberService.findOrCreate(provider, providerId, email)).thenReturn(socialMember);
+            when(socialMemberService.findOrCreate(provider, providerId, Optional.of(email))).thenReturn(socialMember);
             when(jwtProvider.generateAccessToken(1L, account.getRole())).thenReturn(accessToken);
             when(jwtProvider.generateRefreshToken(1L, account.getRole())).thenReturn(refreshToken);
             when(jwtProvider.getIssuedAt(anyString())).thenReturn(LocalDateTime.now());
@@ -194,7 +195,7 @@ class AuthServiceTest {
             when(idTokenParserResolver.resolve(provider)).thenReturn(idTokenParser);
             when(idTokenParser.getProviderId(idToken)).thenReturn(providerId);
             when(idTokenParser.getEmail(idToken)).thenReturn(email);
-            when(socialMemberService.findOrCreate(provider, providerId, email)).thenReturn(socialMember);
+            when(socialMemberService.findOrCreate(provider, providerId, Optional.of(email))).thenReturn(socialMember);
             when(jwtProvider.generateAccessToken(1L, account.getRole())).thenReturn("access-token");
             when(jwtProvider.generateRefreshToken(1L, account.getRole())).thenReturn("refresh-token");
             when(jwtProvider.getIssuedAt(anyString())).thenReturn(LocalDateTime.now());

--- a/backend/turip-app/src/test/java/turip/auth/service/AuthServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/auth/service/AuthServiceTest.java
@@ -30,14 +30,15 @@ import turip.account.domain.TuripMember;
 import turip.account.service.MemberService;
 import turip.account.service.SocialMemberService;
 import turip.account.service.TuripMemberService;
-import turip.auth.controller.dto.request.GoogleLoginRequest;
 import turip.auth.controller.dto.request.RefreshTokenRequest;
+import turip.auth.controller.dto.request.SocialLoginRequest;
 import turip.auth.controller.dto.request.TuripLoginRequest;
 import turip.auth.controller.dto.response.RefreshTokenResponse;
 import turip.auth.domain.RefreshToken;
 import turip.auth.service.dto.SocialLoginResult;
 import turip.auth.service.dto.TuripLoginResult;
-import turip.auth.token.GoogleTokenParser;
+import turip.auth.token.IdTokenParser;
+import turip.auth.token.IdTokenParserResolver;
 import turip.auth.token.JwtProvider;
 import turip.common.exception.ErrorTag;
 import turip.common.exception.custom.NotFoundException;
@@ -54,7 +55,10 @@ class AuthServiceTest {
     private JwtProvider jwtProvider;
 
     @Mock
-    private GoogleTokenParser googleTokenParser;
+    private IdTokenParserResolver idTokenParserResolver;
+
+    @Mock
+    private IdTokenParser idTokenParser;
 
     @Mock
     private MemberService memberService;
@@ -142,11 +146,11 @@ class AuthServiceTest {
             String accessToken = "access-token";
             String refreshToken = "refresh-token";
 
-            GoogleLoginRequest request = new GoogleLoginRequest(idToken);
+            SocialLoginRequest request = new SocialLoginRequest(idToken);
 
-            when(googleTokenParser.getProvider()).thenReturn(provider);
-            when(googleTokenParser.getProviderId(idToken)).thenReturn(providerId);
-            when(googleTokenParser.getEmail(idToken)).thenReturn(email);
+            when(idTokenParserResolver.resolve(provider)).thenReturn(idTokenParser);
+            when(idTokenParser.getProviderId(idToken)).thenReturn(providerId);
+            when(idTokenParser.getEmail(idToken)).thenReturn(email);
             when(socialMemberService.findOrCreate(provider, providerId, email)).thenReturn(socialMember);
             when(jwtProvider.generateAccessToken(1L, account.getRole())).thenReturn(accessToken);
             when(jwtProvider.generateRefreshToken(1L, account.getRole())).thenReturn(refreshToken);
@@ -185,11 +189,11 @@ class AuthServiceTest {
             Member member = MemberFixture.createCustomMember(account, email, true);
             SocialMember socialMember = SocialMemberFixture.createCustomSocialMember(member, provider, providerId);
 
-            GoogleLoginRequest request = new GoogleLoginRequest(idToken);
+            SocialLoginRequest request = new SocialLoginRequest(idToken);
 
-            when(googleTokenParser.getProvider()).thenReturn(provider);
-            when(googleTokenParser.getProviderId(idToken)).thenReturn(providerId);
-            when(googleTokenParser.getEmail(idToken)).thenReturn(email);
+            when(idTokenParserResolver.resolve(provider)).thenReturn(idTokenParser);
+            when(idTokenParser.getProviderId(idToken)).thenReturn(providerId);
+            when(idTokenParser.getEmail(idToken)).thenReturn(email);
             when(socialMemberService.findOrCreate(provider, providerId, email)).thenReturn(socialMember);
             when(jwtProvider.generateAccessToken(1L, account.getRole())).thenReturn("access-token");
             when(jwtProvider.generateRefreshToken(1L, account.getRole())).thenReturn("refresh-token");
@@ -217,10 +221,10 @@ class AuthServiceTest {
             // given
             String invalidIdToken = "invalid-token";
             String deviceFid = "device-123";
-            GoogleLoginRequest request = new GoogleLoginRequest(invalidIdToken);
+            SocialLoginRequest request = new SocialLoginRequest(invalidIdToken);
 
-            when(googleTokenParser.getProvider()).thenReturn(Provider.GOOGLE);
-            when(googleTokenParser.getProviderId(invalidIdToken))
+            when(idTokenParserResolver.resolve(Provider.GOOGLE)).thenReturn(idTokenParser);
+            when(idTokenParser.getProviderId(invalidIdToken))
                     .thenThrow(new UnauthorizedException(ErrorTag.ID_TOKEN_NOT_VALID));
 
             // when & then

--- a/backend/turip-app/src/test/java/turip/auth/token/IdTokenParserResolverTest.java
+++ b/backend/turip-app/src/test/java/turip/auth/token/IdTokenParserResolverTest.java
@@ -1,7 +1,6 @@
 package turip.auth.token;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -12,8 +11,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import turip.account.domain.Provider;
-import turip.common.exception.ErrorTag;
-import turip.common.exception.custom.UnauthorizedException;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("IdTokenParserResolver 테스트")

--- a/backend/turip-app/src/test/java/turip/auth/token/IdTokenParserResolverTest.java
+++ b/backend/turip-app/src/test/java/turip/auth/token/IdTokenParserResolverTest.java
@@ -1,0 +1,58 @@
+package turip.auth.token;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import turip.account.domain.Provider;
+import turip.common.exception.ErrorTag;
+import turip.common.exception.custom.UnauthorizedException;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("IdTokenParserResolver 테스트")
+class IdTokenParserResolverTest {
+
+    @Mock
+    private GoogleTokenParser googleTokenParser;
+
+    @Mock
+    private AppleTokenParser appleTokenParser;
+
+    private IdTokenParserResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        when(googleTokenParser.getProvider()).thenReturn(Provider.GOOGLE);
+        when(appleTokenParser.getProvider()).thenReturn(Provider.APPLE);
+
+        List<IdTokenParser> parsers = List.of(googleTokenParser, appleTokenParser);
+        resolver = new IdTokenParserResolver(parsers);
+    }
+
+    @Test
+    @DisplayName("GOOGLE Provider에 대해 GoogleTokenParser를 반환한다")
+    void resolveGoogleTokenParser() {
+        // when
+        IdTokenParser result = resolver.resolve(Provider.GOOGLE);
+
+        // then
+        assertThat(result).isEqualTo(googleTokenParser);
+    }
+
+    @Test
+    @DisplayName("APPLE Provider에 대해 AppleTokenParser를 반환한다")
+    void resolveAppleTokenParser() {
+        // when
+        IdTokenParser result = resolver.resolve(Provider.APPLE);
+
+        // then
+        assertThat(result).isEqualTo(appleTokenParser);
+    }
+}

--- a/backend/turip-app/src/test/resources/application-test-mysql.yml
+++ b/backend/turip-app/src/test/resources/application-test-mysql.yml
@@ -26,6 +26,7 @@ jwt:
 # Google OAuth 설정 (테스트용)
 google:
   client-id: test-google-client-id.apps.googleusercontent.com
+  ios-client-id: test-google-ios-client-id.apps.googleusercontent.com
   api:
     key: test-google-api-key
     url: https://test.google.com
@@ -39,6 +40,9 @@ youtube:
   api:
     key: test-youtube-api-key
     url: https://test.youtube.com
+
+apple:
+  client-id: com.teamturip.test
 
 # CSV Import 설정
 csv:

--- a/backend/turip-app/src/test/resources/application-test.yml
+++ b/backend/turip-app/src/test/resources/application-test.yml
@@ -33,6 +33,7 @@ jwt:
 # Google OAuth 설정 (테스트용)
 google:
   client-id: test-google-client-id.apps.googleusercontent.com
+  ios-client-id: test-google-ios-client-id.apps.googleusercontent.com
   api:
     key: test-google-api-key
     url: https://test.google.com
@@ -46,6 +47,9 @@ youtube:
   api:
     key: test-youtube-api-key
     url: https://test.youtube.com
+
+apple:
+  client-id: com.teamturip.test
 
 # CSV Import 설정
 csv:


### PR DESCRIPTION
## Issues
- closed #678 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description

- 애플 로그인 구현
- 구글, 애플 로그인 요청에 공통으로 사용하기 위한 SocialLoginRequest 추가
  - 두 로그인 요청 모두 idToken만 요청으로 받아오기 때문에 중복 사용
- IdTokenParserResolver 추가
  - provider(소셜 로그인 종류)에 대한 IdTokenParser를 얻어올 수 있는 IdTokenParserResolver를 추가함으로써 AuthService에서는 구체적은 Parser type에 의존하지 않도록 설정

## 📷 Screenshot

## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
- Apple 로그인 기능 추가(새 로그인 엔드포인트 제공)

## 개선 사항
- Google 로그인에 iOS용 클라이언트 식별자 지원 범위 확대
- 소셜 로그인 요청 처리 방식을 통합해 다중 제공자 지원을 강화

## 테스트
- Apple/Google 소셜 로그인 흐름에 대한 테스트 및 토큰 검증 모킹 로직을 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->