### PR TITLE
[feat] 여러 장소 튜립에 추가하는 API 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -35,6 +35,7 @@ subprojects {
         // 공통 의존성
         implementation 'org.springframework.boot:spring-boot-starter-web'
         implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+        implementation 'org.springframework.boot:spring-boot-starter-validation'
 
         compileOnly 'org.projectlombok:lombok:1.18.38'
         annotationProcessor 'org.projectlombok:lombok:1.18.38'

--- a/backend/turip-app/src/main/java/turip/common/exception/ErrorTag.java
+++ b/backend/turip-app/src/main/java/turip/common/exception/ErrorTag.java
@@ -12,7 +12,6 @@ public enum ErrorTag {
     FCM_TOKEN_BLANK("FCM 토큰은 비워둘 수 없습니다."),
     NOTIFICATION_ENABLED_REQUIRED("알림 수신 여부는 필수 값입니다."),
 
-    FAVORITE_PLACE_BATCH_SIZE_EXCEEDED("한 번에 추가할 수 있는 장소 개수를 초과했습니다."),
     FAVORITE_PLACE_FOLDER_MISMATCH("장소 찜이 해당 폴더에 존재하지 않습니다."),
     SHARED_FAVORITE_FOLDER_OPERATION_NOT_ALLOWED("공유 찜폴더에는 이 작업을 수행할 수 없습니다."),
     PERSONAL_FAVORITE_FOLDER_OPERATION_NOT_ALLOWED("개인 찜폴더에는 이 작업을 수행할 수 없습니다."),

--- a/backend/turip-app/src/main/java/turip/common/exception/ErrorTag.java
+++ b/backend/turip-app/src/main/java/turip/common/exception/ErrorTag.java
@@ -12,6 +12,7 @@ public enum ErrorTag {
     FCM_TOKEN_BLANK("FCM 토큰은 비워둘 수 없습니다."),
     NOTIFICATION_ENABLED_REQUIRED("알림 수신 여부는 필수 값입니다."),
 
+    FAVORITE_PLACE_BATCH_SIZE_EXCEEDED("한 번에 추가할 수 있는 장소 개수를 초과했습니다."),
     FAVORITE_PLACE_FOLDER_MISMATCH("장소 찜이 해당 폴더에 존재하지 않습니다."),
     SHARED_FAVORITE_FOLDER_OPERATION_NOT_ALLOWED("공유 찜폴더에는 이 작업을 수행할 수 없습니다."),
     PERSONAL_FAVORITE_FOLDER_OPERATION_NOT_ALLOWED("개인 찜폴더에는 이 작업을 수행할 수 없습니다."),

--- a/backend/turip-app/src/main/java/turip/common/exception/GlobalExceptionHandler.java
+++ b/backend/turip-app/src/main/java/turip/common/exception/GlobalExceptionHandler.java
@@ -4,6 +4,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -54,6 +56,15 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ErrorResponse.from(ErrorTag.BAD_REQUEST));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.warn(e.getMessage(), e);
+
+        FieldError fieldError = e.getBindingResult().getFieldError();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(ErrorTag.BAD_REQUEST.name(), fieldError.getDefaultMessage()));
     }
 
     @ExceptionHandler(RuntimeException.class)

--- a/backend/turip-app/src/main/java/turip/favorite/controller/FavoritePlaceController.java
+++ b/backend/turip-app/src/main/java/turip/favorite/controller/FavoritePlaceController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.net.URI;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 import turip.account.domain.Account;
 import turip.auth.resolver.AuthAccount;
 import turip.common.exception.ErrorResponse;
+import turip.favorite.controller.dto.request.FavoritePlaceBatchCreateRequest;
 import turip.favorite.controller.dto.request.FavoritePlaceMultiFolderRequest;
 import turip.favorite.controller.dto.request.FavoritePlaceOrderRequest;
 import turip.favorite.controller.dto.response.FavoriteFolderWithFavoriteStatusResponse.FavoritePlaceResponse;
