### PR TITLE
[feat] FCM 토큰 등록/갱신

### DIFF
--- a/backend/turip-app/src/main/java/turip/account/controller/FcmTokenController.java
+++ b/backend/turip-app/src/main/java/turip/account/controller/FcmTokenController.java
@@ -41,6 +41,36 @@ public class FcmTokenController {
                     description = "등록/갱신 성공"
             ),
             @ApiResponse(
+                    responseCode = "400",
+                    description = "실패 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "fcm token blank",
+                                            summary = "FCM 토큰이 빈 값인 경우",
+                                            value = """
+                                                    {
+                                                        "tag": "FCM_TOKEN_BLANK",
+                                                        "message": "FCM 토큰은 비워둘 수 없습니다."
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "device fid required",
+                                            summary = "device-fid 헤더가 빈 값인 경우",
+                                            value = """
+                                                    {
+                                                        "tag": "DEVICE_FID_REQUIRED",
+                                                        "message": "요청 헤더에 device_fid가 존재하지 않습니다."
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
                     responseCode = "401",
                     description = "실패 예시",
                     content = @Content(
@@ -98,6 +128,24 @@ public class FcmTokenController {
             @ApiResponse(
                     responseCode = "204",
                     description = "변경 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "실패 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "notification enabled required",
+                                    summary = "알림 수신 여부 값이 누락된 경우",
+                                    value = """
+                                            {
+                                                "tag": "NOTIFICATION_ENABLED_REQUIRED",
+                                                "message": "알림 수신 여부는 필수 값입니다."
+                                            }
+                                            """
+                            )
+                    )
             ),
             @ApiResponse(
                     responseCode = "401",

--- a/backend/turip-app/src/main/java/turip/account/controller/FcmTokenController.java
+++ b/backend/turip-app/src/main/java/turip/account/controller/FcmTokenController.java
@@ -148,46 +148,6 @@ public class FcmTokenController {
                     )
             ),
             @ApiResponse(
-                    responseCode = "401",
-                    description = "실패 예시",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorResponse.class),
-                            examples = {
-                                    @ExampleObject(
-                                            name = "access token expired",
-                                            summary = "만료된 access token",
-                                            value = """
-                                                    {
-                                                        "tag": "ACCESS_TOKEN_EXPIRED",
-                                                        "message": "access token이 만료됐습니다."
-                                                    }
-                                                    """
-                                    ),
-                                    @ExampleObject(
-                                            name = "invalid signature access token",
-                                            summary = "서명값이 올바르지 않은 access token",
-                                            value = """
-                                                    {
-                                                        "tag": "ACCESS_TOKEN_SIGNATURE_INVALID",
-                                                        "message": "access token이 위조됐습니다."
-                                                    }
-                                                    """
-                                    ),
-                                    @ExampleObject(
-                                            name = "unauthorized",
-                                            summary = "알 수 없는 이유로 인증 실패",
-                                            value = """
-                                                    {
-                                                        "tag": "UNAUTHORIZED",
-                                                        "message": "토큰 기반 인증에 실패했습니다."
-                                                    }
-                                                    """
-                                    )
-                            }
-                    )
-            ),
-            @ApiResponse(
                     responseCode = "404",
                     description = "실패 예시",
                     content = @Content(

--- a/backend/turip-app/src/main/java/turip/account/controller/FcmTokenController.java
+++ b/backend/turip-app/src/main/java/turip/account/controller/FcmTokenController.java
@@ -18,9 +18,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import turip.account.controller.dto.request.FcmTokenNotificationRequest;
 import turip.account.controller.dto.request.FcmTokenRegisterRequest;
-import turip.account.domain.Member;
+import turip.account.domain.Account;
 import turip.account.service.FcmTokenService;
-import turip.auth.resolver.AuthMember;
+import turip.auth.resolver.AuthAccount;
 import turip.common.exception.ErrorResponse;
 
 @RestController
@@ -114,9 +114,9 @@ public class FcmTokenController {
     @PostMapping
     public ResponseEntity<Void> register(
             @Parameter(hidden = true) @RequestHeader("device-fid") String deviceFid,
-            @Parameter(hidden = true) @AuthMember Member member,
+            @Parameter(hidden = true) @AuthAccount Account account,
             @RequestBody FcmTokenRegisterRequest request) {
-        fcmTokenService.registerOrUpdate(member.getAccount(), deviceFid, request.token());
+        fcmTokenService.registerOrUpdate(account, deviceFid, request.token());
         return ResponseEntity.ok().build();
     }
 
@@ -209,9 +209,9 @@ public class FcmTokenController {
     @PatchMapping("/notification")
     public ResponseEntity<Void> changeNotificationEnabled(
             @Parameter(hidden = true) @RequestHeader("device-fid") String deviceFid,
-            @Parameter(hidden = true) @AuthMember Member member,
+            @Parameter(hidden = true) @AuthAccount Account account,
             @RequestBody FcmTokenNotificationRequest request) {
-        fcmTokenService.changeNotificationEnabled(member.getAccount(), deviceFid, request.notificationEnabled());
+        fcmTokenService.changeNotificationEnabled(account, deviceFid, request.notificationEnabled());
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/turip-app/src/main/java/turip/account/controller/FcmTokenController.java
+++ b/backend/turip-app/src/main/java/turip/account/controller/FcmTokenController.java
@@ -69,46 +69,6 @@ public class FcmTokenController {
                                     )
                             }
                     )
-            ),
-            @ApiResponse(
-                    responseCode = "401",
-                    description = "실패 예시",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorResponse.class),
-                            examples = {
-                                    @ExampleObject(
-                                            name = "access token expired",
-                                            summary = "만료된 access token",
-                                            value = """
-                                                    {
-                                                        "tag": "ACCESS_TOKEN_EXPIRED",
-                                                        "message": "access token이 만료됐습니다."
-                                                    }
-                                                    """
-                                    ),
-                                    @ExampleObject(
-                                            name = "invalid signature access token",
-                                            summary = "서명값이 올바르지 않은 access token",
-                                            value = """
-                                                    {
-                                                        "tag": "ACCESS_TOKEN_SIGNATURE_INVALID",
-                                                        "message": "access token이 위조됐습니다."
-                                                    }
-                                                    """
-                                    ),
-                                    @ExampleObject(
-                                            name = "unauthorized",
-                                            summary = "알 수 없는 이유로 인증 실패",
-                                            value = """
-                                                    {
-                                                        "tag": "UNAUTHORIZED",
-                                                        "message": "토큰 기반 인증에 실패했습니다."
-                                                    }
-                                                    """
-                                    )
-                            }
-                    )
             )
     })
     @PostMapping

