### PR TITLE
[feat] 어드민 검수 요청 페이지 개선

### DIFF
--- a/backend/turip-admin/src/main/java/turip/controller/AdminPendingContentController.java
+++ b/backend/turip-admin/src/main/java/turip/controller/AdminPendingContentController.java
@@ -35,6 +35,11 @@ public class AdminPendingContentController {
         return ResponseEntity.ok(adminContentPendingService.findAll());
     }
 
+    @GetMapping("/my-list")
+    public ResponseEntity<List<PendingListResponse>> findMyPending(@AuthAdmin TuripMember admin) {
+        return ResponseEntity.ok(adminContentPendingService.findByValidatorAccount(admin.getMember().getAccount()));
+    }
+
     @GetMapping("/{id}")
     public ResponseEntity<ContentPendingResponse> findById(
             @AuthAdmin TuripMember admin,

--- a/backend/turip-admin/src/main/java/turip/controller/AdminPendingContentController.java
+++ b/backend/turip-admin/src/main/java/turip/controller/AdminPendingContentController.java
@@ -40,6 +40,11 @@ public class AdminPendingContentController {
         return ResponseEntity.ok(adminContentPendingService.findByValidatorAccount(admin.getMember().getAccount()));
     }
 
+    @GetMapping("/my-count")
+    public ResponseEntity<Long> countMyPending(@AuthAdmin TuripMember admin) {
+        return ResponseEntity.ok(adminContentPendingService.countMyPending(admin.getMember().getAccount()));
+    }
+
     @GetMapping("/{id}")
     public ResponseEntity<ContentPendingResponse> findById(
             @AuthAdmin TuripMember admin,

--- a/backend/turip-admin/src/main/java/turip/controller/dto/response/PendingListResponse.java
+++ b/backend/turip-admin/src/main/java/turip/controller/dto/response/PendingListResponse.java
@@ -8,6 +8,7 @@ public record PendingListResponse(
         String videoTitle,
         String channelName,
         String collectorNickname,
+        String validatorNickname,
         LocalDateTime createdAt
 ) {
 
@@ -17,6 +18,7 @@ public record PendingListResponse(
                 p.getContentData().video().title(),
                 p.getContentData().video().channelName(),
                 p.getCollectorAccount().getNickname(),
+                p.getValidatorAccount() != null ? p.getValidatorAccount().getNickname() : null,
                 p.getCreatedAt()
         );
     }

--- a/backend/turip-admin/src/main/java/turip/service/AdminContentPendingService.java
+++ b/backend/turip-admin/src/main/java/turip/service/AdminContentPendingService.java
@@ -59,6 +59,13 @@ public class AdminContentPendingService {
                 .toList();
     }
 
+    public long countMyPending(Account validatorAccount) {
+        return contentPendingRepository.countByStatusAndValidatorAccount(
+                ContentPendingStatus.PENDING,
+                validatorAccount
+        );
+    }
+
     public List<MyCollectContentResponse> getMyHistory(Account account) {
         return contentPendingRepository.findAllByCollectorAccountOrderByIdDesc(account)
                 .stream()

--- a/backend/turip-admin/src/main/java/turip/service/AdminContentPendingService.java
+++ b/backend/turip-admin/src/main/java/turip/service/AdminContentPendingService.java
@@ -49,6 +49,16 @@ public class AdminContentPendingService {
                 .toList();
     }
 
+    public List<PendingListResponse> findByValidatorAccount(Account validatorAccount) {
+        return contentPendingRepository.findAllByStatusAndValidatorAccountOrderByIdDesc(
+                        ContentPendingStatus.PENDING,
+                        validatorAccount
+                )
+                .stream()
+                .map(PendingListResponse::from)
+                .toList();
+    }
+
     public List<MyCollectContentResponse> getMyHistory(Account account) {
         return contentPendingRepository.findAllByCollectorAccountOrderByIdDesc(account)
                 .stream()

--- a/backend/turip-admin/src/main/resources/templates/admin/home.html
+++ b/backend/turip-admin/src/main/resources/templates/admin/home.html
@@ -216,7 +216,7 @@
                 <span class="badge" id="pendingBadge">0</span>
             </div>
             <div class="notification-dropdown" id="notifDropdown">
-                <div class="dropdown-header">최신 검수 요청</div>
+                <div class="dropdown-header">내 검수 요청</div>
                 <div class="dropdown-body" id="notifList">
                     <div class="empty-state">내역이 없습니다.</div>
                 </div>
@@ -268,7 +268,7 @@
     async function fetchRecentPending() {
         const container = document.getElementById('notifList');
         try {
-            const res = await fetch('/api/v1/admin/content-pendings/list');
+            const res = await fetch('/api/v1/admin/content-pendings/my-list');
 
             if (!res.ok) {
                 const errorData = await res.json().catch(() => null);
@@ -279,7 +279,7 @@
             const list = await res.json();
 
             if (!list || list.length === 0) {
-                container.innerHTML = '<div class="empty-state">새로운 요청이 없습니다.</div>';
+                container.innerHTML = '<div class="empty-state">나에게 배정된 요청이 없습니다.</div>';
                 return;
             }
 
@@ -309,16 +309,16 @@
 
     async function updatePendingCount() {
         try {
-            const res = await fetch('/api/v1/admin/content-pendings/list');
+            const res = await fetch('/api/v1/admin/content-pendings/my-count');
 
             if (!res.ok) {
                 throw new Error(`서버 오류 (${res.status})`);
             }
 
-            const list = await res.json();
+            const count = await res.json();
             const badge = document.getElementById('pendingBadge');
-            if (list.length > 0) {
-                badge.innerText = list.length > 99 ? '99+' : list.length;
+            if (count > 0) {
+                badge.innerText = count > 99 ? '99+' : count;
                 badge.style.display = 'block';
             } else {
                 badge.style.display = 'none';

--- a/backend/turip-admin/src/main/resources/templates/admin/pending-list.html
+++ b/backend/turip-admin/src/main/resources/templates/admin/pending-list.html
@@ -128,6 +128,36 @@
             color: #999;
             font-style: italic;
         }
+
+        /* 탭 스타일 */
+        .tab-container {
+            display: flex;
+            gap: 10px;
+            margin-bottom: 20px;
+            border-bottom: 2px solid #f0f0f0;
+        }
+
+        .tab-button {
+            padding: 12px 24px;
+            background: transparent;
+            border: none;
+            color: #888;
+            font-size: 15px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: 0.2s;
+            border-bottom: 3px solid transparent;
+            margin-bottom: -2px;
+        }
+
+        .tab-button:hover {
+            color: #6e8efb;
+        }
+
+        .tab-button.active {
+            color: #6e8efb;
+            border-bottom-color: #6e8efb;
+        }
     </style>
 </head>
 <body>
@@ -140,6 +170,11 @@
 <div class="container">
     <div class="admin-card">
         <h3 class="section-title">검수 대기 목록</h3>
+
+        <div class="tab-container">
+            <button class="tab-button active" data-tab="my" onclick="switchTab('my')">내 검수 요청</button>
+            <button class="tab-button" data-tab="all" onclick="switchTab('all')">전체 검수 요청</button>
+        </div>
 
         <div class="table-responsive">
             <table class="table table-hover">
@@ -161,10 +196,29 @@
 </div>
 
 <script>
-    async function loadPendingList() {
+    let currentTab = 'my'; // 기본 탭은 '내 검수 요청'
+
+    function switchTab(tab) {
+        currentTab = tab;
+
+        // 탭 버튼 active 클래스 변경
+        document.querySelectorAll('.tab-button').forEach(btn => {
+            btn.classList.remove('active');
+        });
+        document.querySelector(`[data-tab="${tab}"]`).classList.add('active');
+
+        // 데이터 로드
+        loadPendingList(tab);
+    }
+
+    async function loadPendingList(tab = 'my') {
         const tbody = document.getElementById('pendingTableBody');
+        const endpoint = tab === 'my'
+            ? '/api/v1/admin/content-pendings/my-list'
+            : '/api/v1/admin/content-pendings/list';
+
         try {
-            const res = await fetch('/api/v1/admin/content-pendings/list');
+            const res = await fetch(endpoint);
 
             if (!res.ok) {
                 const errorData = await res.json().catch(() => null);
@@ -175,7 +229,10 @@
             const list = await res.json();
 
             if (list.length === 0) {
-                tbody.innerHTML = '<tr><td colspan="6" class="text-center py-5 text-muted">검수 대기 중인 콘텐츠가 없습니다.</td></tr>';
+                const emptyMessage = tab === 'my'
+                    ? '나에게 배정된 검수 요청이 없습니다.'
+                    : '검수 대기 중인 콘텐츠가 없습니다.';
+                tbody.innerHTML = `<tr><td colspan="6" class="text-center py-5 text-muted">${emptyMessage}</td></tr>`;
                 return;
             }
 
@@ -238,7 +295,7 @@
         }
     }
 
-    document.addEventListener('DOMContentLoaded', loadPendingList);
+    document.addEventListener('DOMContentLoaded', () => loadPendingList('my'));
 </script>
 </body>
 </html>

--- a/backend/turip-admin/src/main/resources/templates/admin/pending-list.html
+++ b/backend/turip-admin/src/main/resources/templates/admin/pending-list.html
@@ -118,6 +118,16 @@
             font-weight: 600;
             color: #444;
         }
+
+        .validator-name {
+            font-weight: 600;
+            color: #6e8efb;
+        }
+
+        .not-assigned {
+            color: #999;
+            font-style: italic;
+        }
     </style>
 </head>
 <body>
@@ -137,7 +147,8 @@
                 <tr>
                     <th style="width: 50px;">ID</th>
                     <th>영상 정보</th>
-                    <th style="width: 200px;">수집자</th>
+                    <th style="width: 150px;">수집자</th>
+                    <th style="width: 150px;">담당자</th>
                     <th style="width: 100px; text-align: center;">상태</th>
                     <th style="width: 120px; text-align: right;">관리</th>
                 </tr>
@@ -164,7 +175,7 @@
             const list = await res.json();
 
             if (list.length === 0) {
-                tbody.innerHTML = '<tr><td colspan="5" class="text-center py-5 text-muted">검수 대기 중인 콘텐츠가 없습니다.</td></tr>';
+                tbody.innerHTML = '<tr><td colspan="6" class="text-center py-5 text-muted">검수 대기 중인 콘텐츠가 없습니다.</td></tr>';
                 return;
             }
 
@@ -192,6 +203,16 @@
                 tdCollector.textContent = item.collectorNickname;
                 tr.appendChild(tdCollector);
 
+                const tdValidator = document.createElement('td');
+                if (item.validatorNickname) {
+                    tdValidator.className = 'validator-name';
+                    tdValidator.textContent = item.validatorNickname;
+                } else {
+                    tdValidator.className = 'not-assigned';
+                    tdValidator.textContent = '미배정';
+                }
+                tr.appendChild(tdValidator);
+
                 const tdStatus = document.createElement('td');
                 tdStatus.className = 'text-center';
                 const statusBadge = document.createElement('span');
@@ -213,7 +234,7 @@
             });
         } catch (e) {
             console.error("데이터 로드 실패:", e);
-            tbody.innerHTML = '<tr><td colspan="5" class="text-center py-5 text-danger">⚠️ 데이터를 불러오는데 실패했습니다: ' + e.message + '</td></tr>';
+            tbody.innerHTML = '<tr><td colspan="6" class="text-center py-5 text-danger">⚠️ 데이터를 불러오는데 실패했습니다: ' + e.message + '</td></tr>';
         }
     }
 

--- a/backend/turip-admin/src/test/java/turip/controller/AdminPendingContentApiTest.java
+++ b/backend/turip-admin/src/test/java/turip/controller/AdminPendingContentApiTest.java
@@ -343,7 +343,8 @@ class AdminPendingContentApiTest extends TestContainerConfig {
 
             // validator로 지정될 다른 admin 계정 생성
             Long validatorAccountId = testDataHelper.insertAccount(Role.ADMIN);
-            testDataHelper.insertTuripMember(validatorAccountId, "validator@turip.com", false, "validator", "password123!");
+            testDataHelper.insertTuripMember(validatorAccountId, "validator@turip.com", false, "validator",
+                    "password123!");
 
             ContentPendingData contentData = ContentPendingFixture.createTestContentData("서울");
 
@@ -388,7 +389,8 @@ class AdminPendingContentApiTest extends TestContainerConfig {
 
             // validator로 지정될 다른 admin 계정 생성
             Long validatorAccountId = testDataHelper.insertAccount(Role.ADMIN);
-            testDataHelper.insertTuripMember(validatorAccountId, "validator@turip.com", false, "validator", "password123!");
+            testDataHelper.insertTuripMember(validatorAccountId, "validator@turip.com", false, "validator",
+                    "password123!");
 
             Account collectorAccount = AccountFixture.createCustomAccount(1L, Role.ADMIN);
             Long collectorAccountId = testDataHelper.insertAccount(collectorAccount);
@@ -515,6 +517,120 @@ class AdminPendingContentApiTest extends TestContainerConfig {
             RestAssured.given().port(port)
                     .header("Authorization", "Bearer " + userAccessToken)
                     .when().get("/api/v1/admin/content-pendings/list")
+                    .then()
+                    .statusCode(403);
+        }
+    }
+
+    @DisplayName("/api/v1/admin/content-pendings/my-list GET 나의 펜딩 콘텐츠 목록 조회 테스트")
+    @Nested
+    class FindMyPendingTest {
+
+        @DisplayName("관리자가 나의 펜딩 콘텐츠 목록을 조회하면 200 OK와 PENDING 상태의 콘텐츠 리스트를 응답한다")
+        @Test
+        void findMyPending1() {
+            // given
+            Account validator = AccountFixture.createCustomAccount(1L, Role.ADMIN);
+            Long validatorAccountId = testDataHelper.insertAccount(validator);
+            testDataHelper.insertTuripMember(validatorAccountId, "admin@turip.com", false, "admin", "password123!");
+            String validatorAccessToken = testDataHelper.createAccessToken(validatorAccountId, Role.ADMIN);
+
+            Account collectorAccount1 = AccountFixture.createCustomAccount(2L, Role.ADMIN);
+            Long collectorAccountId1 = testDataHelper.insertAccount(collectorAccount1);
+            ReflectionTestUtils.setField(collectorAccount1, "id", collectorAccountId1);
+
+            Account collectorAccount2 = AccountFixture.createCustomAccount(3L, Role.ADMIN);
+            Long collectorAccountId2 = testDataHelper.insertAccount(collectorAccount2);
+            ReflectionTestUtils.setField(collectorAccount2, "id", collectorAccountId2);
+
+            ContentPendingData contentData1 = ContentPendingFixture.createTestContentData("서울");
+            ContentPending contentPending1 = new ContentPending(contentData1, collectorAccount1, validator, null, null);
+            contentPendingRepository.save(contentPending1);
+
+            ContentPendingData contentData2 = ContentPendingFixture.createTestContentData("부산");
+            ContentPending contentPending2 = new ContentPending(contentData2, collectorAccount2, collectorAccount1,
+                    null, null);
+            contentPendingRepository.save(contentPending2);
+
+            // when & then
+            RestAssured.given().port(port)
+                    .header("Authorization", "Bearer " + validatorAccessToken)
+                    .when().get("/api/v1/admin/content-pendings/my-list")
+                    .then()
+                    .statusCode(200)
+                    .body("$", hasSize(1))
+                    .body("[0].id", notNullValue())
+                    .body("[0].videoTitle", is("테스트 비디오"))
+                    .body("[0].channelName", is("테스트 채널"))
+                    .body("[0].collectorNickname", notNullValue())
+                    .body("[0].createdAt", notNullValue());
+        }
+
+        @DisplayName("펜딩 콘텐츠가 없는 경우 빈 리스트를 응답한다")
+        @Test
+        void findMyPending_EmptyList() {
+            // given
+            Long adminAccountId = testDataHelper.insertAccount(Role.ADMIN);
+            testDataHelper.insertTuripMember(adminAccountId, "admin@turip.com", false, "admin", "password123!");
+            String adminAccessToken = testDataHelper.createAccessToken(adminAccountId, Role.ADMIN);
+
+            // when & then
+            RestAssured.given().port(port)
+                    .header("Authorization", "Bearer " + adminAccessToken)
+                    .when().get("/api/v1/admin/content-pendings/my-list")
+                    .then()
+                    .statusCode(200)
+                    .body("$", hasSize(0));
+        }
+
+        @DisplayName("PENDING 상태가 아닌 콘텐츠는 목록에 포함되지 않는다")
+        @Test
+        void findMyPending_OnlyPendingStatus() {
+            // given
+            Account validator = AccountFixture.createCustomAccount(1L, Role.ADMIN);
+            Long validatorAccountId = testDataHelper.insertAccount(validator);
+            testDataHelper.insertTuripMember(validatorAccountId, "admin@turip.com", false, "admin", "password123!");
+            String validatorAccessToken = testDataHelper.createAccessToken(validatorAccountId, Role.ADMIN);
+
+            Account collectorAccount1 = AccountFixture.createCustomAccount(2L, Role.ADMIN);
+            Long collectorAccountId1 = testDataHelper.insertAccount(collectorAccount1);
+            ReflectionTestUtils.setField(collectorAccount1, "id", collectorAccountId1);
+
+            Account collectorAccount2 = AccountFixture.createCustomAccount(3L, Role.ADMIN);
+            Long collectorAccountId2 = testDataHelper.insertAccount(collectorAccount2);
+            ReflectionTestUtils.setField(collectorAccount2, "id", collectorAccountId2);
+
+            ContentPendingData contentData1 = ContentPendingFixture.createTestContentData("서울");
+            ContentPending contentPending1 = new ContentPending(contentData1, collectorAccount1, validator, null, null);
+            contentPendingRepository.save(contentPending1);
+
+            // REJECTED 콘텐츠
+            ContentPendingData contentData2 = ContentPendingFixture.createTestContentData("부산");
+            ContentPending contentPending2 = new ContentPending(contentData2, collectorAccount2, validator, null, null);
+            contentPending2.reject(validator, "거절 사유");
+            contentPendingRepository.save(contentPending2);
+
+            // when & then
+            RestAssured.given().port(port)
+                    .header("Authorization", "Bearer " + validatorAccessToken)
+                    .when().get("/api/v1/admin/content-pendings/my-list")
+                    .then()
+                    .statusCode(200)
+                    .body("$", hasSize(1))
+                    .body("[0].id", is(1));
+        }
+
+        @DisplayName("관리자가 아닌 사용자가 목록을 조회하면 403 Forbidden을 응답한다")
+        @Test
+        void findMyPending_Forbidden() {
+            // given
+            Long userAccountId = testDataHelper.insertAccount(Role.USER);
+            String userAccessToken = testDataHelper.createAccessToken(userAccountId, Role.USER);
+
+            // when & then
+            RestAssured.given().port(port)
+                    .header("Authorization", "Bearer " + userAccessToken)
+                    .when().get("/api/v1/admin/content-pendings/my-list")
                     .then()
                     .statusCode(403);
         }

--- a/backend/turip-admin/src/test/java/turip/controller/AdminPendingContentApiTest.java
+++ b/backend/turip-admin/src/test/java/turip/controller/AdminPendingContentApiTest.java
@@ -635,4 +635,115 @@ class AdminPendingContentApiTest extends TestContainerConfig {
                     .statusCode(403);
         }
     }
+
+    @DisplayName("/api/v1/admin/content-pendings/my-count GET 나의 펜딩 콘텐츠 개수 조회 테스트")
+    @Nested
+    class CountMyPendingTest {
+
+        @DisplayName("관리자가 나의 펜딩 콘텐츠 개수를 조회하면 200 OK와 개수를 응답한다")
+        @Test
+        void countMyPending_Success() {
+            // given
+            Account validator = AccountFixture.createCustomAccount(1L, Role.ADMIN);
+            Long validatorAccountId = testDataHelper.insertAccount(validator);
+            testDataHelper.insertTuripMember(validatorAccountId, "admin@turip.com", false, "admin", "password123!");
+            String validatorAccessToken = testDataHelper.createAccessToken(validatorAccountId, Role.ADMIN);
+
+            Account collectorAccount1 = AccountFixture.createCustomAccount(2L, Role.ADMIN);
+            Long collectorAccountId1 = testDataHelper.insertAccount(collectorAccount1);
+            ReflectionTestUtils.setField(collectorAccount1, "id", collectorAccountId1);
+
+            Account collectorAccount2 = AccountFixture.createCustomAccount(3L, Role.ADMIN);
+            Long collectorAccountId2 = testDataHelper.insertAccount(collectorAccount2);
+            ReflectionTestUtils.setField(collectorAccount2, "id", collectorAccountId2);
+
+            // validator에게 배정된 콘텐츠 2개
+            ContentPendingData contentData1 = ContentPendingFixture.createTestContentData("서울");
+            ContentPending contentPending1 = new ContentPending(contentData1, collectorAccount1, validator, null, null);
+            contentPendingRepository.save(contentPending1);
+
+            ContentPendingData contentData2 = ContentPendingFixture.createTestContentData("부산");
+            ContentPending contentPending2 = new ContentPending(contentData2, collectorAccount2, validator, null, null);
+            contentPendingRepository.save(contentPending2);
+
+            // 다른 validator에게 배정된 콘텐츠 1개
+            ContentPendingData contentData3 = ContentPendingFixture.createTestContentData("대구");
+            ContentPending contentPending3 = new ContentPending(contentData3, collectorAccount1, collectorAccount2,
+                    null, null);
+            contentPendingRepository.save(contentPending3);
+
+            // when & then
+            RestAssured.given().port(port)
+                    .header("Authorization", "Bearer " + validatorAccessToken)
+                    .when().get("/api/v1/admin/content-pendings/my-count")
+                    .then()
+                    .statusCode(200)
+                    .body("$", is(2));
+        }
+
+        @DisplayName("펜딩 콘텐츠가 없는 경우 0을 응답한다")
+        @Test
+        void countMyPending_Zero() {
+            // given
+            Long adminAccountId = testDataHelper.insertAccount(Role.ADMIN);
+            testDataHelper.insertTuripMember(adminAccountId, "admin@turip.com", false, "admin", "password123!");
+            String adminAccessToken = testDataHelper.createAccessToken(adminAccountId, Role.ADMIN);
+
+            // when & then
+            RestAssured.given().port(port)
+                    .header("Authorization", "Bearer " + adminAccessToken)
+                    .when().get("/api/v1/admin/content-pendings/my-count")
+                    .then()
+                    .statusCode(200)
+                    .body("$", is(0));
+        }
+
+        @DisplayName("PENDING 상태가 아닌 콘텐츠는 개수에 포함되지 않는다")
+        @Test
+        void countMyPending_OnlyPendingStatus() {
+            // given
+            Account validator = AccountFixture.createCustomAccount(1L, Role.ADMIN);
+            Long validatorAccountId = testDataHelper.insertAccount(validator);
+            testDataHelper.insertTuripMember(validatorAccountId, "admin@turip.com", false, "admin", "password123!");
+            String validatorAccessToken = testDataHelper.createAccessToken(validatorAccountId, Role.ADMIN);
+
+            Account collectorAccount = AccountFixture.createCustomAccount(2L, Role.ADMIN);
+            Long collectorAccountId = testDataHelper.insertAccount(collectorAccount);
+            ReflectionTestUtils.setField(collectorAccount, "id", collectorAccountId);
+
+            // PENDING 콘텐츠
+            ContentPendingData contentData1 = ContentPendingFixture.createTestContentData("서울");
+            ContentPending contentPending1 = new ContentPending(contentData1, collectorAccount, validator, null, null);
+            contentPendingRepository.save(contentPending1);
+
+            // REJECTED 콘텐츠
+            ContentPendingData contentData2 = ContentPendingFixture.createTestContentData("부산");
+            ContentPending contentPending2 = new ContentPending(contentData2, collectorAccount, validator, null, null);
+            contentPending2.reject(validator, "거절 사유");
+            contentPendingRepository.save(contentPending2);
+
+            // when & then
+            RestAssured.given().port(port)
+                    .header("Authorization", "Bearer " + validatorAccessToken)
+                    .when().get("/api/v1/admin/content-pendings/my-count")
+                    .then()
+                    .statusCode(200)
+                    .body("$", is(1));
+        }
+
+        @DisplayName("관리자가 아닌 사용자가 개수를 조회하면 403 Forbidden을 응답한다")
+        @Test
+        void countMyPending_Forbidden() {
+            // given
+            Long userAccountId = testDataHelper.insertAccount(Role.USER);
+            String userAccessToken = testDataHelper.createAccessToken(userAccountId, Role.USER);
+
+            // when & then
+            RestAssured.given().port(port)
+                    .header("Authorization", "Bearer " + userAccessToken)
+                    .when().get("/api/v1/admin/content-pendings/my-count")
+                    .then()
+                    .statusCode(403);
+        }
+    }
 }

--- a/backend/turip-admin/src/test/java/turip/service/AdminContentPendingServiceTest.java
+++ b/backend/turip-admin/src/test/java/turip/service/AdminContentPendingServiceTest.java
@@ -311,7 +311,8 @@ class AdminContentPendingServiceTest {
         @Test
         void getMyHistory3() {
             // given
-            ContentPending rejectedPending = new ContentPending(contentData, collectorAccount, validatorAccount, null, null);
+            ContentPending rejectedPending = new ContentPending(contentData, collectorAccount, validatorAccount, null,
+                    null);
             ReflectionTestUtils.setField(rejectedPending, "id", 3L);
             ReflectionTestUtils.setField(rejectedPending, "status", ContentPendingStatus.REJECTED);
             ReflectionTestUtils.setField(rejectedPending, "rejectReason", "부적절한 콘텐츠");
@@ -376,6 +377,52 @@ class AdminContentPendingServiceTest {
             );
         }
     }
+
+    @DisplayName("findByValidatorAccount() 테스트")
+    @Nested
+    class FindByValidatorAccount {
+
+        @DisplayName("PENDING 상태의 모든 콘텐츠를 ID 내림차순으로 조회할 수 있다")
+        @Test
+        void findByValidatorAccount1() {
+            // given
+            ContentPending pending1 = new ContentPending(contentData, collectorAccount, validatorAccount, null, null);
+            ReflectionTestUtils.setField(pending1, "id", 1L);
+
+            ContentPendingData.VideoData videoData2 = new ContentPendingData.VideoData(
+                    "videoId456",
+                    "Test Title 2",
+                    "http://test2.url",
+                    "Test Channel 2",
+                    "http://channel2.image",
+                    LocalDate.now()
+            );
+            ContentPendingData contentData2 = new ContentPendingData(
+                    "Busan",
+                    videoData2,
+                    contentData.contentPlaces()
+            );
+            ContentPending pending2 = new ContentPending(contentData2, collectorAccount, null, null, null);
+            ReflectionTestUtils.setField(pending2, "id", 2L);
+
+            given(contentPendingRepository.findAllByStatusAndValidatorAccountOrderByIdDesc(ContentPendingStatus.PENDING,
+                    validatorAccount))
+                    .willReturn(List.of(pending1));
+
+            // when
+            List<PendingListResponse> responses = adminContentPendingService.findByValidatorAccount(validatorAccount);
+
+            // then
+            assertAll(
+                    () -> assertThat(responses).hasSize(1),
+                    () -> assertThat(responses.get(0).id()).isEqualTo(1L),
+                    () -> assertThat(responses.get(0).videoTitle()).isEqualTo("Test Title"),
+                    () -> verify(contentPendingRepository).findAllByStatusAndValidatorAccountOrderByIdDesc(
+                            ContentPendingStatus.PENDING, validatorAccount)
+            );
+        }
+    }
+
 
     @DisplayName("pending() 테스트")
     @Nested

--- a/backend/turip-app/src/main/java/turip/content/repository/ContentPendingRepository.java
+++ b/backend/turip-app/src/main/java/turip/content/repository/ContentPendingRepository.java
@@ -20,6 +20,8 @@ public interface ContentPendingRepository extends JpaRepository<ContentPending, 
 
     long countByStatus(ContentPendingStatus status);
 
+    long countByStatusAndValidatorAccount(ContentPendingStatus status, Account validatorAccount);
+
     List<ContentPending> findAllByStatusOrderByIdDesc(ContentPendingStatus status);
 
     List<ContentPending> findAllByStatusAndValidatorAccountOrderByIdDesc(

--- a/backend/turip-app/src/main/java/turip/content/repository/ContentPendingRepository.java
+++ b/backend/turip-app/src/main/java/turip/content/repository/ContentPendingRepository.java
@@ -22,6 +22,11 @@ public interface ContentPendingRepository extends JpaRepository<ContentPending, 
 
     List<ContentPending> findAllByStatusOrderByIdDesc(ContentPendingStatus status);
 
+    List<ContentPending> findAllByStatusAndValidatorAccountOrderByIdDesc(
+            ContentPendingStatus status,
+            Account validatorAccount
+    );
+
     List<ContentPending> findAllByCollectorAccountOrderByIdDesc(Account collectorAccount);
 
     default boolean existsByVideoUrlAndStatus(String url, ContentPendingStatus status) {


### PR DESCRIPTION
## Issues
- closed #685 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description

- 나에게 온 검수 요청만 확인할 수 있는 탭 추가
<img width="1348" height="417" alt="image" src="https://github.com/user-attachments/assets/8abedf3a-9f26-495b-ac29-db053db855e1" />

- 전체 pending 콘텐츠 목록에서 담당자 확인할 수 있게 수정
<img width="1345" height="623" alt="image" src="https://github.com/user-attachments/assets/83461f3a-c909-4f0b-9882-fea0bdb75c78" />

- 알림창에 나에게 온 검수 요청 수를 띄우도록 수정
<img width="247" height="61" alt="image" src="https://github.com/user-attachments/assets/5e49d250-2dc2-4cb4-8370-548d5c4ad119" />

- 위의 개선사항에 의해 추가된 API
  - `/api/v1/admin/content-pendings/my-list`: 나에게 온 검수 요청 확인 API
  - `/api/v1/admin/content-pendings/my-count`: 나에게 온 검수 요청 수 확인 API

## 📷 Screenshot

## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 검수 대기 목록에 탭 기능 추가: "내 검수 요청"과 "전체 검수 요청"으로 필터링 가능
* 각 검수 항목의 담당자(검증자) 정보 표시 기능 추가
* 관리자 알림 배지가 개인에게 할당된 검수 항목만 기준으로 표시되도록 개선
* 알림 드롭다운 헤더 및 빈 상태 메시지 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->