@@ -183,6 +185,124 @@ public class FavoritePlaceController {
         FavoritePlaceResponse response = favoritePlaceService.create(account, favoriteFolderId, placeId);
         return ResponseEntity.created(URI.create("/api/v1/turips/places/" + response.id()))
                 .body(response);
+    }
+
+    @Operation(
+            summary = "튜립 장소 일괄 추가 api",
+            description = "내 튜립에 여러 장소를 한 번에 추가한다. 이미 추가된 장소나 존재하지 않는 장소는 건너뛰고 나머지만 추가한다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "성공 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(type = "array", implementation = FavoritePlaceResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    summary = "튜립 장소 일괄 추가 성공",
+                                    value = """
+                                            [
+                                                {
+                                                    "id": 1,
+                                                    "turipId": 10,
+                                                    "placeId": 1
+                                                },
+                                                {
+                                                    "id": 2,
+                                                    "turipId": 10,
+                                                    "placeId": 2
+                                                }
+                                            ]
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "실패 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "access token expired",
+                                            summary = "만료된 access token",
+                                            value = """
+                                                    {
+                                                    	"tag": "ACCESS_TOKEN_EXPIRED",
+                                                    	"message": "access token이 만료됐습니다."
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "invalid signature access token",
+                                            summary = "서명값이 올바르지 않은 access token",
+                                            value = """
+                                                    {
+                                                    	"tag": "ACCESS_TOKEN_SIGNATURE_INVALID",
+                                                    	"message": "access token이 위조됐습니다."
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "unauthorized",
+                                            summary = "알 수 없는 이유로 인증 실패",
+                                            value = """
+                                                    {
+                                                    	"tag": "UNAUTHORIZED",
+                                                    	"message": "토큰 기반 인증에 실패했습니다."
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "실패 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "not_turip_owner",
+                                    summary = "튜립 소유자가 아닌 사용자가 요청한 경우",
+                                    value = """
+                                            {
+                                                "tag": "FORBIDDEN",
+                                                "message": "접근 권한이 없습니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "실패 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "turip_not_found",
+                                    summary = "turipId에 대한 튜립을 찾을 수 없는 경우",
+                                    value = """
+                                            {
+                                                "tag": "FAVORITE_FOLDER_NOT_FOUND",
+                                                "message": "찜폴더를 찾을 수 없습니다."
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    @PostMapping("/batch")
+    public ResponseEntity<List<FavoritePlaceResponse>> batchCreate(
+            @Parameter(hidden = true) @AuthAccount Account account,
+            @RequestBody FavoritePlaceBatchCreateRequest request
+    ) {
+        List<FavoritePlaceResponse> responses = favoritePlaceService.batchCreate(
+                account, request.favoriteFolderId(), request.placeIds());
+        return ResponseEntity.status(HttpStatus.CREATED).body(responses);
     }
 
     @Operation(

--- a/backend/turip-app/src/main/java/turip/favorite/controller/FavoritePlaceController.java
+++ b/backend/turip-app/src/main/java/turip/favorite/controller/FavoritePlaceController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -298,7 +299,7 @@ public class FavoritePlaceController {
     @PostMapping("/batch")
     public ResponseEntity<List<FavoritePlaceResponse>> batchCreate(
             @Parameter(hidden = true) @AuthAccount Account account,
-            @RequestBody FavoritePlaceBatchCreateRequest request
+            @Valid @RequestBody FavoritePlaceBatchCreateRequest request
     ) {
         List<FavoritePlaceResponse> responses = favoritePlaceService.batchCreate(
                 account, request.favoriteFolderId(), request.placeIds());

--- a/backend/turip-app/src/main/java/turip/favorite/controller/FavoritePlaceController.java
+++ b/backend/turip-app/src/main/java/turip/favorite/controller/FavoritePlaceController.java
@@ -220,6 +220,56 @@ public class FavoritePlaceController {
                     )
             ),
             @ApiResponse(
+                    responseCode = "400",
+                    description = "실패 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "bad request 1",
+                                            summary = "turipId가 null인 경우",
+                                            value = """
+                                                    {
+                                                        "tag": "BAD_REQUEST",
+                                                        "message": "올바르지 않은 요청입니다."
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "bad request 2",
+                                            summary = "placeIds가 null인 경우",
+                                            value = """
+                                                    {
+                                                        "tag": "BAD_REQUEST",
+                                                        "message": "올바르지 않은 요청입니다."
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "bad request 3",
+                                            summary = "placeId가 null인 경우",
+                                            value = """
+                                                    {
+                                                        "tag": "BAD_REQUEST",
+                                                        "message": "올바르지 않은 요청입니다."
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "bad request 4",
+                                            summary = "추가하려는 장소찜 수가 제한을 초과하는 경우",
+                                            value = """
+                                                    {
+                                                        "tag": "BAD_REQUEST",
+                                                        "message": "한 번에 추가할 수 있는 장소 개수를 초과했습니다."
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
                     responseCode = "401",
                     description = "실패 예시",
                     content = @Content(

--- a/backend/turip-app/src/main/java/turip/favorite/controller/dto/request/FavoritePlaceBatchCreateRequest.java
+++ b/backend/turip-app/src/main/java/turip/favorite/controller/dto/request/FavoritePlaceBatchCreateRequest.java
@@ -1,0 +1,10 @@
+package turip.favorite.controller.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record FavoritePlaceBatchCreateRequest(
+        @JsonProperty("turipId") Long favoriteFolderId,
+        List<Long> placeIds
+) {
+}

--- a/backend/turip-app/src/main/java/turip/favorite/controller/dto/request/FavoritePlaceBatchCreateRequest.java
+++ b/backend/turip-app/src/main/java/turip/favorite/controller/dto/request/FavoritePlaceBatchCreateRequest.java
@@ -1,10 +1,17 @@
 package turip.favorite.controller.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public record FavoritePlaceBatchCreateRequest(
-        @JsonProperty("turipId") Long favoriteFolderId,
-        List<Long> placeIds
+        @JsonProperty("turipId")
+        @NotNull(message = "올바르지 않은 요청입니다.")
+        Long favoriteFolderId,
+
+        @NotNull(message = "올바르지 않은 요청입니다.")
+        @Size(max = 70, message = "한 번에 추가할 수 있는 장소 개수를 초과했습니다.")
+        List<@NotNull(message = "올바르지 않은 요청입니다.") Long> placeIds
 ) {
 }

--- a/backend/turip-app/src/main/java/turip/favorite/repository/FavoriteFolderRepository.java
+++ b/backend/turip-app/src/main/java/turip/favorite/repository/FavoriteFolderRepository.java
@@ -16,6 +16,10 @@ public interface FavoriteFolderRepository extends JpaRepository<FavoriteFolder, 
     @Query("SELECT ff FROM FavoriteFolder ff WHERE ff.id = :id")
     Optional<FavoriteFolder> findByIdWithLock(@Param("id") Long favoriteFolderId);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT ff FROM FavoriteFolder ff WHERE ff.id IN :ids ORDER BY ff.id ASC")
+    List<FavoriteFolder> findAllByIdInWithLock(@Param("ids") List<Long> favoriteFolderIds);
+
     @Query("SELECT ff FROM FavoriteFolder ff " +
             "JOIN FavoriteFolderAccount ffa ON ffa.favoriteFolder = ff " +
             "WHERE ffa.account = :account ")

--- a/backend/turip-app/src/main/java/turip/favorite/repository/FavoritePlaceRepository.java
+++ b/backend/turip-app/src/main/java/turip/favorite/repository/FavoritePlaceRepository.java
@@ -30,6 +30,8 @@ public interface FavoritePlaceRepository extends JpaRepository<FavoritePlace, Lo
 
     Optional<FavoritePlace> findByFavoriteFolderAndPlace(FavoriteFolder favoriteFolder, Place place);
 
+    List<FavoritePlace> findAllByFavoriteFolderAndPlaceIn(FavoriteFolder favoriteFolder, List<Place> places);
+
     @EntityGraph(attributePaths = {"place"}, type = EntityGraph.EntityGraphType.FETCH)
     List<FavoritePlace> findAllByFavoriteFolderOrderByFavoriteOrderAsc(FavoriteFolder favoriteFolder);
 

--- a/backend/turip-app/src/main/java/turip/favorite/service/FavoriteFolderService.java
+++ b/backend/turip-app/src/main/java/turip/favorite/service/FavoriteFolderService.java
@@ -178,7 +178,7 @@ public class FavoriteFolderService {
     @Transactional
     public FavoriteFolderResponse updateName(Account account, Long favoriteFolderId,
                                              FavoriteFolderNameRequest request) {
-        FavoriteFolder favoriteFolder = getById(favoriteFolderId);
+        FavoriteFolder favoriteFolder = getByIdWithLock(favoriteFolderId);
         if (favoriteFolder.isDefault()) {
             throw new BadRequestException(ErrorTag.DEFAULT_FAVORITE_FOLDER_OPERATION_NOT_ALLOWED);
         }
@@ -195,7 +195,7 @@ public class FavoriteFolderService {
 
     @Transactional
     public void remove(Account account, Long favoriteFolderId) {
-        FavoriteFolder favoriteFolder = getById(favoriteFolderId);
+        FavoriteFolder favoriteFolder = getByIdWithLock(favoriteFolderId);
         validateRemovableFolder(account, favoriteFolder);
         removeFavoriteFolderWithFavoritePlaces(favoriteFolderId, favoriteFolder);
         eventPublisher.publishEvent(FavoriteFolderUpdateEvent.of(favoriteFolderId, ActionType.FOLDER_DELETED));

--- a/backend/turip-app/src/main/java/turip/favorite/service/FavoritePlaceService.java
+++ b/backend/turip-app/src/main/java/turip/favorite/service/FavoritePlaceService.java
@@ -41,7 +41,7 @@ public class FavoritePlaceService {
 
     @Transactional
     public FavoritePlaceResponse create(Account account, Long favoriteFolderId, Long placeId) {
-        FavoriteFolder favoriteFolder = getFavoriteFolderById(favoriteFolderId);
+        FavoriteFolder favoriteFolder = getFavoriteFolderByIdWithLock(favoriteFolderId);
         Place place = getPlaceById(placeId);
 
         favoriteFolderAccountService.validateMembership(account, favoriteFolder);
@@ -64,7 +64,7 @@ public class FavoritePlaceService {
             throw new BadRequestException(ErrorTag.BAD_REQUEST);
         }
 
-        FavoriteFolder favoriteFolder = getFavoriteFolderById(favoriteFolderId);
+        FavoriteFolder favoriteFolder = getFavoriteFolderByIdWithLock(favoriteFolderId);
         favoriteFolderAccountService.validateMembership(account, favoriteFolder);
 
         List<Place> requestedPlaces = findPlacesByIdInRequestOrder(placeIds);
@@ -291,5 +291,10 @@ public class FavoritePlaceService {
     private FavoritePlace getByFavoriteFolderAndPlace(FavoriteFolder favoriteFolder, Place place) {
         return favoritePlaceRepository.findByFavoriteFolderAndPlace(favoriteFolder, place)
                 .orElseThrow(() -> new NotFoundException(ErrorTag.FAVORITE_PLACE_NOT_FOUND));
+    }
+
+    private FavoriteFolder getFavoriteFolderByIdWithLock(Long favoriteFolderId) {
+        return favoriteFolderRepository.findByIdWithLock(favoriteFolderId)
+                .orElseThrow(() -> new NotFoundException(ErrorTag.FAVORITE_FOLDER_NOT_FOUND));
     }
 }

--- a/backend/turip-app/src/main/java/turip/favorite/service/FavoritePlaceService.java
+++ b/backend/turip-app/src/main/java/turip/favorite/service/FavoritePlaceService.java
@@ -3,6 +3,7 @@ package turip.favorite.service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -66,7 +67,7 @@ public class FavoritePlaceService {
         FavoriteFolder favoriteFolder = getFavoriteFolderById(favoriteFolderId);
         favoriteFolderAccountService.validateMembership(account, favoriteFolder);
 
-        List<Place> requestedPlaces = placeRepository.findAllById(placeIds);
+        List<Place> requestedPlaces = findPlacesByIdInRequestOrder(placeIds);
         List<Place> placesToAdd = filterPlacesToAdd(favoriteFolder, requestedPlaces);
         List<FavoritePlace> savedFavoritePlaces = saveFavoritePlaces(favoriteFolder, placesToAdd);
 
@@ -154,6 +155,17 @@ public class FavoritePlaceService {
     private FavoriteFolder getFavoriteFolderById(Long favoriteFolderId) {
         return favoriteFolderRepository.findById(favoriteFolderId)
                 .orElseThrow(() -> new NotFoundException(ErrorTag.FAVORITE_FOLDER_NOT_FOUND));
+    }
+
+    private List<Place> findPlacesByIdInRequestOrder(List<Long> placeIds) {
+        Map<Long, Place> placesById = placeRepository.findAllById(placeIds).stream()
+                .collect(Collectors.toMap(Place::getId, place -> place));
+
+        return placeIds.stream()
+                .distinct()
+                .map(placesById::get)
+                .filter(Objects::nonNull)
+                .toList();
     }
 
     private Place getPlaceById(Long placeId) {

--- a/backend/turip-app/src/main/java/turip/favorite/service/FavoritePlaceService.java
+++ b/backend/turip-app/src/main/java/turip/favorite/service/FavoritePlaceService.java
@@ -85,7 +85,7 @@ public class FavoritePlaceService {
                                                              List<Long> favoriteFolderIds,
                                                              Long placeId) {
         List<Long> requestIds = favoriteFolderIds.stream().distinct().toList();
-        List<FavoriteFolder> requestFolders = favoriteFolderRepository.findAllById(requestIds);
+        List<FavoriteFolder> requestFolders = favoriteFolderRepository.findAllByIdInWithLock(requestIds);
         validateMultiFolder(account, requestFolders, requestIds);
 
         Place place = getPlaceById(placeId);

--- a/backend/turip-app/src/main/java/turip/favorite/service/FavoritePlaceService.java
+++ b/backend/turip-app/src/main/java/turip/favorite/service/FavoritePlaceService.java
@@ -1,5 +1,6 @@
 package turip.favorite.service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -54,6 +55,28 @@ public class FavoritePlaceService {
         eventPublisher.publishEvent(FavoriteFolderUpdateEvent.of(favoriteFolderId, ActionType.PLACE_ADDED));
 
         return FavoritePlaceResponse.from(savedFavoritePlace);
+    }
+
+    @Transactional
+    public List<FavoritePlaceResponse> batchCreate(Account account, Long favoriteFolderId, List<Long> placeIds) {
+        if (placeIds == null) {
+            throw new BadRequestException(ErrorTag.BAD_REQUEST);
+        }
+
+        FavoriteFolder favoriteFolder = getFavoriteFolderById(favoriteFolderId);
+        favoriteFolderAccountService.validateMembership(account, favoriteFolder);
+
+        List<Place> requestedPlaces = placeRepository.findAllById(placeIds);
+        List<Place> placesToAdd = filterPlacesToAdd(favoriteFolder, requestedPlaces);
+        List<FavoritePlace> savedFavoritePlaces = saveFavoritePlaces(favoriteFolder, placesToAdd);
+
+        if (!savedFavoritePlaces.isEmpty()) {
+            eventPublisher.publishEvent(FavoriteFolderUpdateEvent.of(favoriteFolderId, ActionType.PLACE_ADDED));
+        }
+
+        return savedFavoritePlaces.stream()
+                .map(FavoritePlaceResponse::from)
+                .toList();
     }
 
     @Transactional
@@ -220,6 +243,31 @@ public class FavoritePlaceService {
         if (isAlreadyFavorite) {
             throw new ConflictException(ErrorTag.FAVORITE_PLACE_IN_FOLDER_CONFLICT);
         }
+    }
+
+    private List<Place> filterPlacesToAdd(FavoriteFolder favoriteFolder, List<Place> requestedPlaces) {
+        // 이미 튜립에 추가되어 있는 장소들
+        Set<Place> alreadyAddedPlaces = favoritePlaceRepository
+                .findAllByFavoriteFolderAndPlaceIn(favoriteFolder, requestedPlaces)
+                .stream()
+                .map(FavoritePlace::getPlace)
+                .collect(Collectors.toSet());
+
+        return requestedPlaces.stream()
+                .filter(place -> !alreadyAddedPlaces.contains(place))
+                .toList();
+    }
+
+    private List<FavoritePlace> saveFavoritePlaces(FavoriteFolder favoriteFolder, List<Place> placesToAdd) {
+        int nextOrder = favoritePlaceRepository.findMaxFavoriteOrderByFavoriteFolder(favoriteFolder).orElse(0) + 1;
+
+        List<FavoritePlace> newFavoritePlaces = new ArrayList<>();
+        for (Place place : placesToAdd) {
+            newFavoritePlaces.add(new FavoritePlace(favoriteFolder, place, nextOrder));
+            nextOrder++;
+        }
+
+        return favoritePlaceRepository.saveAll(newFavoritePlaces);
     }
 
     private void validateFavoritePlaceBelongsToFolder(FavoritePlace favoritePlace, FavoriteFolder favoriteFolder) {

--- a/backend/turip-app/src/main/java/turip/favorite/service/FavoritePlaceService.java
+++ b/backend/turip-app/src/main/java/turip/favorite/service/FavoritePlaceService.java
@@ -124,7 +124,7 @@ public class FavoritePlaceService {
     @Transactional
     public void updatePlaceOrder(Account account, Long favoriteFolderId,
                                  FavoritePlaceOrderRequest request) {
-        FavoriteFolder favoriteFolder = getFavoriteFolderById(favoriteFolderId);
+        FavoriteFolder favoriteFolder = getFavoriteFolderByIdWithLock(favoriteFolderId);
         favoriteFolderAccountService.validateMembership(account, favoriteFolder);
 
         List<Long> favoritePlaceIdsOrder = request.favoritePlaceIdsOrder();
@@ -141,7 +141,7 @@ public class FavoritePlaceService {
 
     @Transactional
     public void remove(Account account, Long favoriteFolderId, Long placeId) {
-        FavoriteFolder favoriteFolder = getFavoriteFolderById(favoriteFolderId);
+        FavoriteFolder favoriteFolder = getFavoriteFolderByIdWithLock(favoriteFolderId);
         Place place = getPlaceById(placeId);
 
         favoriteFolderAccountService.validateMembership(account, favoriteFolder);

--- a/backend/turip-app/src/main/java/turip/favorite/service/FavoritePlaceService.java
+++ b/backend/turip-app/src/main/java/turip/favorite/service/FavoritePlaceService.java
@@ -60,8 +60,6 @@ public class FavoritePlaceService {
 
     @Transactional
     public List<FavoritePlaceResponse> batchCreate(Account account, Long favoriteFolderId, List<Long> placeIds) {
-        validatePlaceIds(placeIds);
-
         FavoriteFolder favoriteFolder = getFavoriteFolderByIdWithLock(favoriteFolderId);
         favoriteFolderAccountService.validateMembership(account, favoriteFolder);
 
@@ -246,15 +244,6 @@ public class FavoritePlaceService {
             throw new NotFoundException(ErrorTag.FAVORITE_FOLDER_NOT_FOUND);
         }
         requestedFavoriteFolders.forEach(folder -> favoriteFolderAccountService.validateMembership(account, folder));
-    }
-
-    private void validatePlaceIds(List<Long> placeIds) {
-        if (placeIds == null) {
-            throw new BadRequestException(ErrorTag.BAD_REQUEST);
-        }
-        if (placeIds.size() > 70) {
-            throw new BadRequestException(ErrorTag.FAVORITE_PLACE_BATCH_SIZE_EXCEEDED);
-        }
     }
 
     private void validateDuplicated(FavoriteFolder favoriteFolder, Place place) {

--- a/backend/turip-app/src/main/java/turip/favorite/service/FavoritePlaceService.java
+++ b/backend/turip-app/src/main/java/turip/favorite/service/FavoritePlaceService.java
@@ -64,6 +64,10 @@ public class FavoritePlaceService {
         favoriteFolderAccountService.validateMembership(account, favoriteFolder);
 
         List<Place> requestedPlaces = findPlacesByIdInRequestOrder(placeIds);
+        if (requestedPlaces.isEmpty()) {
+            return List.of();
+        }
+
         List<Place> placesToAdd = filterPlacesToAdd(favoriteFolder, requestedPlaces);
         List<FavoritePlace> savedFavoritePlaces = saveFavoritePlaces(favoriteFolder, placesToAdd);
 

--- a/backend/turip-app/src/main/java/turip/favorite/service/FavoritePlaceService.java
+++ b/backend/turip-app/src/main/java/turip/favorite/service/FavoritePlaceService.java
@@ -60,9 +60,7 @@ public class FavoritePlaceService {
 
     @Transactional
     public List<FavoritePlaceResponse> batchCreate(Account account, Long favoriteFolderId, List<Long> placeIds) {
-        if (placeIds == null) {
-            throw new BadRequestException(ErrorTag.BAD_REQUEST);
-        }
+        validatePlaceIds(placeIds);
 
         FavoriteFolder favoriteFolder = getFavoriteFolderByIdWithLock(favoriteFolderId);
         favoriteFolderAccountService.validateMembership(account, favoriteFolder);
@@ -248,6 +246,15 @@ public class FavoritePlaceService {
             throw new NotFoundException(ErrorTag.FAVORITE_FOLDER_NOT_FOUND);
         }
         requestedFavoriteFolders.forEach(folder -> favoriteFolderAccountService.validateMembership(account, folder));
+    }
+
+    private void validatePlaceIds(List<Long> placeIds) {
+        if (placeIds == null) {
+            throw new BadRequestException(ErrorTag.BAD_REQUEST);
+        }
+        if (placeIds.size() > 70) {
+            throw new BadRequestException(ErrorTag.FAVORITE_PLACE_BATCH_SIZE_EXCEEDED);
+        }
     }
 
     private void validateDuplicated(FavoriteFolder favoriteFolder, Place place) {

--- a/backend/turip-app/src/main/java/turip/favorite/service/FavoritePlaceService.java
+++ b/backend/turip-app/src/main/java/turip/favorite/service/FavoritePlaceService.java
@@ -85,13 +85,16 @@ public class FavoritePlaceService {
                                                              List<Long> favoriteFolderIds,
                                                              Long placeId) {
         List<Long> requestIds = favoriteFolderIds.stream().distinct().toList();
-        List<FavoriteFolder> requestFolders = favoriteFolderRepository.findAllByIdInWithLock(requestIds);
-        validateMultiFolder(account, requestFolders, requestIds);
-
         Place place = getPlaceById(placeId);
         List<FavoritePlace> existingPlaces = favoritePlaceRepository.findAllByPlaceAndAccount(place, account);
 
         Set<Long> affectedFolderIds = calculateAffectedFolderIds(existingPlaces, requestIds);
+        List<FavoriteFolder> lockedFolders = favoriteFolderRepository.findAllByIdInWithLock(affectedFolderIds.stream().toList());
+
+        List<FavoriteFolder> requestFolders = lockedFolders.stream()
+                .filter(folder -> requestIds.contains(folder.getId()))
+                .toList();
+        validateMultiFolder(account, requestFolders, requestIds);
 
         deleteRemovedFavoritePlaces(existingPlaces, requestIds);
         List<FavoritePlace> createdPlaces = createFavoritePlaces(place, existingPlaces, requestFolders, requestIds);

--- a/backend/turip-app/src/test/java/turip/favorite/api/FavoritePlaceApiTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/api/FavoritePlaceApiTest.java
@@ -264,6 +264,169 @@ class FavoritePlaceApiTest {
         }
     }
 
+    @DisplayName("/api/v1/turips/places/batch POST 여러 장소 찜 일괄 생성 테스트")
+    @Nested
+    class BatchCreate {
+
+        @DisplayName("여러 장소 찜 생성에 성공한 경우 201 CREATED 코드와 생성된 장소 찜 목록을 응답한다")
+        @Test
+        void batchCreate1() {
+            // given
+            Long accountId = testDataHelper.insertAccount();
+            jdbcTemplate.update("INSERT INTO guest (account_id, device_fid) VALUES (?, 'testDeviceFid')", accountId);
+            Long folderId = testDataHelper.insertFavoriteFolder("테스트 폴더");
+            testDataHelper.insertFavoriteFolderAccount(accountId, folderId, AccountRole.OWNER);
+            jdbcTemplate.update(
+                    "INSERT INTO place (name, url, address, latitude, longitude) VALUES ('장소1','https://naver.me/place1', '장소1 주소', 37.1234, 127.1234)");
+            jdbcTemplate.update(
+                    "INSERT INTO place (name, url, address, latitude, longitude) VALUES ('장소2','https://naver.me/place2', '장소2 주소', 37.5678, 127.5678)");
+
+            // when & then
+            Map<String, Object> request = new HashMap<>();
+            request.put("turipId", 1L);
+            request.put("placeIds", List.of(1L, 2L));
+
+            RestAssured.given().port(port)
+                    .header("device-fid", "testDeviceFid")
+                    .body(request)
+                    .contentType(ContentType.JSON)
+                    .when().post("/api/v1/turips/places/batch")
+                    .then()
+                    .statusCode(201)
+                    .body("size()", is(2))
+                    .body("[0].placeId", is(1))
+                    .body("[1].placeId", is(2));
+        }
+
+        @DisplayName("이미 폴더에 추가된 장소는 건너뛰고 나머지만 생성한다")
+        @Test
+        void batchCreate2() {
+            // given
+            Long accountId = testDataHelper.insertAccount();
+            jdbcTemplate.update("INSERT INTO guest (account_id, device_fid) VALUES (?, 'testDeviceFid')", accountId);
+            Long folderId = testDataHelper.insertFavoriteFolder("테스트 폴더");
+            testDataHelper.insertFavoriteFolderAccount(accountId, folderId, AccountRole.OWNER);
+            jdbcTemplate.update(
+                    "INSERT INTO place (name, url, address, latitude, longitude) VALUES ('장소1','https://naver.me/place1', '장소1 주소', 37.1234, 127.1234)");
+            jdbcTemplate.update(
+                    "INSERT INTO place (name, url, address, latitude, longitude) VALUES ('장소2','https://naver.me/place2', '장소2 주소', 37.5678, 127.5678)");
+            jdbcTemplate.update(
+                    "INSERT INTO favorite_place (favorite_folder_id, place_id, favorite_order) VALUES (1, 1, 1)");
+
+            // when & then
+            Map<String, Object> request = new HashMap<>();
+            request.put("turipId", 1L);
+            request.put("placeIds", List.of(1L, 2L));
+
+            RestAssured.given().port(port)
+                    .header("device-fid", "testDeviceFid")
+                    .body(request)
+                    .contentType(ContentType.JSON)
+                    .when().post("/api/v1/turips/places/batch")
+                    .then()
+                    .statusCode(201)
+                    .body("size()", is(1))
+                    .body("[0].placeId", is(2));
+        }
+
+        @DisplayName("존재하지 않는 placeId는 건너뛰고 나머지만 생성한다")
+        @Test
+        void batchCreate3() {
+            // given
+            Long accountId = testDataHelper.insertAccount();
+            jdbcTemplate.update("INSERT INTO guest (account_id, device_fid) VALUES (?, 'testDeviceFid')", accountId);
+            Long folderId = testDataHelper.insertFavoriteFolder("테스트 폴더");
+            testDataHelper.insertFavoriteFolderAccount(accountId, folderId, AccountRole.OWNER);
+            jdbcTemplate.update(
+                    "INSERT INTO place (name, url, address, latitude, longitude) VALUES ('장소1','https://naver.me/place1', '장소1 주소', 37.1234, 127.1234)");
+
+            // when & then
+            Map<String, Object> request = new HashMap<>();
+            request.put("turipId", 1L);
+            request.put("placeIds", List.of(1L, 999L));
+
+            RestAssured.given().port(port)
+                    .header("device-fid", "testDeviceFid")
+                    .body(request)
+                    .contentType(ContentType.JSON)
+                    .when().post("/api/v1/turips/places/batch")
+                    .then()
+                    .statusCode(201)
+                    .body("size()", is(1))
+                    .body("[0].placeId", is(1));
+        }
+
+        @DisplayName("placeIds가 빈 배열이면 빈 배열을 응답한다")
+        @Test
+        void batchCreate4() {
+            // given
+            Long accountId = testDataHelper.insertAccount();
+            jdbcTemplate.update("INSERT INTO guest (account_id, device_fid) VALUES (?, 'testDeviceFid')", accountId);
+            Long folderId = testDataHelper.insertFavoriteFolder("테스트 폴더");
+            testDataHelper.insertFavoriteFolderAccount(accountId, folderId, AccountRole.OWNER);
+
+            // when & then
+            Map<String, Object> request = new HashMap<>();
+            request.put("turipId", 1L);
+            request.put("placeIds", List.of());
+
+            RestAssured.given().port(port)
+                    .header("device-fid", "testDeviceFid")
+                    .body(request)
+                    .contentType(ContentType.JSON)
+                    .when().post("/api/v1/turips/places/batch")
+                    .then()
+                    .statusCode(201)
+                    .body("size()", is(0));
+        }
+
+        @DisplayName("폴더 소유자의 기기id와 요청자의 기기id가 같지 않은 경우 403 FORBIDDEN을 응답한다")
+        @Test
+        void batchCreate5() {
+            // given
+            Long accountId = testDataHelper.insertAccount();
+            jdbcTemplate.update("INSERT INTO guest (account_id, device_fid) VALUES (?, 'may')", accountId);
+            Long folderId = testDataHelper.insertFavoriteFolder("테스트 폴더");
+            testDataHelper.insertFavoriteFolderAccount(accountId, folderId, AccountRole.OWNER);
+            jdbcTemplate.update(
+                    "INSERT INTO place (name, url, address, latitude, longitude) VALUES ('장소1','https://naver.me/place1', '장소1 주소', 37.1234, 127.1234)");
+
+            // when & then
+            Map<String, Object> request = new HashMap<>();
+            request.put("turipId", 1L);
+            request.put("placeIds", List.of(1L));
+
+            RestAssured.given().port(port)
+                    .header("device-fid", "cool")
+                    .body(request)
+                    .contentType(ContentType.JSON)
+                    .when().post("/api/v1/turips/places/batch")
+                    .then()
+                    .statusCode(403);
+        }
+
+        @DisplayName("turipId에 대한 폴더가 존재하지 않는 경우 404 NOT FOUND를 응답한다")
+        @Test
+        void batchCreate6() {
+            // given
+            Long accountId = testDataHelper.insertAccount();
+            jdbcTemplate.update("INSERT INTO guest (account_id, device_fid) VALUES (?, 'testDeviceFid')", accountId);
+
+            // when & then
+            Map<String, Object> request = new HashMap<>();
+            request.put("turipId", 999L);
+            request.put("placeIds", List.of(1L));
+
+            RestAssured.given().port(port)
+                    .header("device-fid", "testDeviceFid")
+                    .body(request)
+                    .contentType(ContentType.JSON)
+                    .when().post("/api/v1/turips/places/batch")
+                    .then()
+                    .statusCode(404);
+        }
+    }
+
     @DisplayName("/api/v1/turips/places GET 장소 찜 폴더의 장소 찜 목록 조회 테스트")
     @Nested
     class ReadAllByFolder {

--- a/backend/turip-app/src/test/java/turip/favorite/api/FavoritePlaceApiTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/api/FavoritePlaceApiTest.java
@@ -425,6 +425,44 @@ class FavoritePlaceApiTest {
                     .then()
                     .statusCode(404);
         }
+
+        @DisplayName("placeIds를 id 역순으로 요청해도 요청 순서대로 응답하고 favorite_order도 요청 순서대로 저장된다")
+        @Test
+        void batchCreate7() {
+            // given
+            Long accountId = testDataHelper.insertAccount();
+            jdbcTemplate.update("INSERT INTO guest (account_id, device_fid) VALUES (?, 'testDeviceFid')", accountId);
+            Long folderId = testDataHelper.insertFavoriteFolder("테스트 폴더");
+            testDataHelper.insertFavoriteFolderAccount(accountId, folderId, AccountRole.OWNER);
+            jdbcTemplate.update(
+                    "INSERT INTO place (name, url, address, latitude, longitude) VALUES ('장소1','https://naver.me/place1', '장소1 주소', 37.1234, 127.1234)");
+            jdbcTemplate.update(
+                    "INSERT INTO place (name, url, address, latitude, longitude) VALUES ('장소2','https://naver.me/place2', '장소2 주소', 37.5678, 127.5678)");
+            jdbcTemplate.update(
+                    "INSERT INTO place (name, url, address, latitude, longitude) VALUES ('장소3','https://naver.me/place3', '장소3 주소', 37.9999, 127.9999)");
+
+            // when & then
+            Map<String, Object> request = new HashMap<>();
+            request.put("turipId", 1L);
+            request.put("placeIds", List.of(3L, 1L, 2L));
+
+            RestAssured.given().port(port)
+                    .header("device-fid", "testDeviceFid")
+                    .body(request)
+                    .contentType(ContentType.JSON)
+                    .when().post("/api/v1/turips/places/batch")
+                    .then()
+                    .statusCode(201)
+                    .body("size()", is(3))
+                    .body("[0].placeId", is(3))
+                    .body("[1].placeId", is(1))
+                    .body("[2].placeId", is(2));
+
+            List<Long> savedOrderByPlaceId = jdbcTemplate.queryForList(
+                    "SELECT place_id FROM favorite_place WHERE favorite_folder_id = ? ORDER BY favorite_order ASC",
+                    Long.class, folderId);
+            assertThat(savedOrderByPlaceId).containsExactly(3L, 1L, 2L);
+        }
     }
 
     @DisplayName("/api/v1/turips/places GET 장소 찜 폴더의 장소 찜 목록 조회 테스트")

--- a/backend/turip-app/src/test/java/turip/favorite/api/FavoritePlaceApiTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/api/FavoritePlaceApiTest.java
@@ -5,6 +5,8 @@ import static org.hamcrest.Matchers.is;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -462,6 +464,92 @@ class FavoritePlaceApiTest {
                     "SELECT place_id FROM favorite_place WHERE favorite_folder_id = ? ORDER BY favorite_order ASC",
                     Long.class, folderId);
             assertThat(savedOrderByPlaceId).containsExactly(3L, 1L, 2L);
+        }
+
+        @DisplayName("turipId가 누락된 경우 400 BAD REQUEST를 응답한다")
+        @Test
+        void batchCreate8() {
+            // given
+            Long accountId = testDataHelper.insertAccount();
+            jdbcTemplate.update("INSERT INTO guest (account_id, device_fid) VALUES (?, 'testDeviceFid')", accountId);
+
+            // when & then
+            Map<String, Object> request = new HashMap<>();
+            request.put("placeIds", List.of(1L));
+
+            RestAssured.given().port(port)
+                    .header("device-fid", "testDeviceFid")
+                    .body(request)
+                    .contentType(ContentType.JSON)
+                    .when().post("/api/v1/turips/places/batch")
+                    .then()
+                    .statusCode(400);
+        }
+
+        @DisplayName("placeIds가 누락된 경우 400 BAD REQUEST를 응답한다")
+        @Test
+        void batchCreate9() {
+            // given
+            Long accountId = testDataHelper.insertAccount();
+            jdbcTemplate.update("INSERT INTO guest (account_id, device_fid) VALUES (?, 'testDeviceFid')", accountId);
+
+            // when & then
+            Map<String, Object> request = new HashMap<>();
+            request.put("turipId", 1L);
+
+            RestAssured.given().port(port)
+                    .header("device-fid", "testDeviceFid")
+                    .body(request)
+                    .contentType(ContentType.JSON)
+                    .when().post("/api/v1/turips/places/batch")
+                    .then()
+                    .statusCode(400);
+        }
+
+        @DisplayName("placeIds에 null이 포함된 경우 400 BAD REQUEST를 응답한다")
+        @Test
+        void batchCreate10() {
+            // given
+            Long accountId = testDataHelper.insertAccount();
+            jdbcTemplate.update("INSERT INTO guest (account_id, device_fid) VALUES (?, 'testDeviceFid')", accountId);
+
+            // when & then
+            Map<String, Object> request = new HashMap<>();
+            request.put("turipId", 1L);
+            request.put("placeIds", Arrays.asList(1L, null));
+
+            RestAssured.given().port(port)
+                    .header("device-fid", "testDeviceFid")
+                    .body(request)
+                    .contentType(ContentType.JSON)
+                    .when().post("/api/v1/turips/places/batch")
+                    .then()
+                    .statusCode(400);
+        }
+
+        @DisplayName("placeIds 개수가 70개를 초과하면 400 BAD REQUEST를 응답한다")
+        @Test
+        void batchCreate11() {
+            // given
+            Long accountId = testDataHelper.insertAccount();
+            jdbcTemplate.update("INSERT INTO guest (account_id, device_fid) VALUES (?, 'testDeviceFid')", accountId);
+            List<Long> placeIds = new ArrayList<>();
+            for (long id = 1L; id <= 71L; id++) {
+                placeIds.add(id);
+            }
+
+            // when & then
+            Map<String, Object> request = new HashMap<>();
+            request.put("turipId", 1L);
+            request.put("placeIds", placeIds);
+
+            RestAssured.given().port(port)
+                    .header("device-fid", "testDeviceFid")
+                    .body(request)
+                    .contentType(ContentType.JSON)
+                    .when().post("/api/v1/turips/places/batch")
+                    .then()
+                    .statusCode(400);
         }
     }
 

--- a/backend/turip-app/src/test/java/turip/favorite/api/FavoritePlaceApiTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/api/FavoritePlaceApiTest.java
@@ -551,6 +551,30 @@ class FavoritePlaceApiTest {
                     .then()
                     .statusCode(400);
         }
+
+        @DisplayName("요청한 placeIds가 모두 존재하지 않으면 빈 배열을 응답한다")
+        @Test
+        void batchCreate12() {
+            // given
+            Long accountId = testDataHelper.insertAccount();
+            jdbcTemplate.update("INSERT INTO guest (account_id, device_fid) VALUES (?, 'testDeviceFid')", accountId);
+            Long folderId = testDataHelper.insertFavoriteFolder("테스트 폴더");
+            testDataHelper.insertFavoriteFolderAccount(accountId, folderId, AccountRole.OWNER);
+
+            // when & then
+            Map<String, Object> request = new HashMap<>();
+            request.put("turipId", 1L);
+            request.put("placeIds", List.of(998L, 999L));
+
+            RestAssured.given().port(port)
+                    .header("device-fid", "testDeviceFid")
+                    .body(request)
+                    .contentType(ContentType.JSON)
+                    .when().post("/api/v1/turips/places/batch")
+                    .then()
+                    .statusCode(201)
+                    .body("size()", is(0));
+        }
     }
 
     @DisplayName("/api/v1/turips/places GET 장소 찜 폴더의 장소 찜 목록 조회 테스트")

--- a/backend/turip-app/src/test/java/turip/favorite/service/FavoriteFolderServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/service/FavoriteFolderServiceTest.java
@@ -271,7 +271,7 @@ class FavoriteFolderServiceTest {
             FavoriteFolder favoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(folderId, oldName);
             FavoriteFolderNameRequest request = new FavoriteFolderNameRequest(newName);
 
-            given(favoriteFolderRepository.findById(folderId))
+            given(favoriteFolderRepository.findByIdWithLock(folderId))
                     .willReturn(Optional.of(favoriteFolder));
 
             // when
@@ -299,7 +299,7 @@ class FavoriteFolderServiceTest {
             Account member = AccountFixture.createCustomAccount(accountId, Role.USER);
             FavoriteFolderNameRequest request = new FavoriteFolderNameRequest(newName);
 
-            given(favoriteFolderRepository.findById(nonExistentFolderId))
+            given(favoriteFolderRepository.findByIdWithLock(nonExistentFolderId))
                     .willReturn(Optional.empty());
 
             // when & then
@@ -321,7 +321,7 @@ class FavoriteFolderServiceTest {
             FavoriteFolder favoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(folderId, oldName);
             FavoriteFolderNameRequest request = new FavoriteFolderNameRequest(newName);
 
-            given(favoriteFolderRepository.findById(folderId))
+            given(favoriteFolderRepository.findByIdWithLock(folderId))
                     .willReturn(Optional.of(favoriteFolder));
             willThrow(new ForbiddenException(ErrorTag.FORBIDDEN))
                     .given(favoriteFolderAccountService).validateMembership(requestAccount, favoriteFolder);
@@ -345,7 +345,7 @@ class FavoriteFolderServiceTest {
             FavoriteFolder newFavoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(newFolderId, newName);
             FavoriteFolderNameRequest request = new FavoriteFolderNameRequest(newName);
 
-            given(favoriteFolderRepository.findById(newFolderId))
+            given(favoriteFolderRepository.findByIdWithLock(newFolderId))
                     .willReturn(Optional.of(newFavoriteFolder));
             given(favoriteFolderRepository.findAllByAccount(account))
                     .willReturn(List.of(oldFavoriteFolder));
@@ -368,7 +368,7 @@ class FavoriteFolderServiceTest {
             FavoriteFolder favoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(folderId, oldName);
             FavoriteFolderNameRequest request = new FavoriteFolderNameRequest(newName);
 
-            given(favoriteFolderRepository.findById(folderId))
+            given(favoriteFolderRepository.findByIdWithLock(folderId))
                     .willReturn(Optional.of(favoriteFolder));
 
             // when & then
@@ -388,7 +388,7 @@ class FavoriteFolderServiceTest {
             FavoriteFolder favoriteFolder = FavoriteFolderFixture.createDefaultFolderWithId(folderId);
             FavoriteFolderNameRequest request = new FavoriteFolderNameRequest(newName);
 
-            given(favoriteFolderRepository.findById(folderId))
+            given(favoriteFolderRepository.findByIdWithLock(folderId))
                     .willReturn(Optional.of(favoriteFolder));
 
             // when & then
@@ -591,7 +591,7 @@ class FavoriteFolderServiceTest {
             Account member = AccountFixture.createCustomAccount(accountId, Role.USER);
             FavoriteFolder favoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(folderId, folderName);
 
-            given(favoriteFolderRepository.findById(folderId))
+            given(favoriteFolderRepository.findByIdWithLock(folderId))
                     .willReturn(Optional.of(favoriteFolder));
 
             // when
@@ -615,7 +615,7 @@ class FavoriteFolderServiceTest {
 
             Account member = AccountFixture.createCustomAccount(accountId, Role.USER);
 
-            given(favoriteFolderRepository.findById(nonExistentFolderId))
+            given(favoriteFolderRepository.findByIdWithLock(nonExistentFolderId))
                     .willReturn(Optional.empty());
 
             // when & then
@@ -635,7 +635,7 @@ class FavoriteFolderServiceTest {
             Account requestAccount = AccountFixture.createCustomAccount(requestAccountId, Role.USER);
             FavoriteFolder favoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(folderId, folderName);
 
-            given(favoriteFolderRepository.findById(folderId))
+            given(favoriteFolderRepository.findByIdWithLock(folderId))
                     .willReturn(Optional.of(favoriteFolder));
             willThrow(new ForbiddenException(ErrorTag.FORBIDDEN))
                     .given(favoriteFolderAccountService).validateOwnership(requestAccount, favoriteFolder);
@@ -655,7 +655,7 @@ class FavoriteFolderServiceTest {
             Account member = AccountFixture.createCustomAccount(accountId, Role.USER);
             FavoriteFolder favoriteFolder = FavoriteFolderFixture.createDefaultFolderWithId(folderId);
 
-            given(favoriteFolderRepository.findById(folderId))
+            given(favoriteFolderRepository.findByIdWithLock(folderId))
                     .willReturn(Optional.of(favoriteFolder));
 
             // when & then
@@ -674,7 +674,7 @@ class FavoriteFolderServiceTest {
             Account member = AccountFixture.createCustomAccount(accountId, Role.USER);
             FavoriteFolder favoriteFolder = FavoriteFolderFixture.createSharedFolder("공유 폴더");
 
-            given(favoriteFolderRepository.findById(folderId))
+            given(favoriteFolderRepository.findByIdWithLock(folderId))
                     .willReturn(Optional.of(favoriteFolder));
 
             // when & then

--- a/backend/turip-app/src/test/java/turip/favorite/service/FavoritePlaceServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/service/FavoritePlaceServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.util.List;
@@ -182,6 +183,210 @@ class FavoritePlaceServiceTest {
             // when & then
             assertThatThrownBy(() -> favoritePlaceService.create(account, favoriteFolderId, placeId))
                     .isInstanceOf(ConflictException.class);
+        }
+    }
+
+    @DisplayName("여러 장소 찜 일괄 생성 테스트")
+    @Nested
+    class BatchCreate {
+
+        @DisplayName("여러 장소 찜을 한 번에 생성하고 알림 이벤트를 발행한다")
+        @Test
+        void batchCreate1() {
+            // given
+            Long favoriteFolderId = 1L;
+            Account account = AccountFixture.createUser();
+            FavoriteFolder favoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(favoriteFolderId, "폴더1");
+            Place place1 = new Place(1L, "장소1", "url1", "주소1", 1, 1);
+            Place place2 = new Place(2L, "장소2", "url2", "주소2", 2, 2);
+
+            given(favoriteFolderRepository.findById(favoriteFolderId))
+                    .willReturn(Optional.of(favoriteFolder));
+            given(placeRepository.findAllById(List.of(1L, 2L)))
+                    .willReturn(List.of(place1, place2));
+            given(favoritePlaceRepository.findAllByFavoriteFolderAndPlaceIn(favoriteFolder, List.of(place1, place2)))
+                    .willReturn(List.of());
+            given(favoritePlaceRepository.findMaxFavoriteOrderByFavoriteFolder(favoriteFolder))
+                    .willReturn(Optional.empty());
+            given(favoritePlaceRepository.saveAll(any()))
+                    .willReturn(List.of(
+                            new FavoritePlace(10L, favoriteFolder, place1, 1),
+                            new FavoritePlace(11L, favoriteFolder, place2, 2)
+                    ));
+
+            // when
+            List<FavoritePlaceResponse> responses =
+                    favoritePlaceService.batchCreate(account, favoriteFolderId, List.of(1L, 2L));
+
+            // then
+            assertAll(
+                    () -> assertThat(responses).hasSize(2),
+                    () -> assertThat(responses.get(0).placeId()).isEqualTo(1L),
+                    () -> assertThat(responses.get(1).placeId()).isEqualTo(2L),
+                    () -> verify(eventPublisher).publishEvent(
+                            FavoriteFolderUpdateEvent.of(favoriteFolderId, ActionType.PLACE_ADDED))
+            );
+        }
+
+        @DisplayName("이미 폴더에 추가된 장소는 건너뛰고 나머지만 생성한다")
+        @Test
+        void batchCreate2() {
+            // given
+            Long favoriteFolderId = 1L;
+            Account account = AccountFixture.createUser();
+            FavoriteFolder favoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(favoriteFolderId, "폴더1");
+            Place place1 = new Place(1L, "장소1", "url1", "주소1", 1, 1);
+            Place place2 = new Place(2L, "장소2", "url2", "주소2", 2, 2);
+            FavoritePlace alreadyFavorited = new FavoritePlace(5L, favoriteFolder, place1, 1);
+
+            given(favoriteFolderRepository.findById(favoriteFolderId))
+                    .willReturn(Optional.of(favoriteFolder));
+            given(placeRepository.findAllById(List.of(1L, 2L)))
+                    .willReturn(List.of(place1, place2));
+            given(favoritePlaceRepository.findAllByFavoriteFolderAndPlaceIn(favoriteFolder, List.of(place1, place2)))
+                    .willReturn(List.of(alreadyFavorited));
+            given(favoritePlaceRepository.findMaxFavoriteOrderByFavoriteFolder(favoriteFolder))
+                    .willReturn(Optional.of(1));
+            given(favoritePlaceRepository.saveAll(any()))
+                    .willReturn(List.of(new FavoritePlace(11L, favoriteFolder, place2, 2)));
+
+            // when
+            List<FavoritePlaceResponse> responses =
+                    favoritePlaceService.batchCreate(account, favoriteFolderId, List.of(1L, 2L));
+
+            // then
+            assertAll(
+                    () -> assertThat(responses).hasSize(1),
+                    () -> assertThat(responses.get(0).placeId()).isEqualTo(2L)
+            );
+        }
+
+        @DisplayName("존재하지 않는 placeId는 건너뛰고 나머지만 생성한다")
+        @Test
+        void batchCreate3() {
+            // given
+            Long favoriteFolderId = 1L;
+            Account account = AccountFixture.createUser();
+            FavoriteFolder favoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(favoriteFolderId, "폴더1");
+            Place place1 = new Place(1L, "장소1", "url1", "주소1", 1, 1);
+
+            given(favoriteFolderRepository.findById(favoriteFolderId))
+                    .willReturn(Optional.of(favoriteFolder));
+            given(placeRepository.findAllById(List.of(1L, 999L)))
+                    .willReturn(List.of(place1));
+            given(favoritePlaceRepository.findAllByFavoriteFolderAndPlaceIn(favoriteFolder, List.of(place1)))
+                    .willReturn(List.of());
+            given(favoritePlaceRepository.findMaxFavoriteOrderByFavoriteFolder(favoriteFolder))
+                    .willReturn(Optional.empty());
+            given(favoritePlaceRepository.saveAll(any()))
+                    .willReturn(List.of(new FavoritePlace(10L, favoriteFolder, place1, 1)));
+
+            // when
+            List<FavoritePlaceResponse> responses =
+                    favoritePlaceService.batchCreate(account, favoriteFolderId, List.of(1L, 999L));
+
+            // then
+            assertThat(responses).hasSize(1);
+            assertThat(responses.get(0).placeId()).isEqualTo(1L);
+        }
+
+        @DisplayName("placeIds가 빈 배열이면 빈 리스트를 반환하고 이벤트를 발행하지 않는다")
+        @Test
+        void batchCreate4() {
+            // given
+            Long favoriteFolderId = 1L;
+            Account account = AccountFixture.createUser();
+            FavoriteFolder favoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(favoriteFolderId, "폴더1");
+
+            given(favoriteFolderRepository.findById(favoriteFolderId))
+                    .willReturn(Optional.of(favoriteFolder));
+
+            // when
+            List<FavoritePlaceResponse> responses =
+                    favoritePlaceService.batchCreate(account, favoriteFolderId, List.of());
+
+            // then
+            assertAll(
+                    () -> assertThat(responses).isEmpty(),
+                    () -> verify(eventPublisher, never()).publishEvent(any())
+            );
+        }
+
+        @DisplayName("모든 placeId가 이미 추가되어 있으면 빈 리스트를 반환하고 이벤트를 발행하지 않는다")
+        @Test
+        void batchCreate5() {
+            // given
+            Long favoriteFolderId = 1L;
+            Account account = AccountFixture.createUser();
+            FavoriteFolder favoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(favoriteFolderId, "폴더1");
+            Place place1 = new Place(1L, "장소1", "url1", "주소1", 1, 1);
+            FavoritePlace alreadyFavorited = new FavoritePlace(5L, favoriteFolder, place1, 1);
+
+            given(favoriteFolderRepository.findById(favoriteFolderId))
+                    .willReturn(Optional.of(favoriteFolder));
+            given(placeRepository.findAllById(List.of(1L)))
+                    .willReturn(List.of(place1));
+            given(favoritePlaceRepository.findAllByFavoriteFolderAndPlaceIn(favoriteFolder, List.of(place1)))
+                    .willReturn(List.of(alreadyFavorited));
+
+            // when
+            List<FavoritePlaceResponse> responses =
+                    favoritePlaceService.batchCreate(account, favoriteFolderId, List.of(1L));
+
+            // then
+            assertAll(
+                    () -> assertThat(responses).isEmpty(),
+                    () -> verify(eventPublisher, never()).publishEvent(any())
+            );
+        }
+
+        @DisplayName("폴더 소유자가 아닌 요청자가 시도하면 ForbiddenException을 발생시킨다")
+        @Test
+        void batchCreate6() {
+            // given
+            Long favoriteFolderId = 1L;
+            Account requestAccount = AccountFixture.createCustomAccount(2L, Role.USER);
+            FavoriteFolder favoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(favoriteFolderId, "폴더1");
+
+            given(favoriteFolderRepository.findById(favoriteFolderId))
+                    .willReturn(Optional.of(favoriteFolder));
+            doThrow(new ForbiddenException(ErrorTag.FORBIDDEN))
+                    .when(favoriteFolderAccountService)
+                    .validateMembership(requestAccount, favoriteFolder);
+
+            // when & then
+            assertThatThrownBy(
+                    () -> favoritePlaceService.batchCreate(requestAccount, favoriteFolderId, List.of(1L)))
+                    .isInstanceOf(ForbiddenException.class);
+        }
+
+        @DisplayName("favoriteFolderId에 대한 폴더가 존재하지 않는 경우 NotFoundException을 발생시킨다")
+        @Test
+        void batchCreate7() {
+            // given
+            Long favoriteFolderId = 1L;
+            Account account = AccountFixture.createUser();
+
+            given(favoriteFolderRepository.findById(favoriteFolderId))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> favoritePlaceService.batchCreate(account, favoriteFolderId, List.of(1L)))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage(ErrorTag.FAVORITE_FOLDER_NOT_FOUND.getMessage());
+        }
+
+        @DisplayName("placeIds가 null이면 BadRequestException을 발생시킨다")
+        @Test
+        void batchCreate8() {
+            // given
+            Long favoriteFolderId = 1L;
+            Account account = AccountFixture.createUser();
+
+            // when & then
+            assertThatThrownBy(() -> favoritePlaceService.batchCreate(account, favoriteFolderId, null))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage(ErrorTag.BAD_REQUEST.getMessage());
         }
     }
 

--- a/backend/turip-app/src/test/java/turip/favorite/service/FavoritePlaceServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/service/FavoritePlaceServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -387,6 +388,51 @@ class FavoritePlaceServiceTest {
             assertThatThrownBy(() -> favoritePlaceService.batchCreate(account, favoriteFolderId, null))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage(ErrorTag.BAD_REQUEST.getMessage());
+        }
+
+        @DisplayName("요청한 placeIds의 순서대로 응답 및 favoriteOrder가 지정된다")
+        @Test
+        void batchCreate9() {
+            // given
+            Long favoriteFolderId = 1L;
+            Account account = AccountFixture.createUser();
+            FavoriteFolder favoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(favoriteFolderId, "폴더1");
+            Place place1 = new Place(1L, "장소1", "url1", "주소1", 1, 1);
+            Place place2 = new Place(2L, "장소2", "url2", "주소2", 2, 2);
+            Place place3 = new Place(3L, "장소3", "url3", "주소3", 3, 3);
+
+            // 저장소는 요청과 다른 순서(오름차순 id)로 결과를 반환한다
+            given(favoriteFolderRepository.findById(favoriteFolderId))
+                    .willReturn(Optional.of(favoriteFolder));
+            given(placeRepository.findAllById(List.of(3L, 1L, 2L)))
+                    .willReturn(List.of(place1, place2, place3));
+            given(favoritePlaceRepository.findAllByFavoriteFolderAndPlaceIn(favoriteFolder, List.of(place3, place1, place2)))
+                    .willReturn(List.of());
+            given(favoritePlaceRepository.findMaxFavoriteOrderByFavoriteFolder(favoriteFolder))
+                    .willReturn(Optional.empty());
+            given(favoritePlaceRepository.saveAll(any()))
+                    .willAnswer(invocation -> {
+                        List<FavoritePlace> favoritePlaces = invocation.getArgument(0);
+                        List<FavoritePlace> saved = new ArrayList<>();
+                        long id = 10L;
+                        for (FavoritePlace favoritePlace : favoritePlaces) {
+                            saved.add(new FavoritePlace(id++, favoriteFolder, favoritePlace.getPlace(),
+                                    favoritePlace.getFavoriteOrder()));
+                        }
+                        return saved;
+                    });
+
+            // when
+            List<FavoritePlaceResponse> responses =
+                    favoritePlaceService.batchCreate(account, favoriteFolderId, List.of(3L, 1L, 2L));
+
+            // then
+            assertAll(
+                    () -> assertThat(responses).hasSize(3),
+                    () -> assertThat(responses.get(0).placeId()).isEqualTo(3L),
+                    () -> assertThat(responses.get(1).placeId()).isEqualTo(1L),
+                    () -> assertThat(responses.get(2).placeId()).isEqualTo(2L)
+            );
         }
     }
 

--- a/backend/turip-app/src/test/java/turip/favorite/service/FavoritePlaceServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/service/FavoritePlaceServiceTest.java
@@ -406,7 +406,8 @@ class FavoritePlaceServiceTest {
                     .willReturn(Optional.of(favoriteFolder));
             given(placeRepository.findAllById(List.of(3L, 1L, 2L)))
                     .willReturn(List.of(place1, place2, place3));
-            given(favoritePlaceRepository.findAllByFavoriteFolderAndPlaceIn(favoriteFolder, List.of(place3, place1, place2)))
+            given(favoritePlaceRepository.findAllByFavoriteFolderAndPlaceIn(favoriteFolder,
+                    List.of(place3, place1, place2)))
                     .willReturn(List.of());
             given(favoritePlaceRepository.findMaxFavoriteOrderByFavoriteFolder(favoriteFolder))
                     .willReturn(Optional.empty());
@@ -663,7 +664,7 @@ class FavoritePlaceServiceTest {
             Place place = new Place(placeId, "장소 이름", "장소 url", "주소", 1, 1);
             FavoritePlace favoritePlace = new FavoritePlace(favoriteFolder, place, 1);
 
-            given(favoriteFolderRepository.findById(favoriteFolderId))
+            given(favoriteFolderRepository.findByIdWithLock(favoriteFolderId))
                     .willReturn(Optional.of(favoriteFolder));
             given(placeRepository.findById(placeId))
                     .willReturn(Optional.of(place));
@@ -689,7 +690,7 @@ class FavoritePlaceServiceTest {
             FavoriteFolder favoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(1L, "폴더1");
             Place place = new Place(placeId, "장소 이름", "장소 url", "주소", 1, 1);
 
-            given(favoriteFolderRepository.findById(favoriteFolderId))
+            given(favoriteFolderRepository.findByIdWithLock(favoriteFolderId))
                     .willReturn(Optional.of(favoriteFolder));
             given(placeRepository.findById(placeId))
                     .willReturn(Optional.of(place));
@@ -710,7 +711,7 @@ class FavoritePlaceServiceTest {
             Long placeId = 1L;
             Account account = AccountFixture.createUser();
 
-            given(favoriteFolderRepository.findById(favoriteFolderId))
+            given(favoriteFolderRepository.findByIdWithLock(favoriteFolderId))
                     .willReturn(Optional.empty());
 
             // when & then
@@ -728,7 +729,7 @@ class FavoritePlaceServiceTest {
             Account account = AccountFixture.createUser();
             FavoriteFolder favoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(favoriteFolderId, "폴더1");
 
-            given(favoriteFolderRepository.findById(favoriteFolderId))
+            given(favoriteFolderRepository.findByIdWithLock(favoriteFolderId))
                     .willReturn(Optional.of(favoriteFolder));
             given(placeRepository.findById(placeId))
                     .willReturn(Optional.empty());
@@ -749,7 +750,7 @@ class FavoritePlaceServiceTest {
             FavoriteFolder favoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(favoriteFolderId, "폴더1");
             Place place = new Place(placeId, "장소 이름", "장소 url", "주소", 1, 1);
 
-            given(favoriteFolderRepository.findById(favoriteFolderId))
+            given(favoriteFolderRepository.findByIdWithLock(favoriteFolderId))
                     .willReturn(Optional.of(favoriteFolder));
             given(placeRepository.findById(placeId))
                     .willReturn(Optional.of(place));

--- a/backend/turip-app/src/test/java/turip/favorite/service/FavoritePlaceServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/service/FavoritePlaceServiceTest.java
@@ -81,7 +81,7 @@ class FavoritePlaceServiceTest {
             Place place = new Place(placeId, "장소 이름", "장소 url", "주소", 1, 1);
             FavoritePlace favoritePlace = new FavoritePlace(favoriteFolder, place, 1);
 
-            given(favoriteFolderRepository.findById(favoriteFolderId))
+            given(favoriteFolderRepository.findByIdWithLock(favoriteFolderId))
                     .willReturn(Optional.of(favoriteFolder));
             given(placeRepository.findById(placeId))
                     .willReturn(Optional.of(place));
@@ -114,7 +114,7 @@ class FavoritePlaceServiceTest {
             FavoriteFolder favoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(favoriteFolderId, "폴더1");
             Place place = new Place(placeId, "장소 이름", "장소 url", "주소", 1, 1);
 
-            given(favoriteFolderRepository.findById(favoriteFolderId))
+            given(favoriteFolderRepository.findByIdWithLock(favoriteFolderId))
                     .willReturn(Optional.of(favoriteFolder));
             given(placeRepository.findById(placeId))
                     .willReturn(Optional.of(place));
@@ -135,7 +135,7 @@ class FavoritePlaceServiceTest {
             Long placeId = 1L;
             Account account = AccountFixture.createUser();
 
-            given(favoriteFolderRepository.findById(favoriteFolderId))
+            given(favoriteFolderRepository.findByIdWithLock(favoriteFolderId))
                     .willReturn(Optional.empty());
 
             // when & then
@@ -153,7 +153,7 @@ class FavoritePlaceServiceTest {
             Account account = AccountFixture.createUser();
             FavoriteFolder favoriteFolder = FavoriteFolderFixture.createDefaultFolder();
 
-            given(favoriteFolderRepository.findById(favoriteFolderId))
+            given(favoriteFolderRepository.findByIdWithLock(favoriteFolderId))
                     .willReturn(Optional.of(favoriteFolder));
             given(placeRepository.findById(placeId))
                     .willReturn(Optional.empty());
@@ -174,7 +174,7 @@ class FavoritePlaceServiceTest {
             FavoriteFolder favoriteFolder = FavoriteFolderFixture.createDefaultFolder();
             Place place = new Place(placeId, "장소 이름", "장소 url", "주소", 1, 1);
 
-            given(favoriteFolderRepository.findById(favoriteFolderId))
+            given(favoriteFolderRepository.findByIdWithLock(favoriteFolderId))
                     .willReturn(Optional.of(favoriteFolder));
             given(placeRepository.findById(placeId))
                     .willReturn(Optional.of(place));
@@ -201,7 +201,7 @@ class FavoritePlaceServiceTest {
             Place place1 = new Place(1L, "장소1", "url1", "주소1", 1, 1);
             Place place2 = new Place(2L, "장소2", "url2", "주소2", 2, 2);
 
-            given(favoriteFolderRepository.findById(favoriteFolderId))
+            given(favoriteFolderRepository.findByIdWithLock(favoriteFolderId))
                     .willReturn(Optional.of(favoriteFolder));
             given(placeRepository.findAllById(List.of(1L, 2L)))
                     .willReturn(List.of(place1, place2));
@@ -240,7 +240,7 @@ class FavoritePlaceServiceTest {
             Place place2 = new Place(2L, "장소2", "url2", "주소2", 2, 2);
             FavoritePlace alreadyFavorited = new FavoritePlace(5L, favoriteFolder, place1, 1);
 
-            given(favoriteFolderRepository.findById(favoriteFolderId))
+            given(favoriteFolderRepository.findByIdWithLock(favoriteFolderId))
                     .willReturn(Optional.of(favoriteFolder));
             given(placeRepository.findAllById(List.of(1L, 2L)))
                     .willReturn(List.of(place1, place2));
@@ -271,7 +271,7 @@ class FavoritePlaceServiceTest {
             FavoriteFolder favoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(favoriteFolderId, "폴더1");
             Place place1 = new Place(1L, "장소1", "url1", "주소1", 1, 1);
 
-            given(favoriteFolderRepository.findById(favoriteFolderId))
+            given(favoriteFolderRepository.findByIdWithLock(favoriteFolderId))
                     .willReturn(Optional.of(favoriteFolder));
             given(placeRepository.findAllById(List.of(1L, 999L)))
                     .willReturn(List.of(place1));
@@ -299,7 +299,7 @@ class FavoritePlaceServiceTest {
             Account account = AccountFixture.createUser();
             FavoriteFolder favoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(favoriteFolderId, "폴더1");
 
-            given(favoriteFolderRepository.findById(favoriteFolderId))
+            given(favoriteFolderRepository.findByIdWithLock(favoriteFolderId))
                     .willReturn(Optional.of(favoriteFolder));
 
             // when
@@ -323,7 +323,7 @@ class FavoritePlaceServiceTest {
             Place place1 = new Place(1L, "장소1", "url1", "주소1", 1, 1);
             FavoritePlace alreadyFavorited = new FavoritePlace(5L, favoriteFolder, place1, 1);
 
-            given(favoriteFolderRepository.findById(favoriteFolderId))
+            given(favoriteFolderRepository.findByIdWithLock(favoriteFolderId))
                     .willReturn(Optional.of(favoriteFolder));
             given(placeRepository.findAllById(List.of(1L)))
                     .willReturn(List.of(place1));
@@ -349,7 +349,7 @@ class FavoritePlaceServiceTest {
             Account requestAccount = AccountFixture.createCustomAccount(2L, Role.USER);
             FavoriteFolder favoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(favoriteFolderId, "폴더1");
 
-            given(favoriteFolderRepository.findById(favoriteFolderId))
+            given(favoriteFolderRepository.findByIdWithLock(favoriteFolderId))
                     .willReturn(Optional.of(favoriteFolder));
             doThrow(new ForbiddenException(ErrorTag.FORBIDDEN))
                     .when(favoriteFolderAccountService)
@@ -368,7 +368,7 @@ class FavoritePlaceServiceTest {
             Long favoriteFolderId = 1L;
             Account account = AccountFixture.createUser();
 
-            given(favoriteFolderRepository.findById(favoriteFolderId))
+            given(favoriteFolderRepository.findByIdWithLock(favoriteFolderId))
                     .willReturn(Optional.empty());
 
             // when & then
@@ -402,7 +402,7 @@ class FavoritePlaceServiceTest {
             Place place3 = new Place(3L, "장소3", "url3", "주소3", 3, 3);
 
             // 저장소는 요청과 다른 순서(오름차순 id)로 결과를 반환한다
-            given(favoriteFolderRepository.findById(favoriteFolderId))
+            given(favoriteFolderRepository.findByIdWithLock(favoriteFolderId))
                     .willReturn(Optional.of(favoriteFolder));
             given(placeRepository.findAllById(List.of(3L, 1L, 2L)))
                     .willReturn(List.of(place1, place2, place3));
@@ -518,7 +518,7 @@ class FavoritePlaceServiceTest {
             FavoriteFolder favoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(favoriteFolderId, "폴더");
             FavoritePlace firstFavoritePlace = new FavoritePlace(1L, favoriteFolder, null, 1);
             FavoritePlace secondFavoritePlace = new FavoritePlace(2L, favoriteFolder, null, 2);
-            given(favoriteFolderRepository.findById(favoriteFolder.getId()))
+            given(favoriteFolderRepository.findByIdWithLock(favoriteFolder.getId()))
                     .willReturn(Optional.of(favoriteFolder));
             given(favoritePlaceRepository.findById(firstFavoritePlace.getId()))
                     .willReturn(Optional.of(firstFavoritePlace));
@@ -545,7 +545,7 @@ class FavoritePlaceServiceTest {
             Account requestAccount = AccountFixture.createCustomAccount(2L, Role.USER);
             FavoriteFolder favoriteFolder = FavoriteFolderFixture.createDefaultFolder();
 
-            given(favoriteFolderRepository.findById(favoriteFolder.getId()))
+            given(favoriteFolderRepository.findByIdWithLock(favoriteFolder.getId()))
                     .willReturn(Optional.of(favoriteFolder));
             doThrow(new ForbiddenException(ErrorTag.FORBIDDEN))
                     .when(favoriteFolderAccountService)
@@ -569,7 +569,7 @@ class FavoritePlaceServiceTest {
             FavoriteFolder otherFavoriteFolder = FavoriteFolderFixture.createCustomFolderWithId(2L, "다른 폴더");
             FavoritePlace firstFavoritePlace = new FavoritePlace(1L, favoriteFolder, null, 1);
             FavoritePlace secondFavoritePlace = new FavoritePlace(2L, otherFavoriteFolder, null, 2);
-            given(favoriteFolderRepository.findById(favoriteFolder.getId()))
+            given(favoriteFolderRepository.findByIdWithLock(favoriteFolder.getId()))
                     .willReturn(Optional.of(favoriteFolder));
             given(favoritePlaceRepository.findById(firstFavoritePlace.getId()))
                     .willReturn(Optional.of(firstFavoritePlace));
@@ -607,7 +607,7 @@ class FavoritePlaceServiceTest {
             FavoritePlace existingPlace = new FavoritePlace(10L, existingFolder, place, 1);
 
             given(placeRepository.findById(placeId)).willReturn(Optional.of(place));
-            given(favoriteFolderRepository.findAllById(any())).willReturn(List.of(requestFolder));
+            given(favoriteFolderRepository.findAllByIdInWithLock(any())).willReturn(List.of(requestFolder));
             given(favoritePlaceRepository.findAllByPlaceAndAccount(place, account)).willReturn(List.of(existingPlace));
 
             // when
@@ -634,7 +634,7 @@ class FavoritePlaceServiceTest {
             FavoriteFolder folder = FavoriteFolderFixture.createSharedFolderWithId(folderId, "공유 찜폴더");
 
             given(placeRepository.findById(placeId)).willReturn(Optional.of(place));
-            given(favoriteFolderRepository.findAllById(any())).willReturn(List.of(folder));
+            given(favoriteFolderRepository.findAllByIdInWithLock(any())).willReturn(List.of(folder));
             given(favoritePlaceRepository.findAllByPlaceAndAccount(place, account)).willReturn(List.of());
 
             lenient().doThrow(new ForbiddenException(ErrorTag.FORBIDDEN))

--- a/backend/turip-app/src/test/java/turip/favorite/service/FavoritePlaceServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/service/FavoritePlaceServiceTest.java
@@ -377,19 +377,6 @@ class FavoritePlaceServiceTest {
                     .hasMessage(ErrorTag.FAVORITE_FOLDER_NOT_FOUND.getMessage());
         }
 
-        @DisplayName("placeIds가 null이면 BadRequestException을 발생시킨다")
-        @Test
-        void batchCreate8() {
-            // given
-            Long favoriteFolderId = 1L;
-            Account account = AccountFixture.createUser();
-
-            // when & then
-            assertThatThrownBy(() -> favoritePlaceService.batchCreate(account, favoriteFolderId, null))
-                    .isInstanceOf(BadRequestException.class)
-                    .hasMessage(ErrorTag.BAD_REQUEST.getMessage());
-        }
-
         @DisplayName("요청한 placeIds의 순서대로 응답 및 favoriteOrder가 지정된다")
         @Test
         void batchCreate9() {
@@ -436,22 +423,6 @@ class FavoritePlaceServiceTest {
             );
         }
 
-        @DisplayName("placeIds 개수가 70개를 초과하면 BadRequestException을 발생시킨다")
-        @Test
-        void batchCreate10() {
-            // given
-            Long favoriteFolderId = 1L;
-            Account account = AccountFixture.createUser();
-            List<Long> placeIds = new ArrayList<>();
-            for (long id = 1L; id <= 71L; id++) {
-                placeIds.add(id);
-            }
-
-            // when & then
-            assertThatThrownBy(() -> favoritePlaceService.batchCreate(account, favoriteFolderId, placeIds))
-                    .isInstanceOf(BadRequestException.class)
-                    .hasMessage(ErrorTag.FAVORITE_PLACE_BATCH_SIZE_EXCEEDED.getMessage());
-        }
     }
 
     @DisplayName("특정 폴더의 장소 찜 조회 테스트")

--- a/backend/turip-app/src/test/java/turip/favorite/service/FavoritePlaceServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/favorite/service/FavoritePlaceServiceTest.java
@@ -435,6 +435,23 @@ class FavoritePlaceServiceTest {
                     () -> assertThat(responses.get(2).placeId()).isEqualTo(2L)
             );
         }
+
+        @DisplayName("placeIds 개수가 70개를 초과하면 BadRequestException을 발생시킨다")
+        @Test
+        void batchCreate10() {
+            // given
+            Long favoriteFolderId = 1L;
+            Account account = AccountFixture.createUser();
+            List<Long> placeIds = new ArrayList<>();
+            for (long id = 1L; id <= 71L; id++) {
+                placeIds.add(id);
+            }
+
+            // when & then
+            assertThatThrownBy(() -> favoritePlaceService.batchCreate(account, favoriteFolderId, placeIds))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage(ErrorTag.FAVORITE_PLACE_BATCH_SIZE_EXCEEDED.getMessage());
+        }
     }
 
     @DisplayName("특정 폴더의 장소 찜 조회 테스트")


### PR DESCRIPTION
## Issues
- closed #705 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
- 여러 장소 튜립에 추가하는 API(POST `/api/v1/turips/places/batch`) 구현했습니다.
  - 요청된 placeId 중, 현재 튜립에 존재하지 않는 place만 FavoritePlace로 추가합니다.
  - 추가된 place가 없는 경우, 빈 리스트를 반환하고 event를 발행하지 않도록 했어요.


## 📷 Screenshot

## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 여러 장소를 한 번에 즐겨찾기 폴더에 추가할 수 있습니다.
  - 이미 추가된 장소와 존재하지 않는 장소는 자동으로 건너뜁니다.
  - 요청한 순서대로 즐겨찾기 순서가 저장됩니다.

- **개선 사항**
  - 일괄 추가 요청의 필수값, 장소 수(최대 70개), null 입력을 검증합니다.
  - 잘못된 요청에 더 명확한 오류 응답을 제공합니다.
  - 즐겨찾기 폴더 변경·삭제 시 동시 작업으로 인한 데이터 충돌을 방지합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->