--- a/backend/turip-app/src/main/java/turip/account/controller/FcmTokenController.java
+++ b/backend/turip-app/src/main/java/turip/account/controller/FcmTokenController.java
@@ -1,0 +1,169 @@
+package turip.account.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import turip.account.controller.dto.request.FcmTokenNotificationRequest;
+import turip.account.controller.dto.request.FcmTokenRegisterRequest;
+import turip.account.domain.Member;
+import turip.account.service.FcmTokenService;
+import turip.auth.resolver.AuthMember;
+import turip.common.exception.ErrorResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/fcm-tokens")
+@Tag(name = "FcmToken", description = "FCM 토큰 API")
+public class FcmTokenController {
+
+    private final FcmTokenService fcmTokenService;
+
+    @Operation(
+            summary = "FCM 토큰 등록/갱신 api",
+            description = "현재 로그인한 회원의 해당 기기(device-fid)에 대한 FCM 토큰을 등록하거나 갱신한다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "등록/갱신 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "실패 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "access token expired",
+                                            summary = "만료된 access token",
+                                            value = """
+                                                    {
+                                                        "tag": "ACCESS_TOKEN_EXPIRED",
+                                                        "message": "access token이 만료됐습니다."
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "invalid signature access token",
+                                            summary = "서명값이 올바르지 않은 access token",
+                                            value = """
+                                                    {
+                                                        "tag": "ACCESS_TOKEN_SIGNATURE_INVALID",
+                                                        "message": "access token이 위조됐습니다."
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "unauthorized",
+                                            summary = "알 수 없는 이유로 인증 실패",
+                                            value = """
+                                                    {
+                                                        "tag": "UNAUTHORIZED",
+                                                        "message": "토큰 기반 인증에 실패했습니다."
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            )
+    })
+    @PostMapping
+    public ResponseEntity<Void> register(
+            @Parameter(hidden = true) @RequestHeader("device-fid") String deviceFid,
+            @Parameter(hidden = true) @AuthMember Member member,
+            @RequestBody FcmTokenRegisterRequest request) {
+        fcmTokenService.registerOrUpdate(member.getAccount(), deviceFid, request.token());
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(
+            summary = "FCM 알림 수신 여부 변경 api",
+            description = "현재 로그인한 회원의 해당 기기(device-fid)에 대한 알림 수신 여부를 변경한다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "변경 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "실패 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "access token expired",
+                                            summary = "만료된 access token",
+                                            value = """
+                                                    {
+                                                        "tag": "ACCESS_TOKEN_EXPIRED",
+                                                        "message": "access token이 만료됐습니다."
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "invalid signature access token",
+                                            summary = "서명값이 올바르지 않은 access token",
+                                            value = """
+                                                    {
+                                                        "tag": "ACCESS_TOKEN_SIGNATURE_INVALID",
+                                                        "message": "access token이 위조됐습니다."
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "unauthorized",
+                                            summary = "알 수 없는 이유로 인증 실패",
+                                            value = """
+                                                    {
+                                                        "tag": "UNAUTHORIZED",
+                                                        "message": "토큰 기반 인증에 실패했습니다."
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "실패 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "fcm token not found",
+                                    summary = "해당 기기의 FCM 토큰이 존재하지 않는 경우",
+                                    value = """
+                                            {
+                                                "tag": "FCM_TOKEN_NOT_FOUND",
+                                                "message": "FCM 토큰을 찾을 수 없습니다."
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    @PatchMapping("/notification")
+    public ResponseEntity<Void> changeNotificationEnabled(
+            @Parameter(hidden = true) @RequestHeader("device-fid") String deviceFid,
+            @Parameter(hidden = true) @AuthMember Member member,
+            @RequestBody FcmTokenNotificationRequest request) {
+        fcmTokenService.changeNotificationEnabled(member.getAccount(), deviceFid, request.notificationEnabled());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/turip-app/src/main/java/turip/account/controller/dto/request/FcmTokenNotificationRequest.java
+++ b/backend/turip-app/src/main/java/turip/account/controller/dto/request/FcmTokenNotificationRequest.java
@@ -1,0 +1,13 @@
+package turip.account.controller.dto.request;
+
+import turip.common.exception.ErrorTag;
+import turip.common.exception.custom.BadRequestException;
+
+public record FcmTokenNotificationRequest(Boolean notificationEnabled) {
+
+    public FcmTokenNotificationRequest {
+        if (notificationEnabled == null) {
+            throw new BadRequestException(ErrorTag.NOTIFICATION_ENABLED_REQUIRED);
+        }
+    }
+}

--- a/backend/turip-app/src/main/java/turip/account/controller/dto/request/FcmTokenRegisterRequest.java
+++ b/backend/turip-app/src/main/java/turip/account/controller/dto/request/FcmTokenRegisterRequest.java
@@ -1,0 +1,4 @@
+package turip.account.controller.dto.request;
+
+public record FcmTokenRegisterRequest(String token) {
+}

--- a/backend/turip-app/src/main/java/turip/account/domain/FcmToken.java
+++ b/backend/turip-app/src/main/java/turip/account/domain/FcmToken.java
@@ -1,25 +1,30 @@
 package turip.account.domain;
 
+import io.micrometer.common.util.StringUtils;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import turip.common.domain.BaseTimeEntity;
+import turip.common.exception.ErrorTag;
+import turip.common.exception.custom.BadRequestException;
 
 @Entity
 @Getter
-@AllArgsConstructor
-@Table(name = "fcm_token")
+@Table(name = "fcm_token", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_fcm_token__account_id_device_fid", columnNames = {"account_id", "device_fid"})
+})
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FcmToken extends BaseTimeEntity {
@@ -30,8 +35,11 @@ public class FcmToken extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "account_id", nullable = false)
+    @JoinColumn(name = "account_id", nullable = false, foreignKey = @ForeignKey(name = "fk_fcm_token__account"))
     private Account account;
+
+    @Column(name = "device_fid", nullable = false)
+    private String deviceFid;
 
     @Column(name = "token", length = 500, nullable = false, unique = true)
     private String token;
@@ -39,9 +47,26 @@ public class FcmToken extends BaseTimeEntity {
     @Column(name = "notification_enabled", nullable = false)
     private boolean notificationEnabled;
 
-    public FcmToken(Account account, String token) {
+    public FcmToken(Account account, String deviceFid, String token) {
+        validateToken(token);
         this.account = account;
+        this.deviceFid = deviceFid;
         this.token = token;
         this.notificationEnabled = true;
+    }
+
+    public void updateToken(String token) {
+        validateToken(token);
+        this.token = token;
+    }
+
+    public void changeNotificationEnabled(boolean notificationEnabled) {
+        this.notificationEnabled = notificationEnabled;
+    }
+
+    private void validateToken(String token) {
+        if (StringUtils.isBlank(token)) {
+            throw new BadRequestException(ErrorTag.FCM_TOKEN_BLANK);
+        }
     }
 }

--- a/backend/turip-app/src/main/java/turip/account/domain/FcmToken.java
+++ b/backend/turip-app/src/main/java/turip/account/domain/FcmToken.java
@@ -48,6 +48,7 @@ public class FcmToken extends BaseTimeEntity {
     private boolean notificationEnabled;
 
     public FcmToken(Account account, String deviceFid, String token) {
+        validateDeviceFid(deviceFid);
         validateToken(token);
         this.account = account;
         this.deviceFid = deviceFid;
@@ -62,6 +63,12 @@ public class FcmToken extends BaseTimeEntity {
 
     public void changeNotificationEnabled(boolean notificationEnabled) {
         this.notificationEnabled = notificationEnabled;
+    }
+
+    private void validateDeviceFid(String deviceFid) {
+        if (StringUtils.isBlank(deviceFid)) {
+            throw new BadRequestException(ErrorTag.DEVICE_FID_REQUIRED);
+        }
     }
 
     private void validateToken(String token) {

--- a/backend/turip-app/src/main/java/turip/account/domain/FcmToken.java
+++ b/backend/turip-app/src/main/java/turip/account/domain/FcmToken.java
@@ -18,7 +18,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import turip.common.domain.BaseTimeEntity;
 import turip.common.exception.ErrorTag;
-import turip.common.exception.custom.BadRequestException;
+import turip.common.exception.custom.IllegalArgumentException;
 
 @Entity
 @Getter
@@ -67,13 +67,13 @@ public class FcmToken extends BaseTimeEntity {
 
     private void validateDeviceFid(String deviceFid) {
         if (StringUtils.isBlank(deviceFid)) {
-            throw new BadRequestException(ErrorTag.DEVICE_FID_REQUIRED);
+            throw new IllegalArgumentException(ErrorTag.DEVICE_FID_REQUIRED);
         }
     }
 
     private void validateToken(String token) {
         if (StringUtils.isBlank(token)) {
-            throw new BadRequestException(ErrorTag.FCM_TOKEN_BLANK);
+            throw new IllegalArgumentException(ErrorTag.FCM_TOKEN_BLANK);
         }
     }
 }

--- a/backend/turip-app/src/main/java/turip/account/repository/FcmTokenRepository.java
+++ b/backend/turip-app/src/main/java/turip/account/repository/FcmTokenRepository.java
@@ -1,0 +1,25 @@
+package turip.account.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import turip.account.domain.Account;
+import turip.account.domain.FcmToken;
+
+public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
+
+    Optional<FcmToken> findByAccountAndDeviceFid(Account account, String deviceFid);
+
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("delete from FcmToken f "
+            + "where f.token = :token and (f.account <> :account or f.deviceFid <> :deviceFid)")
+    void deleteReassignedToken(@Param("token") String token,
+                               @Param("account") Account account,
+                               @Param("deviceFid") String deviceFid);
+
+    void deleteByAccountAndDeviceFid(Account account, String deviceFid);
+
+    void deleteByAccount(Account account);
+}

--- a/backend/turip-app/src/main/java/turip/account/service/AccountService.java
+++ b/backend/turip-app/src/main/java/turip/account/service/AccountService.java
@@ -9,6 +9,7 @@ import turip.account.domain.Role;
 import turip.account.domain.nickname.NicknameCreator;
 import turip.account.repository.AccountInsertRepository;
 import turip.account.repository.AccountRepository;
+import turip.account.repository.FcmTokenRepository;
 import turip.common.exception.ErrorTag;
 import turip.common.exception.custom.InternalServerException;
 import turip.common.exception.custom.NotFoundException;
@@ -23,6 +24,7 @@ public class AccountService {
     private final FavoriteContentRepository favoriteContentRepository;
     private final FavoriteFolderService favoriteFolderService;
     private final AccountInsertRepository accountInsertRepository;
+    private final FcmTokenRepository fcmTokenRepository;
 
     @Transactional
     public Account create(NicknameCreator nicknameCreator) {
@@ -50,6 +52,7 @@ public class AccountService {
     public void deleteAccountAndFavorites(Account account) {
         favoriteContentRepository.deleteByAccount(account);
         favoriteFolderService.deleteAloneFoldersByAccount(account);
+        fcmTokenRepository.deleteByAccount(account);
         accountRepository.delete(account);
     }
 }

--- a/backend/turip-app/src/main/java/turip/account/service/FcmTokenService.java
+++ b/backend/turip-app/src/main/java/turip/account/service/FcmTokenService.java
@@ -1,0 +1,43 @@
+package turip.account.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import turip.account.domain.Account;
+import turip.account.domain.FcmToken;
+import turip.account.repository.FcmTokenRepository;
+import turip.common.exception.ErrorTag;
+import turip.common.exception.custom.NotFoundException;
+
+@Service
+@RequiredArgsConstructor
+public class FcmTokenService {
+
+    private final FcmTokenRepository fcmTokenRepository;
+
+    @Transactional
+    public void registerOrUpdate(Account account, String deviceFid, String token) {
+        reassignTokenIfOwnedByOther(account, deviceFid, token);
+        fcmTokenRepository.findByAccountAndDeviceFid(account, deviceFid)
+                .ifPresentOrElse(
+                        existing -> existing.updateToken(token),
+                        () -> fcmTokenRepository.save(new FcmToken(account, deviceFid, token))
+                );
+    }
+
+    @Transactional
+    public void changeNotificationEnabled(Account account, String deviceFid, boolean notificationEnabled) {
+        FcmToken fcmToken = fcmTokenRepository.findByAccountAndDeviceFid(account, deviceFid)
+                .orElseThrow(() -> new NotFoundException(ErrorTag.FCM_TOKEN_NOT_FOUND));
+        fcmToken.changeNotificationEnabled(notificationEnabled);
+    }
+
+    @Transactional
+    public void deleteByAccountAndDeviceFid(Account account, String deviceFid) {
+        fcmTokenRepository.deleteByAccountAndDeviceFid(account, deviceFid);
+    }
+
+    private void reassignTokenIfOwnedByOther(Account account, String deviceFid, String token) {
+        fcmTokenRepository.deleteReassignedToken(token, account, deviceFid);
+    }
+}

--- a/backend/turip-app/src/main/java/turip/auth/service/AuthService.java
+++ b/backend/turip-app/src/main/java/turip/auth/service/AuthService.java
@@ -9,6 +9,7 @@ import turip.account.domain.Account;
 import turip.account.domain.Member;
 import turip.account.domain.Provider;
 import turip.account.domain.Role;
+import turip.account.service.FcmTokenService;
 import turip.account.service.MemberService;
 import turip.account.service.SocialMemberService;
 import turip.account.service.TuripMemberService;
@@ -38,6 +39,7 @@ public class AuthService {
     private final MemberService memberService;
     private final SocialMemberService socialMemberService;
     private final TuripMemberService turipMemberService;
+    private final FcmTokenService fcmTokenService;
 
     @Transactional
     public TuripLoginResult loginWithTurip(TuripLoginRequest request, String deviceFid) {
@@ -112,6 +114,7 @@ public class AuthService {
     public void logout(Account account, String deviceFid) {
         Member member = getMemberByAccountId(account.getId());
         refreshTokenService.deleteByMemberAndDeviceFid(member, deviceFid);
+        fcmTokenService.deleteByAccountAndDeviceFid(account, deviceFid);
     }
 
     private TokenResult issueToken(String deviceFid, Member member) {

--- a/backend/turip-app/src/main/java/turip/common/exception/ErrorTag.java
+++ b/backend/turip-app/src/main/java/turip/common/exception/ErrorTag.java
@@ -9,6 +9,9 @@ public enum ErrorTag {
     DEFAULT_FAVORITE_FOLDER_OPERATION_NOT_ALLOWED("기본 찜폴더에는 이 작업을 수행할 수 없습니다."),
     REGION_CATEGORY_INVALID("잘못된 지역 카테고리입니다."),
     DEVICE_FID_REQUIRED("요청 헤더에 device_fid가 존재하지 않습니다."),
+    FCM_TOKEN_BLANK("FCM 토큰은 비워둘 수 없습니다."),
+    NOTIFICATION_ENABLED_REQUIRED("알림 수신 여부는 필수 값입니다."),
+
     FAVORITE_PLACE_FOLDER_MISMATCH("장소 찜이 해당 폴더에 존재하지 않습니다."),
     SHARED_FAVORITE_FOLDER_OPERATION_NOT_ALLOWED("공유 찜폴더에는 이 작업을 수행할 수 없습니다."),
     PERSONAL_FAVORITE_FOLDER_OPERATION_NOT_ALLOWED("개인 찜폴더에는 이 작업을 수행할 수 없습니다."),
@@ -46,6 +49,8 @@ public enum ErrorTag {
     CREATOR_NOT_FOUND("크리에이터를 찾을 수 없습니다."),
     FAVORITE_CONTENT_NOT_FOUND("찜한 컨텐츠를 찾을 수 없습니다."),
     FAVORITE_FOLDER_ACCOUNT_NOT_FOUND("찜폴더에 참여중인 계정 목록에서 해당 계정을 찾을 수 없습니다."),
+    FCM_TOKEN_NOT_FOUND("FCM 토큰을 찾을 수 없습니다."),
+
 
     // 409 Conflict
     FAVORITE_FOLDER_NAME_CONFLICT("이미 존재하는 찜폴더 이름입니다."),

--- a/backend/turip-app/src/main/java/turip/infrastructure/config/FirebaseConfig.java
+++ b/backend/turip-app/src/main/java/turip/infrastructure/config/FirebaseConfig.java
@@ -10,8 +10,10 @@ import java.io.InputStream;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.Resource;
 
+@Profile("!test & !test-mysql")
 @Configuration
 public class FirebaseConfig {
 

--- a/backend/turip-app/src/main/resources/db/migration/V18__add_device_fid_to_fcm_token.mysql.sql
+++ b/backend/turip-app/src/main/resources/db/migration/V18__add_device_fid_to_fcm_token.mysql.sql
@@ -1,0 +1,5 @@
+DELETE FROM fcm_token;
+
+ALTER TABLE fcm_token
+    ADD COLUMN device_fid VARCHAR(255) NOT NULL AFTER account_id,
+    ADD CONSTRAINT uk_fcm_token__account_id_device_fid UNIQUE (account_id, device_fid);

--- a/backend/turip-app/src/test/java/turip/account/api/FcmTokenApiTest.java
+++ b/backend/turip-app/src/test/java/turip/account/api/FcmTokenApiTest.java
@@ -171,6 +171,27 @@ class FcmTokenApiTest {
                     .statusCode(400)
                     .body("tag", is("FCM_TOKEN_BLANK"));
         }
+
+        @Test
+        @DisplayName("device-fid 헤더가 공백 값이면 400 Bad Request를 응답한다")
+        void register6() {
+            Long accountId = testDataHelper.insertAccount(Role.USER);
+            testDataHelper.insertMember(accountId, "member@turip.com", false);
+            String accessToken = testDataHelper.createAccessToken(accountId);
+
+            Map<String, String> requestBody = new HashMap<>(Map.of("token", "fcm-token-1"));
+
+            RestAssured
+                    .given().log().all()
+                    .contentType(ContentType.JSON)
+                    .header("Authorization", "Bearer " + accessToken)
+                    .header("device-fid", " ")
+                    .body(requestBody)
+                    .when().post("/api/v1/fcm-tokens")
+                    .then().log().all()
+                    .statusCode(400)
+                    .body("tag", is("DEVICE_FID_REQUIRED"));
+        }
     }
 
     @Nested

--- a/backend/turip-app/src/test/java/turip/account/api/FcmTokenApiTest.java
+++ b/backend/turip-app/src/test/java/turip/account/api/FcmTokenApiTest.java
@@ -136,18 +136,24 @@ class FcmTokenApiTest {
         }
 
         @Test
-        @DisplayName("인증되지 않은 요청은 401 Unauthorized를 응답한다")
+        @DisplayName("액세스 토큰 없이 device-fid만 있는 게스트 요청도 토큰을 등록한다")
         void register4() {
-            Map<String, String> requestBody = new HashMap<>(Map.of("token", "fcm-token-1"));
+            String deviceFid = "guest-device";
+            Map<String, String> requestBody = new HashMap<>(Map.of("token", "guest-fcm-token"));
 
             RestAssured
                     .given().log().all()
                     .contentType(ContentType.JSON)
-                    .header("device-fid", "device-1")
+                    .header("device-fid", deviceFid)
                     .body(requestBody)
                     .when().post("/api/v1/fcm-tokens")
                     .then().log().all()
-                    .statusCode(401);
+                    .statusCode(200);
+
+            Long count = jdbcTemplate.queryForObject(
+                    "SELECT COUNT(*) FROM fcm_token WHERE device_fid = ? AND token = ?",
+                    Long.class, deviceFid, "guest-fcm-token");
+            assertThat(count).isEqualTo(1);
         }
 
         @Test

--- a/backend/turip-app/src/test/java/turip/account/api/FcmTokenApiTest.java
+++ b/backend/turip-app/src/test/java/turip/account/api/FcmTokenApiTest.java
@@ -1,0 +1,279 @@
+package turip.account.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import turip.account.domain.Role;
+import turip.util.helper.TestDataHelper;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class FcmTokenApiTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private TestDataHelper testDataHelper;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        testDataHelper.cleanDatabase();
+    }
+
+    @Nested
+    @DisplayName("/api/v1/fcm-tokens POST FCM 토큰 등록/갱신 테스트")
+    class RegisterTest {
+
+        @Test
+        @DisplayName("새로운 토큰 등록 시 200 OK와 함께 알림이 활성화된 토큰을 저장한다")
+        void register1() {
+            Long accountId = testDataHelper.insertAccount(Role.USER);
+            testDataHelper.insertMember(accountId, "member@turip.com", false);
+            String accessToken = testDataHelper.createAccessToken(accountId);
+            String deviceFid = "device-1";
+
+            Map<String, String> requestBody = new HashMap<>(Map.of("token", "fcm-token-1"));
+
+            RestAssured
+                    .given().log().all()
+                    .contentType(ContentType.JSON)
+                    .header("Authorization", "Bearer " + accessToken)
+                    .header("device-fid", deviceFid)
+                    .body(requestBody)
+                    .when().post("/api/v1/fcm-tokens")
+                    .then().log().all()
+                    .statusCode(200);
+
+            Map<String, Object> saved = jdbcTemplate.queryForMap(
+                    "SELECT token, notification_enabled FROM fcm_token WHERE account_id = ? AND device_fid = ?",
+                    accountId, deviceFid);
+            assertThat(saved.get("token")).isEqualTo("fcm-token-1");
+            assertThat(saved.get("notification_enabled")).isEqualTo(true);
+        }
+
+        @Test
+        @DisplayName("이미 등록된 기기의 토큰 갱신 시 토큰만 갱신되고 알림 설정은 유지된다")
+        void register2() {
+            Long accountId = testDataHelper.insertAccount(Role.USER);
+            testDataHelper.insertMember(accountId, "member@turip.com", false);
+            String accessToken = testDataHelper.createAccessToken(accountId);
+            String deviceFid = "device-1";
+            testDataHelper.insertFcmToken(accountId, deviceFid, "old-token", false);
+
+            Map<String, String> requestBody = new HashMap<>(Map.of("token", "new-token"));
+
+            RestAssured
+                    .given().log().all()
+                    .contentType(ContentType.JSON)
+                    .header("Authorization", "Bearer " + accessToken)
+                    .header("device-fid", deviceFid)
+                    .body(requestBody)
+                    .when().post("/api/v1/fcm-tokens")
+                    .then().log().all()
+                    .statusCode(200);
+
+            Long count = jdbcTemplate.queryForObject(
+                    "SELECT COUNT(*) FROM fcm_token WHERE account_id = ? AND device_fid = ?",
+                    Long.class, accountId, deviceFid);
+            assertThat(count).isEqualTo(1);
+
+            Map<String, Object> saved = jdbcTemplate.queryForMap(
+                    "SELECT token, notification_enabled FROM fcm_token WHERE account_id = ? AND device_fid = ?",
+                    accountId, deviceFid);
+            assertThat(saved.get("token")).isEqualTo("new-token");
+            assertThat(saved.get("notification_enabled")).isEqualTo(false);
+        }
+
+        @Test
+        @DisplayName("다른 기기에 등록된 토큰을 등록하면 기존 토큰 레코드를 재할당한다")
+        void register3() {
+            Long otherAccountId = testDataHelper.insertAccount(Role.USER);
+            testDataHelper.insertMember(otherAccountId, "other@turip.com", false);
+            testDataHelper.insertFcmToken(otherAccountId, "other-device", "shared-token", true);
+
+            Long accountId = testDataHelper.insertAccount(Role.USER);
+            testDataHelper.insertMember(accountId, "member@turip.com", false);
+            String accessToken = testDataHelper.createAccessToken(accountId);
+            String deviceFid = "device-1";
+
+            Map<String, String> requestBody = new HashMap<>(Map.of("token", "shared-token"));
+
+            RestAssured
+                    .given().log().all()
+                    .contentType(ContentType.JSON)
+                    .header("Authorization", "Bearer " + accessToken)
+                    .header("device-fid", deviceFid)
+                    .body(requestBody)
+                    .when().post("/api/v1/fcm-tokens")
+                    .then().log().all()
+                    .statusCode(200);
+
+            Long count = jdbcTemplate.queryForObject(
+                    "SELECT COUNT(*) FROM fcm_token WHERE token = ?", Long.class, "shared-token");
+            assertThat(count).isEqualTo(1);
+
+            Long ownerAccountId = jdbcTemplate.queryForObject(
+                    "SELECT account_id FROM fcm_token WHERE token = ?", Long.class, "shared-token");
+            assertThat(ownerAccountId).isEqualTo(accountId);
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 요청은 401 Unauthorized를 응답한다")
+        void register4() {
+            Map<String, String> requestBody = new HashMap<>(Map.of("token", "fcm-token-1"));
+
+            RestAssured
+                    .given().log().all()
+                    .contentType(ContentType.JSON)
+                    .header("device-fid", "device-1")
+                    .body(requestBody)
+                    .when().post("/api/v1/fcm-tokens")
+                    .then().log().all()
+                    .statusCode(401);
+        }
+
+        @Test
+        @DisplayName("토큰이 공백 값이면 400 Bad Request를 응답한다")
+        void register5() {
+            Long accountId = testDataHelper.insertAccount(Role.USER);
+            testDataHelper.insertMember(accountId, "member@turip.com", false);
+            String accessToken = testDataHelper.createAccessToken(accountId);
+
+            Map<String, String> requestBody = new HashMap<>();
+            requestBody.put("token", "  ");
+
+            RestAssured
+                    .given().log().all()
+                    .contentType(ContentType.JSON)
+                    .header("Authorization", "Bearer " + accessToken)
+                    .header("device-fid", "device-1")
+                    .body(requestBody)
+                    .when().post("/api/v1/fcm-tokens")
+                    .then().log().all()
+                    .statusCode(400)
+                    .body("tag", is("FCM_TOKEN_BLANK"));
+        }
+    }
+
+    @Nested
+    @DisplayName("/api/v1/fcm-tokens/notification PATCH 알림 수신 여부 변경 테스트")
+    class ChangeNotificationEnabledTest {
+
+        @Test
+        @DisplayName("등록된 기기의 알림 수신 여부를 변경하면 204 No Content를 응답한다")
+        void changeNotificationEnabled1() {
+            Long accountId = testDataHelper.insertAccount(Role.USER);
+            testDataHelper.insertMember(accountId, "member@turip.com", false);
+            String accessToken = testDataHelper.createAccessToken(accountId);
+            String deviceFid = "device-1";
+            testDataHelper.insertFcmToken(accountId, deviceFid, "fcm-token-1", true);
+
+            Map<String, Object> requestBody = new HashMap<>(Map.of("notificationEnabled", false));
+
+            RestAssured
+                    .given().log().all()
+                    .contentType(ContentType.JSON)
+                    .header("Authorization", "Bearer " + accessToken)
+                    .header("device-fid", deviceFid)
+                    .body(requestBody)
+                    .when().patch("/api/v1/fcm-tokens/notification")
+                    .then().log().all()
+                    .statusCode(204);
+
+            Boolean notificationEnabled = jdbcTemplate.queryForObject(
+                    "SELECT notification_enabled FROM fcm_token WHERE account_id = ? AND device_fid = ?",
+                    Boolean.class, accountId, deviceFid);
+            assertThat(notificationEnabled).isFalse();
+        }
+
+        @Test
+        @DisplayName("등록된 토큰이 없는 기기에 대해 요청하면 404 Not Found를 응답한다")
+        void changeNotificationEnabled2() {
+            Long accountId = testDataHelper.insertAccount(Role.USER);
+            testDataHelper.insertMember(accountId, "member@turip.com", false);
+            String accessToken = testDataHelper.createAccessToken(accountId);
+
+            Map<String, Object> requestBody = new HashMap<>(Map.of("notificationEnabled", false));
+
+            RestAssured
+                    .given().log().all()
+                    .contentType(ContentType.JSON)
+                    .header("Authorization", "Bearer " + accessToken)
+                    .header("device-fid", "unregistered-device")
+                    .body(requestBody)
+                    .when().patch("/api/v1/fcm-tokens/notification")
+                    .then().log().all()
+                    .statusCode(404)
+                    .body("tag", is("FCM_TOKEN_NOT_FOUND"));
+        }
+    }
+
+    @Nested
+    @DisplayName("/api/v1/auth/logout POST 로그아웃 시 FCM 토큰 삭제 테스트")
+    class LogoutTest {
+
+        @Test
+        @DisplayName("로그아웃 시 해당 기기의 FCM 토큰이 삭제된다")
+        void logout1() {
+            Long accountId = testDataHelper.insertAccount(Role.USER);
+            testDataHelper.insertMember(accountId, "member@turip.com", false);
+            String accessToken = testDataHelper.createAccessToken(accountId);
+            String deviceFid = "device-1";
+            testDataHelper.insertFcmToken(accountId, deviceFid, "fcm-token-1", true);
+
+            RestAssured
+                    .given().log().all()
+                    .header("Authorization", "Bearer " + accessToken)
+                    .header("device-fid", deviceFid)
+                    .when().post("/api/v1/auth/logout")
+                    .then().log().all()
+                    .statusCode(204);
+
+            Long count = jdbcTemplate.queryForObject(
+                    "SELECT COUNT(*) FROM fcm_token WHERE account_id = ? AND device_fid = ?",
+                    Long.class, accountId, deviceFid);
+            assertThat(count).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("다른 기기의 FCM 토큰은 로그아웃의 영향을 받지 않는다")
+        void logout2() {
+            Long accountId = testDataHelper.insertAccount(Role.USER);
+            testDataHelper.insertMember(accountId, "member@turip.com", false);
+            String accessToken = testDataHelper.createAccessToken(accountId);
+            testDataHelper.insertFcmToken(accountId, "device-1", "fcm-token-1", true);
+            testDataHelper.insertFcmToken(accountId, "device-2", "fcm-token-2", true);
+
+            RestAssured
+                    .given().log().all()
+                    .header("Authorization", "Bearer " + accessToken)
+                    .header("device-fid", "device-1")
+                    .when().post("/api/v1/auth/logout")
+                    .then().log().all()
+                    .statusCode(204);
+
+            Long remaining = jdbcTemplate.queryForObject(
+                    "SELECT COUNT(*) FROM fcm_token WHERE account_id = ? AND device_fid = ?",
+                    Long.class, accountId, "device-2");
+            assertThat(remaining).isEqualTo(1);
+        }
+    }
+}

--- a/backend/turip-app/src/test/java/turip/account/notification/FcmNotificationServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/account/notification/FcmNotificationServiceTest.java
@@ -47,8 +47,8 @@ class FcmNotificationServiceTest {
             Account account2 = createAccount(2L);
             List<Account> accounts = List.of(account1, account2);
 
-            FcmToken fcmToken1 = new FcmToken(account1, "token1");
-            FcmToken fcmToken2 = new FcmToken(account2, "token2");
+            FcmToken fcmToken1 = new FcmToken(account1, "device1", "token1");
+            FcmToken fcmToken2 = new FcmToken(account2, "device2", "token2");
             List<FcmToken> fcmTokens = List.of(fcmToken1, fcmToken2);
 
             FcmNotificationMessage message = FcmNotificationMessage.of("테스트 제목", "테스트 내용");
@@ -103,8 +103,8 @@ class FcmNotificationServiceTest {
             List<Account> accounts = List.of(account1, account2, account3);
 
             // account1, account2만 알림 활성화된 토큰
-            FcmToken fcmToken1 = new FcmToken(account1, "token1");
-            FcmToken fcmToken2 = new FcmToken(account2, "token2");
+            FcmToken fcmToken1 = new FcmToken(account1, "device1", "token1");
+            FcmToken fcmToken2 = new FcmToken(account2, "device2", "token2");
             List<FcmToken> fcmTokens = List.of(fcmToken1, fcmToken2);
 
             FcmNotificationMessage message = FcmNotificationMessage.of("테스트 제목", "테스트 내용");
@@ -136,8 +136,8 @@ class FcmNotificationServiceTest {
             Account account2 = createAccount(2L);
             List<Account> accounts = List.of(account1, account2);
 
-            FcmToken fcmToken1 = new FcmToken(account1, "token1");
-            FcmToken fcmToken2 = new FcmToken(account2, "invalid-token");
+            FcmToken fcmToken1 = new FcmToken(account1, "device1", "token1");
+            FcmToken fcmToken2 = new FcmToken(account2, "device2", "invalid-token");
             List<FcmToken> fcmTokens = List.of(fcmToken1, fcmToken2);
 
             FcmNotificationMessage message = FcmNotificationMessage.of("테스트 제목", "테스트 내용");

--- a/backend/turip-app/src/test/java/turip/account/service/AccountServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/account/service/AccountServiceTest.java
@@ -19,6 +19,7 @@ import turip.account.domain.Account;
 import turip.account.domain.Role;
 import turip.account.repository.AccountInsertRepository;
 import turip.account.repository.AccountRepository;
+import turip.account.repository.FcmTokenRepository;
 import turip.common.exception.ErrorTag;
 import turip.common.exception.custom.InternalServerException;
 import turip.common.exception.custom.NotFoundException;
@@ -43,6 +44,9 @@ class AccountServiceTest {
 
     @Mock
     private FavoriteFolderService favoriteFolderService;
+
+    @Mock
+    private FcmTokenRepository fcmTokenRepository;
 
     @DisplayName("Account 생성 테스트")
     @Nested
@@ -134,6 +138,7 @@ class AccountServiceTest {
             // then
             verify(favoriteContentRepository).deleteByAccount(account);
             verify(favoriteFolderService).deleteAloneFoldersByAccount(account);
+            verify(fcmTokenRepository).deleteByAccount(account);
             verify(accountRepository).delete(account);
         }
     }

--- a/backend/turip-app/src/test/java/turip/auth/service/AuthServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/auth/service/AuthServiceTest.java
@@ -28,6 +28,7 @@ import turip.account.domain.Member;
 import turip.account.domain.Provider;
 import turip.account.domain.SocialMember;
 import turip.account.domain.TuripMember;
+import turip.account.service.FcmTokenService;
 import turip.account.service.MemberService;
 import turip.account.service.SocialMemberService;
 import turip.account.service.TuripMemberService;
@@ -72,6 +73,9 @@ class AuthServiceTest {
 
     @Mock
     private RefreshTokenService refreshTokenService;
+
+    @Mock
+    private FcmTokenService fcmTokenService;
 
     @InjectMocks
     private AuthService authService;

--- a/backend/turip-app/src/test/java/turip/infrastructure/config/TestFirebaseConfig.java
+++ b/backend/turip-app/src/test/java/turip/infrastructure/config/TestFirebaseConfig.java
@@ -1,0 +1,18 @@
+package turip.infrastructure.config;
+
+import static org.mockito.Mockito.mock;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Profile("test | test-mysql")
+@Configuration
+public class TestFirebaseConfig {
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging() {
+        return mock(FirebaseMessaging.class);
+    }
+}

--- a/backend/turip-app/src/test/java/turip/util/helper/TestDataHelper.java
+++ b/backend/turip-app/src/test/java/turip/util/helper/TestDataHelper.java
@@ -42,6 +42,7 @@ public class TestDataHelper {
         jdbcTemplate.update("DELETE FROM social_member");
         jdbcTemplate.update("DELETE FROM guest");
         jdbcTemplate.update("DELETE FROM refresh_token");
+        jdbcTemplate.update("DELETE FROM fcm_token");
         jdbcTemplate.update("DELETE FROM member");
 
         jdbcTemplate.update("DELETE FROM account");
@@ -64,6 +65,7 @@ public class TestDataHelper {
         jdbcTemplate.update("ALTER TABLE social_member ALTER COLUMN id RESTART WITH 1");
         jdbcTemplate.update("ALTER TABLE guest ALTER COLUMN id RESTART WITH 1");
         jdbcTemplate.update("ALTER TABLE refresh_token ALTER COLUMN id RESTART WITH 1");
+        jdbcTemplate.update("ALTER TABLE fcm_token ALTER COLUMN id RESTART WITH 1");
         jdbcTemplate.update("ALTER TABLE member ALTER COLUMN id RESTART WITH 1");
         jdbcTemplate.update("ALTER TABLE account ALTER COLUMN id RESTART WITH 1");
         jdbcTemplate.update("ALTER TABLE content ALTER COLUMN id RESTART WITH 1");
@@ -121,6 +123,25 @@ public class TestDataHelper {
             ps.setString(2, email);
             ps.setBoolean(3, isFirstLogin);
             ps.setBoolean(4, false);
+            return ps;
+        }, keyHolder);
+
+        return extractGeneratedKey(keyHolder);
+    }
+
+    public Long insertFcmToken(Long accountId, String deviceFid, String token, boolean notificationEnabled) {
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+
+        jdbcTemplate.update(connection -> {
+            PreparedStatement ps = connection.prepareStatement(
+                    "INSERT INTO fcm_token "
+                            + "(account_id, device_fid, token, notification_enabled, created_at, updated_at) "
+                            + "VALUES (?, ?, ?, ?, NOW(), NOW())",
+                    Statement.RETURN_GENERATED_KEYS);
+            ps.setLong(1, accountId);
+            ps.setString(2, deviceFid);
+            ps.setString(3, token);
+            ps.setBoolean(4, notificationEnabled);
             return ps;
         }, keyHolder);
 


### PR DESCRIPTION
## Issues
- closed #694

## ✔️ Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description

- 구현한 기능
  - FCM 토큰 등록/갱신 API** (`POST /api/v1/fcm-tokens`)
    - 기기(`device-fid`) 단위로 토큰을 관리하도록 `fcm_token`에 `device_fid` 컬럼 추가 + `(account_id, device_fid)` 유니크 제약 추가
    - 이미 등록된 기기면 토큰 값만 갱신(알림 수신 설정은 유지), 신규 기기면 새로 저장
    - 동일 토큰이 다른 계정/기기에 연결돼 있으면(기기 교체·재설치 케이스) 기존 레코드를 정리한 뒤 현재 회원에게 재할당
  - FCM 알림 수신 여부 변경 API (`PATCH /api/v1/fcm-tokens/notification`)
    - 기기 단위로 알림 on/off 설정
  - 세션/계정 정리 시 토큰 정리
    - 로그아웃 시 해당 기기(`device-fid`)의 FCM 토큰 삭제 → 로그아웃 후 알림 미발송
    - 회원 탈퇴 시 해당 계정의 모든 기기 FCM 토큰 삭제
  - DB 마이그레이션(V18) 추가
    - 마이그레이션에서 `DELETE FROM fcm_token` 선행 후 컬럼/제약을 추가하도록 처리

## 🤔 고민한 부분
- 토큰 재할당 시 flush 순서 문제
  - `다른 소유자 토큰 삭제 → 신규 insert` 흐름에서, Hibernate가 INSERT를 DELETE보다 먼저 실행해 token 유니크 충돌 위험
  - `@Modifying` 벌크 DELETE로 즉시 DB에 반영해 순서 역전 차단

- 토큰 정리 시점 -> 로그아웃 & 탈퇴 시
  - 로그아웃은 refresh token을 device-fid 기준으로 삭제 중. FCM 토큰도 동일하게 device-fid에 종속되어있어 별도 API로 빼면 (클라이언트의 호출 누락 가능성) refresh token은 지워졌는데 FCM 토큰은 남아있는 불일치 상태가 생길 수 있음. (로그아웃 이후에도 그 기기로 해당 계정의 알림이 발송 될 수 있음)

## 📷 Screenshot

## 📚 Reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 인증된 회원의 기기별 FCM 토큰을 등록/갱신할 수 있는 API가 추가되었습니다.  
  * 기기별 알림 수신 여부를 변경할 수 있는 API가 추가되었습니다.
* **버그 수정**
  * 토큰이 기기별로 올바르게 갱신되며, 다른 계정에 있던 토큰은 재할당되도록 처리 로직을 보강했습니다.
  * 토큰/기기 식별자/알림 설정 값이 비어 있거나 누락된 경우 더 명확한 오류를 반환합니다.
* **개선/정리**
  * 로그아웃 또는 계정 삭제 시 해당 기기 FCM 토큰이 자동 정리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->