### PR TITLE
[feat] 지역별 관광 인기도 히트맵 및 인기 여행지 Top10 조회 API

### DIFF
--- a/backend/turip-app/src/main/java/turip/infrastructure/client/KoreaTourismApiConstants.java
+++ b/backend/turip-app/src/main/java/turip/infrastructure/client/KoreaTourismApiConstants.java
@@ -1,0 +1,25 @@
+package turip.infrastructure.client;
+
+/**
+ * 한국관광공사 TourAPI 공통 요청 파라미터 상수
+ */
+public final class KoreaTourismApiConstants {
+
+    /**
+     * MobileOS 파라미터 - 호출 OS 구분 (ETC: 기타)
+     */
+    public static final String MOBILE_OS = "ETC";
+
+    /**
+     * MobileApp 파라미터 - 서비스(앱)명
+     */
+    public static final String MOBILE_APP = "Turip";
+
+    /**
+     * _type 파라미터 - 응답 메시지 형식 (json)
+     */
+    public static final String RESPONSE_TYPE = "json";
+
+    private KoreaTourismApiConstants() {
+    }
+}

--- a/backend/turip-app/src/main/java/turip/infrastructure/client/KoreaTourismRelatedSpotClient.java
+++ b/backend/turip-app/src/main/java/turip/infrastructure/client/KoreaTourismRelatedSpotClient.java
@@ -1,5 +1,9 @@
 package turip.infrastructure.client;
 
+import static turip.infrastructure.client.KoreaTourismApiConstants.MOBILE_APP;
+import static turip.infrastructure.client.KoreaTourismApiConstants.MOBILE_OS;
+import static turip.infrastructure.client.KoreaTourismApiConstants.RESPONSE_TYPE;
+
 import java.net.URI;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
@@ -15,9 +19,6 @@ import turip.infrastructure.client.dto.RelatedSpotResult;
 @Component
 public class KoreaTourismRelatedSpotClient {
 
-    private static final String MOBILE_OS = "ETC";
-    private static final String MOBILE_APP = "Turip";
-    private static final String RESPONSE_TYPE = "json";
     private static final int DEFAULT_NUM_OF_ROWS = 30;
     private static final int DEFAULT_PAGE_NO = 1;
     private static final String DEFAULT_BASE_YM = "202606"; // 초기 기준월

--- a/backend/turip-app/src/main/java/turip/infrastructure/client/KoreaTourismVisitorClient.java
+++ b/backend/turip-app/src/main/java/turip/infrastructure/client/KoreaTourismVisitorClient.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
 import turip.infrastructure.client.dto.KoreaTourismVisitorResponse;
 import turip.infrastructure.client.dto.KoreaTourismVisitorResponse.VisitorItem;
 import turip.infrastructure.client.dto.VisitorFetchResult;
@@ -113,8 +114,14 @@ public class KoreaTourismVisitorClient {
                     log.info("방문자 수 최신 완결 월 발견: {}", baseMonth);
                     return Optional.of(baseMonth);
                 }
+            } catch (RestClientResponseException e) {
+                // 응답 오류(4xx/5xx)는 상태코드만 남긴다.
+                log.info("방문자 수 기준월 {} 탐색 실패: status={}",
+                        candidate.format(YEAR_MONTH_FORMATTER), e.getStatusCode());
             } catch (Exception e) {
-                log.info("방문자 수 기준월 {} 탐색 실패: {}", candidate.format(YEAR_MONTH_FORMATTER), e.getMessage());
+                // I/O 오류 등은 메시지에 serviceKey가 담긴 요청 URI가 포함될 수 있어 예외 타입만 남긴다.
+                log.info("방문자 수 기준월 {} 탐색 실패: {}",
+                        candidate.format(YEAR_MONTH_FORMATTER), e.getClass().getSimpleName());
             }
         }
 
@@ -147,8 +154,11 @@ public class KoreaTourismVisitorClient {
                 }
             }
             return VisitorFetchResult.success(collected);
+        } catch (RestClientResponseException e) {
+            log.warn("방문자 수 API 호출 실패: status={}", e.getStatusCode());
+            return VisitorFetchResult.failure();
         } catch (Exception e) {
-            log.warn("방문자 수 API 호출 실패", e);
+            log.warn("방문자 수 API 호출 실패: {}", e.getClass().getSimpleName());
             return VisitorFetchResult.failure();
         }
     }

--- a/backend/turip-app/src/main/java/turip/infrastructure/client/KoreaTourismVisitorClient.java
+++ b/backend/turip-app/src/main/java/turip/infrastructure/client/KoreaTourismVisitorClient.java
@@ -1,0 +1,159 @@
+package turip.infrastructure.client;
+
+import static turip.infrastructure.client.KoreaTourismApiConstants.MOBILE_APP;
+import static turip.infrastructure.client.KoreaTourismApiConstants.MOBILE_OS;
+import static turip.infrastructure.client.KoreaTourismApiConstants.RESPONSE_TYPE;
+
+import java.net.URI;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import turip.infrastructure.client.dto.KoreaTourismVisitorResponse;
+import turip.infrastructure.client.dto.KoreaTourismVisitorResponse.VisitorItem;
+import turip.infrastructure.client.dto.VisitorFetchResult;
+
+/**
+ * 한국관광 데이터랩 지역별 방문자 수 API 클라이언트 - 광역(metco): 시도 단위 방문자 수 (지역 필터 없이 전체 시도 반환) - 기초(locgo): 시군구 단위 방문자 수 (signguCd로 필터)
+ */
+@Slf4j
+@Component
+public class KoreaTourismVisitorClient {
+
+    private static final int DEFAULT_NUM_OF_ROWS = 1000;
+    private static final int MAX_PAGE = 50;
+    private static final int MAX_MONTH_TO_CHECK = 6;
+    private static final DateTimeFormatter YEAR_MONTH_FORMATTER = DateTimeFormatter.ofPattern("yyyyMM");
+    private static final DateTimeFormatter YMD_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private final RestClient restClient;
+    private final String serviceKey;
+    private final String metcoUrl;
+    private final String locgoUrl;
+
+    public KoreaTourismVisitorClient(RestClient baseRestClient,
+                                     @Value("${korea-tourism.api.key}") String serviceKey,
+                                     @Value("${korea-tourism.visitor-api.metco-url}") String metcoUrl,
+                                     @Value("${korea-tourism.visitor-api.locgo-url}") String locgoUrl) {
+        this.restClient = baseRestClient;
+        this.serviceKey = serviceKey;
+        this.metcoUrl = metcoUrl;
+        this.locgoUrl = locgoUrl;
+    }
+
+    /**
+     * 광역(시도) 방문자 수를 조회한다. 지역 필터가 없어 전체 시도가 한 번에 반환된다.
+     */
+    public VisitorFetchResult fetchProvinceVisitors(String startYmd, String endYmd) {
+        return fetchAllPages(pageNo -> URI.create(new StringBuilder(metcoUrl)
+                .append("?serviceKey=").append(serviceKey)
+                .append("&pageNo=").append(pageNo)
+                .append("&numOfRows=").append(DEFAULT_NUM_OF_ROWS)
+                .append("&MobileOS=").append(MOBILE_OS)
+                .append("&MobileApp=").append(MOBILE_APP)
+                .append("&_type=").append(RESPONSE_TYPE)
+                .append("&startYmd=").append(startYmd)
+                .append("&endYmd=").append(endYmd)
+                .toString()));
+    }
+
+    /**
+     * 기초(시군구) 방문자 수를 조회한다. 지역 필터가 없어 전체 시군구가 반환되므로 호출부에서 signguCode로 필터한다.
+     */
+    public VisitorFetchResult fetchCityVisitors(String startYmd, String endYmd) {
+        return fetchAllPages(pageNo -> URI.create(new StringBuilder(locgoUrl)
+                .append("?serviceKey=").append(serviceKey)
+                .append("&pageNo=").append(pageNo)
+                .append("&numOfRows=").append(DEFAULT_NUM_OF_ROWS)
+                .append("&MobileOS=").append(MOBILE_OS)
+                .append("&MobileApp=").append(MOBILE_APP)
+                .append("&_type=").append(RESPONSE_TYPE)
+                .append("&startYmd=").append(startYmd)
+                .append("&endYmd=").append(endYmd)
+                .toString()));
+    }
+
+    /**
+     * 데이터가 존재하는 최신 완결 월을 현재 월부터 역순으로 탐색한다. 방문자 수 데이터는 1~2개월 지연되어 공개되므로 가장 최근 가용 월을 동적으로 찾는다.
+     *
+     * @return 데이터가 존재하는 최신 월 (yyyyMM), 찾지 못하면 Optional.empty()
+     */
+    public Optional<String> findLatestBaseMonth() {
+        YearMonth currentMonth = YearMonth.now();
+
+        for (int i = 0; i < MAX_MONTH_TO_CHECK; i++) {
+            YearMonth candidate = currentMonth.minusMonths(i);
+            String firstDay = candidate.atDay(1).format(YMD_FORMATTER);
+
+            try {
+                URI uri = URI.create(new StringBuilder(metcoUrl)
+                        .append("?serviceKey=").append(serviceKey)
+                        .append("&pageNo=").append(1)
+                        .append("&numOfRows=").append(1)
+                        .append("&MobileOS=").append(MOBILE_OS)
+                        .append("&MobileApp=").append(MOBILE_APP)
+                        .append("&_type=").append(RESPONSE_TYPE)
+                        .append("&startYmd=").append(firstDay)
+                        .append("&endYmd=").append(firstDay)
+                        .toString());
+
+                KoreaTourismVisitorResponse response = restClient.get()
+                        .uri(uri)
+                        .retrieve()
+                        .body(KoreaTourismVisitorResponse.class);
+
+                if (response != null && response.isSuccess() && !response.getVisitorItems().isEmpty()) {
+                    String baseMonth = candidate.format(YEAR_MONTH_FORMATTER);
+                    log.info("방문자 수 최신 완결 월 발견: {}", baseMonth);
+                    return Optional.of(baseMonth);
+                }
+            } catch (Exception e) {
+                log.info("방문자 수 기준월 {} 탐색 실패: {}", candidate.format(YEAR_MONTH_FORMATTER), e.getMessage());
+            }
+        }
+
+        log.warn("방문자 수 최신 완결 월을 찾지 못했습니다.");
+        return Optional.empty();
+    }
+
+    private VisitorFetchResult fetchAllPages(PageUriFactory uriFactory) {
+        List<VisitorItem> collected = new ArrayList<>();
+        try {
+            for (int pageNo = 1; pageNo <= MAX_PAGE; pageNo++) {
+                KoreaTourismVisitorResponse response = restClient.get()
+                        .uri(uriFactory.create(pageNo))
+                        .retrieve()
+                        .body(KoreaTourismVisitorResponse.class);
+
+                if (response == null || !response.isSuccess()) {
+                    log.warn("방문자 수 API 응답 실패: resultCode={}, resultMsg={}",
+                            response == null ? null : response.getResultCode(),
+                            response == null ? null : response.getResultMsg());
+                    return VisitorFetchResult.failure();
+                }
+
+                List<VisitorItem> items = response.getVisitorItems();
+                collected.addAll(items);
+
+                Integer totalCount = response.getTotalCount();
+                if (items.isEmpty() || totalCount == null || collected.size() >= totalCount) {
+                    break;
+                }
+            }
+            return VisitorFetchResult.success(collected);
+        } catch (Exception e) {
+            log.warn("방문자 수 API 호출 실패", e);
+            return VisitorFetchResult.failure();
+        }
+    }
+
+    @FunctionalInterface
+    private interface PageUriFactory {
+        URI create(int pageNo);
+    }
+}

--- a/backend/turip-app/src/main/java/turip/infrastructure/client/KoreaTourismVisitorClient.java
+++ b/backend/turip-app/src/main/java/turip/infrastructure/client/KoreaTourismVisitorClient.java
@@ -84,10 +84,11 @@ public class KoreaTourismVisitorClient {
      * @return 데이터가 존재하는 최신 월 (yyyyMM), 찾지 못하면 Optional.empty()
      */
     public Optional<String> findLatestBaseMonth() {
-        YearMonth currentMonth = YearMonth.now();
+        // 진행 중인 이번 달은 완결되지 않았으므로 지난 달부터 역순 탐색한다.
+        YearMonth lastCompletedMonth = YearMonth.now().minusMonths(1);
 
         for (int i = 0; i < MAX_MONTH_TO_CHECK; i++) {
-            YearMonth candidate = currentMonth.minusMonths(i);
+            YearMonth candidate = lastCompletedMonth.minusMonths(i);
             String firstDay = candidate.atDay(1).format(YMD_FORMATTER);
 
             try {

--- a/backend/turip-app/src/main/java/turip/infrastructure/client/dto/KoreaTourismVisitorResponse.java
+++ b/backend/turip-app/src/main/java/turip/infrastructure/client/dto/KoreaTourismVisitorResponse.java
@@ -1,0 +1,139 @@
+package turip.infrastructure.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import turip.infrastructure.client.dto.deserializer.EmptyStringAsNullDeserializer;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KoreaTourismVisitorResponse {
+
+    @JsonProperty("response")
+    private Response response;
+
+    public List<VisitorItem> getVisitorItems() {
+        if (response == null || response.body == null || response.body.items == null) {
+            return List.of();
+        }
+        return response.body.items.getItemsOrEmpty();
+    }
+
+    public boolean isSuccess() {
+        return response != null
+                && response.header != null
+                && response.header.isSuccess();
+    }
+
+    public String getResultCode() {
+        return response != null && response.header != null ? response.header.resultCode : null;
+    }
+
+    public String getResultMsg() {
+        return response != null && response.header != null ? response.header.resultMsg : null;
+    }
+
+    public Integer getTotalCount() {
+        if (response == null || response.body == null) {
+            return null;
+        }
+        return response.body.totalCount;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Response {
+
+        @JsonProperty("header")
+        private Header header;
+
+        @JsonProperty("body")
+        private Body body;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Header {
+
+        @JsonProperty("resultCode")
+        private String resultCode;
+
+        @JsonProperty("resultMsg")
+        private String resultMsg;
+
+        public boolean isSuccess() {
+            return "0000".equals(resultCode);
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Body {
+
+        @JsonProperty("items")
+        @JsonDeserialize(using = EmptyStringAsNullDeserializer.class)
+        private Items items;
+
+        @JsonProperty("numOfRows")
+        private Integer numOfRows;
+
+        @JsonProperty("pageNo")
+        private Integer pageNo;
+
+        @JsonProperty("totalCount")
+        private Integer totalCount;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Items {
+
+        @JsonProperty("item")
+        private List<VisitorItem> item;
+
+        public List<VisitorItem> getItemsOrEmpty() {
+            return item != null ? item : List.of();
+        }
+    }
+
+    /**
+     * 지역별 방문자 수 항목 (일별) touDivCd - 관광객 구분 코드 (1:현지인, 2:외지인, 3:외국인) touNum   - 관광객 수 (소수점 포함)
+     */
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class VisitorItem {
+
+        @JsonProperty("areaCode")
+        private String areaCode;
+
+        @JsonProperty("areaNm")
+        private String areaName;
+
+        @JsonProperty("signguCode")
+        private String signguCode;
+
+        @JsonProperty("signguNm")
+        private String signguName;
+
+        @JsonProperty("touDivCd")
+        private String touristDivisionCode;
+
+        @JsonProperty("touDivNm")
+        private String touristDivisionName;
+
+        @JsonProperty("touNum")
+        private Double touristCount;
+
+        @JsonProperty("baseYmd")
+        private String baseYmd;
+    }
+}

--- a/backend/turip-app/src/main/java/turip/infrastructure/client/dto/KoreaTourismVisitorResponse.java
+++ b/backend/turip-app/src/main/java/turip/infrastructure/client/dto/KoreaTourismVisitorResponse.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import turip.infrastructure.client.dto.deserializer.EmptyStringAsNullDeserializer;
+import turip.infrastructure.client.dto.deserializer.EmptyStringAsNullVisitorItemsDeserializer;
 
 @Getter
 @NoArgsConstructor
@@ -78,7 +78,7 @@ public class KoreaTourismVisitorResponse {
     public static class Body {
 
         @JsonProperty("items")
-        @JsonDeserialize(using = EmptyStringAsNullDeserializer.class)
+        @JsonDeserialize(using = EmptyStringAsNullVisitorItemsDeserializer.class)
         private Items items;
 
         @JsonProperty("numOfRows")

--- a/backend/turip-app/src/main/java/turip/infrastructure/client/dto/VisitorFetchResult.java
+++ b/backend/turip-app/src/main/java/turip/infrastructure/client/dto/VisitorFetchResult.java
@@ -1,0 +1,17 @@
+package turip.infrastructure.client.dto;
+
+import java.util.List;
+import turip.infrastructure.client.dto.KoreaTourismVisitorResponse.VisitorItem;
+
+public record VisitorFetchResult(
+        boolean isSuccess,
+        List<VisitorItem> items
+) {
+    public static VisitorFetchResult success(List<VisitorItem> items) {
+        return new VisitorFetchResult(true, items);
+    }
+
+    public static VisitorFetchResult failure() {
+        return new VisitorFetchResult(false, List.of());
+    }
+}

--- a/backend/turip-app/src/main/java/turip/infrastructure/client/dto/deserializer/EmptyStringAsNullVisitorItemsDeserializer.java
+++ b/backend/turip-app/src/main/java/turip/infrastructure/client/dto/deserializer/EmptyStringAsNullVisitorItemsDeserializer.java
@@ -1,0 +1,20 @@
+package turip.infrastructure.client.dto.deserializer;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.io.IOException;
+import turip.infrastructure.client.dto.KoreaTourismVisitorResponse.Items;
+
+public class EmptyStringAsNullVisitorItemsDeserializer extends JsonDeserializer<Items> {
+
+    @Override
+    public Items deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+        String value = parser.getText();
+        if (value == null || value.trim().isEmpty()) {
+            return null;
+        }
+
+        return parser.getCodec().readValue(parser, Items.class);
+    }
+}

--- a/backend/turip-app/src/main/java/turip/infrastructure/scheduler/RegionPopularityScheduler.java
+++ b/backend/turip-app/src/main/java/turip/infrastructure/scheduler/RegionPopularityScheduler.java
@@ -1,0 +1,32 @@
+package turip.infrastructure.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import turip.region.service.RegionPopularityService;
+
+/**
+ * 지역별 관광 인기도(방문 인원수) 스냅샷 갱신 스케줄러
+ * 방문자 수 데이터는 월 단위로 공개되므로 매월 1회 갱신한다.
+ * 서버 재기동 등으로 스냅샷이 비어있는 경우는 최초 조회 시점의 지연 로딩(RegionPopularityService)이 커버한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RegionPopularityScheduler {
+
+    private static final String LOG_HEADER = "[한국관광 데이터랩 - 지역 인기도 스케줄러]";
+
+    private final RegionPopularityService regionPopularityService;
+
+    @Scheduled(cron = "0 0 4 1 * *") // 매월 1일 새벽 4시
+    public void refreshMonthly() {
+        log.info("{} 월간 스냅샷 갱신 시작", LOG_HEADER);
+        try {
+            regionPopularityService.refresh();
+        } catch (Exception e) {
+            log.error("{} 스냅샷 갱신 중 예외 발생: {}", LOG_HEADER, e.getMessage(), e);
+        }
+    }
+}

--- a/backend/turip-app/src/main/java/turip/region/controller/RegionPopularityController.java
+++ b/backend/turip-app/src/main/java/turip/region/controller/RegionPopularityController.java
@@ -1,0 +1,42 @@
+package turip.region.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import turip.region.controller.dto.response.PopularDestinationsResponse;
+import turip.region.controller.dto.response.RegionPopularityResponse;
+import turip.region.domain.RegionPopularitySnapshot;
+import turip.region.service.RegionPopularityService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+@Tag(name = "RegionPopularity", description = "지역별 관광 인기도 API")
+public class RegionPopularityController {
+
+    private final RegionPopularityService regionPopularityService;
+
+    @Operation(
+            summary = "지역별 관광 인기도 조회",
+            description = "최근 한 달 기준 전체 시도의 방문 인원수(외지인 + 외국인)를 조회한다. 지원하지 않는 시도도 포함하며, 방문 인원수 내림차순으로 정렬된다."
+    )
+    @GetMapping("/regions/popularity")
+    public ResponseEntity<RegionPopularityResponse> readRegionPopularity() {
+        RegionPopularitySnapshot snapshot = regionPopularityService.getPopularity();
+        return ResponseEntity.ok(RegionPopularityResponse.from(snapshot));
+    }
+
+    @Operation(
+            summary = "최근 한 달 인기 여행지 Top 10 조회",
+            description = "튜립이 지원하는 지역 카테고리 중 최근 한 달 방문 인원수(외지인 + 외국인) 상위 10개를 순위와 함께 조회한다. "
+    )
+    @GetMapping("/regions/popular-destinations")
+    public ResponseEntity<PopularDestinationsResponse> readPopularDestinations() {
+        RegionPopularitySnapshot snapshot = regionPopularityService.getPopularity();
+        return ResponseEntity.ok(PopularDestinationsResponse.from(snapshot));
+    }
+}

--- a/backend/turip-app/src/main/java/turip/region/controller/dto/response/PopularDestinationsResponse.java
+++ b/backend/turip-app/src/main/java/turip/region/controller/dto/response/PopularDestinationsResponse.java
@@ -1,0 +1,46 @@
+package turip.region.controller.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import turip.region.domain.DomesticRegionCategory;
+import turip.region.domain.RegionPopularitySnapshot;
+
+public record PopularDestinationsResponse(
+        @JsonProperty("baseMonth")
+        String baseMonth,
+
+        @JsonProperty("destinations")
+        List<PopularDestination> destinations
+) {
+
+    private static final int TOP_LIMIT = 10;
+
+    public static PopularDestinationsResponse from(RegionPopularitySnapshot snapshot) {
+        List<Map.Entry<DomesticRegionCategory, Long>> ranked = snapshot.categoryCounts().entrySet().stream()
+                .sorted(Map.Entry.<DomesticRegionCategory, Long>comparingByValue().reversed())
+                .limit(TOP_LIMIT)
+                .toList();
+
+        List<PopularDestination> destinations = new ArrayList<>();
+        int rank = 1;
+        for (Map.Entry<DomesticRegionCategory, Long> entry : ranked) {
+            destinations.add(new PopularDestination(rank++, entry.getKey().getDisplayName(), entry.getValue()));
+        }
+
+        return new PopularDestinationsResponse(snapshot.baseMonth(), destinations);
+    }
+
+    public record PopularDestination(
+            @JsonProperty("rank")
+            int rank,
+
+            @JsonProperty("regionCategory")
+            String regionCategory,
+
+            @JsonProperty("visitorCount")
+            long visitorCount
+    ) {
+    }
+}

--- a/backend/turip-app/src/main/java/turip/region/controller/dto/response/RegionPopularityResponse.java
+++ b/backend/turip-app/src/main/java/turip/region/controller/dto/response/RegionPopularityResponse.java
@@ -1,0 +1,41 @@
+package turip.region.controller.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Comparator;
+import java.util.List;
+import turip.region.domain.ProvinceVisitorCount;
+import turip.region.domain.RegionPopularitySnapshot;
+
+public record RegionPopularityResponse(
+        @JsonProperty("baseMonth")
+        String baseMonth,
+
+        @JsonProperty("regions")
+        List<RegionPopularity> regions
+) {
+
+    public static RegionPopularityResponse from(RegionPopularitySnapshot snapshot) {
+        List<RegionPopularity> regions = snapshot.provinceVisitors().stream()
+                .sorted(Comparator.comparingLong(ProvinceVisitorCount::visitorCount).reversed())
+                .map(province -> new RegionPopularity(
+                        province.areaCode(),
+                        province.areaName(),
+                        province.visitorCount()
+                ))
+                .toList();
+
+        return new RegionPopularityResponse(snapshot.baseMonth(), regions);
+    }
+
+    public record RegionPopularity(
+            @JsonProperty("areaCode")
+            int areaCode,
+
+            @JsonProperty("regionName")
+            String regionName,
+
+            @JsonProperty("visitorCount")
+            long visitorCount
+    ) {
+    }
+}

--- a/backend/turip-app/src/main/java/turip/region/domain/ProvinceVisitorCount.java
+++ b/backend/turip-app/src/main/java/turip/region/domain/ProvinceVisitorCount.java
@@ -1,0 +1,16 @@
+package turip.region.domain;
+
+/**
+ * 시도(광역지자체) 단위 방문 인원수 (외지인 + 외국인)
+ * 히트맵용으로 지원 여부와 무관하게 전체 시도를 담는다.
+ *
+ * @param areaCode      법정동 시도 코드 (예: 11 서울, 26 부산)
+ * @param areaName      시도명 (예: 서울특별시) - 방문자 수 API 응답값을 그대로 사용
+ * @param visitorCount  최근 한 달 방문 인원수 (외지인 + 외국인)
+ */
+public record ProvinceVisitorCount(
+        int areaCode,
+        String areaName,
+        long visitorCount
+) {
+}

--- a/backend/turip-app/src/main/java/turip/region/domain/RegionPopularitySnapshot.java
+++ b/backend/turip-app/src/main/java/turip/region/domain/RegionPopularitySnapshot.java
@@ -1,0 +1,32 @@
+package turip.region.domain;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 지역별 관광 인기도(방문 인원수) 스냅샷
+ * 월 단위로 갱신되는 방문자 수 데이터를 메모리에 보관하기 위한 불변 값 객체.
+ *
+ * @param baseMonth         기준월 (yyyyMM), 데이터가 없으면 null
+ * @param provinceVisitors  전체 시도(17개) 방문 인원수 - 히트맵용 (지원/미지원 무관)
+ * @param categoryCounts    지원 지역 카테고리(14개)별 방문 인원수 - 인기 여행지 Top N용
+ */
+public record RegionPopularitySnapshot(
+        String baseMonth,
+        List<ProvinceVisitorCount> provinceVisitors,
+        Map<DomesticRegionCategory, Long> categoryCounts
+) {
+    public RegionPopularitySnapshot {
+        // 방어적 복사로 불변 스냅샷을 보장한다 (발행 이후 내부 상태가 변하지 않도록).
+        provinceVisitors = List.copyOf(provinceVisitors);
+        categoryCounts = Map.copyOf(categoryCounts);
+    }
+
+    public static RegionPopularitySnapshot empty() {
+        return new RegionPopularitySnapshot(null, List.of(), Map.of());
+    }
+
+    public boolean isEmpty() {
+        return baseMonth == null || (provinceVisitors.isEmpty() && categoryCounts.isEmpty());
+    }
+}

--- a/backend/turip-app/src/main/java/turip/region/domain/TourApiAreaCode.java
+++ b/backend/turip-app/src/main/java/turip/region/domain/TourApiAreaCode.java
@@ -16,77 +16,77 @@ public enum TourApiAreaCode {
     /**
      * 서울특별시 areaCode: 11 sigunguCodes: 종로구(11110), 마포구(11440), 중구(11140)
      */
-    SEOUL(11, List.of(11110, 11440, 11140), DomesticRegionCategory.SEOUL),
+    SEOUL(11, List.of(11110, 11440, 11140), DomesticRegionCategory.SEOUL, VisitorQueryLevel.PROVINCE),
 
     /**
      * 인천광역시 areaCode: 28 sigunguCodes: 중구(28110), 강화군(28710), 연수구(28185)
      */
-    INCHEON(28, List.of(28110, 28710, 28185), DomesticRegionCategory.INCHEON),
+    INCHEON(28, List.of(28110, 28710, 28185), DomesticRegionCategory.INCHEON, VisitorQueryLevel.PROVINCE),
 
     /**
      * 대전광역시 areaCode: 30 sigunguCodes: 유성구(30200), 중구(30140), 서구(30170)
      */
-    DAEJEON(30, List.of(30200, 30140, 30170), DomesticRegionCategory.DAEJEON),
+    DAEJEON(30, List.of(30200, 30140, 30170), DomesticRegionCategory.DAEJEON, VisitorQueryLevel.PROVINCE),
 
     /**
      * 부산광역시 areaCode: 26 sigunguCodes: 해운대구(26350), 중구(26110), 부산진구(26230)
      */
-    BUSAN(26, List.of(26350, 26110, 26230), DomesticRegionCategory.BUSAN),
+    BUSAN(26, List.of(26350, 26110, 26230), DomesticRegionCategory.BUSAN, VisitorQueryLevel.PROVINCE),
 
     /**
      * 강원도 > 강릉시 areaCode: 51 sigunguCodes: 강릉시(51150)
      */
-    GANGNEUNG(51, List.of(51150), DomesticRegionCategory.GANGNEUNG),
+    GANGNEUNG(51, List.of(51150), DomesticRegionCategory.GANGNEUNG, VisitorQueryLevel.CITY),
 
     /**
      * 강원도 > 속초시 areaCode: 51 sigunguCodes: 속초시(51210)
      */
-    SOKCHO(51, List.of(51210), DomesticRegionCategory.SOKCHO),
+    SOKCHO(51, List.of(51210), DomesticRegionCategory.SOKCHO, VisitorQueryLevel.CITY),
 
     /**
      * 경상북도 > 경주시 areaCode: 47 sigunguCodes: 경주시(47130)
      */
-    GYEONGJU(47, List.of(47130), DomesticRegionCategory.GYEONGJU),
+    GYEONGJU(47, List.of(47130), DomesticRegionCategory.GYEONGJU, VisitorQueryLevel.CITY),
 
     /**
      * 전북특별자치도 > 전주시 areaCode: 52 sigunguCodes: 전주시 완산구(52111), 전주시 덕진구(52113)
      */
-    JEONJU(52, List.of(52111, 52113), DomesticRegionCategory.JEONJU),
+    JEONJU(52, List.of(52111, 52113), DomesticRegionCategory.JEONJU, VisitorQueryLevel.CITY),
 
     /**
      * 제주특별자치도 areaCode: 50 sigunguCodes: 제주시(50110), 서귀포시(50130)
      */
-    JEJU(50, List.of(50110, 50130), DomesticRegionCategory.JEJU),
+    JEJU(50, List.of(50110, 50130), DomesticRegionCategory.JEJU, VisitorQueryLevel.PROVINCE),
 
     /**
      * 충청남도 > 공주시 areaCode: 44 sigunguCodes: 공주시(44150)
      */
-    GONGJU(44, List.of(44150), DomesticRegionCategory.GONGJU),
+    GONGJU(44, List.of(44150), DomesticRegionCategory.GONGJU, VisitorQueryLevel.CITY),
 
     /**
      * 전라남도 > 여수시 areaCode: 46 sigunguCodes: 여수시(46130)
      */
-    YEOSU(46, List.of(46130), DomesticRegionCategory.YEOSU),
+    YEOSU(46, List.of(46130), DomesticRegionCategory.YEOSU, VisitorQueryLevel.CITY),
 
     /**
      * 경기도 > 수원시 areaCode: 41 sigunguCodes: 장안구(41111), 팔달구(41115), 영통구(41117)
      */
-    SUWON(41, List.of(41111, 41115, 41117), DomesticRegionCategory.SUWON),
+    SUWON(41, List.of(41111, 41115, 41117), DomesticRegionCategory.SUWON, VisitorQueryLevel.CITY),
 
     /**
      * 전북특별자치도 > 군산시 areaCode: 52 sigunguCodes: 군산시(52130)
      */
-    GUNSAN(52, List.of(52130), DomesticRegionCategory.GUNSAN),
+    GUNSAN(52, List.of(52130), DomesticRegionCategory.GUNSAN, VisitorQueryLevel.CITY),
 
     /**
      * 대구광역시 areaCode: 27 sigunguCodes: 중구(27110), 수성구(27260), 달서구(27290)
      */
-    DAEGU(27, List.of(27110, 27260, 27290), DomesticRegionCategory.DAEGU),
+    DAEGU(27, List.of(27110, 27260, 27290), DomesticRegionCategory.DAEGU, VisitorQueryLevel.PROVINCE),
 
     /**
      * 매핑되지 않는 지역 (OTHER_DOMESTIC 등)
      */
-    NOT_FOUND(null, Collections.emptyList(), null);
+    NOT_FOUND(null, Collections.emptyList(), null, null);
 
     /**
      * 한국관광공사 TourAPI의 지역 코드 (시도 단위)
@@ -104,6 +104,11 @@ public enum TourApiAreaCode {
     private final DomesticRegionCategory domesticRegionCategory;
 
     /**
+     * 데이터랩 방문자 수 API 집계 단위 (PROVINCE: 시도 전체, CITY: 시군구) null인 경우 미지원 지역
+     */
+    private final VisitorQueryLevel visitorQueryLevel;
+
+    /**
      * 튜립의 DomesticRegionCategory로부터 TourApiAreaCode를 찾는다
      *
      * @param category 튜립의 국내 지역 카테고리
@@ -115,6 +120,19 @@ public enum TourApiAreaCode {
                 .filter(code -> code.domesticRegionCategory == category)
                 .findFirst()
                 .orElse(NOT_FOUND);
+    }
+
+    /**
+     * 지정한 집계 단위(PROVINCE/CITY)에 해당하는 지원 지역 목록을 반환한다
+     *
+     * @param level 방문자 수 API 집계 단위
+     * @return 해당 집계 단위의 TourApiAreaCode 목록 (NOT_FOUND 제외)
+     */
+    public static List<TourApiAreaCode> findByVisitorQueryLevel(VisitorQueryLevel level) {
+        return Arrays.stream(values())
+                .filter(TourApiAreaCode::isFound)
+                .filter(code -> code.visitorQueryLevel == level)
+                .toList();
     }
 
     public boolean isFound() {

--- a/backend/turip-app/src/main/java/turip/region/domain/VisitorQueryLevel.java
+++ b/backend/turip-app/src/main/java/turip/region/domain/VisitorQueryLevel.java
@@ -1,0 +1,17 @@
+package turip.region.domain;
+
+/**
+ * 한국관광 데이터랩 방문자 수 API의 집계 단위
+ */
+public enum VisitorQueryLevel {
+
+    /**
+     * 광역지자체(시도) 단위 - metcoRegnVisitrDDList, areaCode 기준 집계 예: 서울특별시 전체, 부산광역시 전체
+     */
+    PROVINCE,
+
+    /**
+     * 기초지자체(시군구) 단위 - locgoRegnVisitrDDList, signguCode 기준 집계 예: 강릉시, 수원 팔달구
+     */
+    CITY
+}

--- a/backend/turip-app/src/main/java/turip/region/service/RegionPopularityService.java
+++ b/backend/turip-app/src/main/java/turip/region/service/RegionPopularityService.java
@@ -51,10 +51,22 @@ public class RegionPopularityService {
     public RegionPopularitySnapshot getPopularity() {
         RegionPopularitySnapshot current = snapshot.get();
         if (current.isEmpty()) {
-            refresh();
-            current = snapshot.get();
+            return refreshIfEmpty();
         }
         return current;
+    }
+
+    /**
+     * 지연 로딩 경로. 락 획득 후 스냅샷이 여전히 비어있을 때만 갱신한다.
+     * 대기하는 동안 앞선 스레드가 이미 채웠다면 중복 갱신(무거운 API 호출)을 피한다.
+     * (스케줄러의 월간 강제 갱신은 refresh()를 직접 호출한다.)
+     */
+    private synchronized RegionPopularitySnapshot refreshIfEmpty() {
+        if (!snapshot.get().isEmpty()) {
+            return snapshot.get();
+        }
+        refresh();
+        return snapshot.get();
     }
 
     /**

--- a/backend/turip-app/src/main/java/turip/region/service/RegionPopularityService.java
+++ b/backend/turip-app/src/main/java/turip/region/service/RegionPopularityService.java
@@ -72,10 +72,19 @@ public class RegionPopularityService {
         String startYmd = yearMonth.atDay(1).format(YMD_FORMATTER);
         String endYmd = yearMonth.atEndOfMonth().format(YMD_FORMATTER);
 
-        List<ProvinceVisitorCount> provinceVisitors = fetchProvinceVisitors(startYmd, endYmd);
+        // 광역/기초 중 하나라도 실패하면 부분 데이터로 스냅샷을 덮어쓰지 않고 기존 스냅샷을 유지한다.
+        VisitorFetchResult provinceResult = visitorClient.fetchProvinceVisitors(startYmd, endYmd);
+        VisitorFetchResult cityResult = visitorClient.fetchCityVisitors(startYmd, endYmd);
+        if (!provinceResult.isSuccess() || !cityResult.isSuccess()) {
+            log.warn("방문자 수 조회 실패로 인기도 스냅샷을 유지합니다. baseMonth={}, provinceSuccess={}, citySuccess={}",
+                    baseMonth, provinceResult.isSuccess(), cityResult.isSuccess());
+            return;
+        }
+
+        List<ProvinceVisitorCount> provinceVisitors = aggregateProvinceVisitors(provinceResult.items());
         Map<DomesticRegionCategory, Long> categoryCounts = new EnumMap<>(DomesticRegionCategory.class);
         putProvinceCategoryCounts(categoryCounts, provinceVisitors);
-        putCityCategoryCounts(categoryCounts, startYmd, endYmd);
+        putCityCategoryCounts(categoryCounts, cityResult.items());
 
         if (provinceVisitors.isEmpty() && categoryCounts.isEmpty()) {
             log.warn("방문자 수 집계 결과가 비어 인기도 스냅샷을 유지합니다. baseMonth={}", baseMonth);
@@ -88,17 +97,11 @@ public class RegionPopularityService {
     }
 
     /**
-     * 광역(metco)에서 전체 시도의 방문 인원수를 시도별로 집계한다.
+     * 광역(metco) 응답 항목을 전체 시도의 방문 인원수로 시도별 집계한다.
      */
-    private List<ProvinceVisitorCount> fetchProvinceVisitors(String startYmd, String endYmd) {
-        VisitorFetchResult result = visitorClient.fetchProvinceVisitors(startYmd, endYmd);
-        if (!result.isSuccess()) {
-            log.warn("광역 방문자 수 조회 실패. 시도 히트맵 데이터를 이번 갱신에서 제외합니다.");
-            return List.of();
-        }
-
+    private List<ProvinceVisitorCount> aggregateProvinceVisitors(List<VisitorItem> items) {
         // areaCode 기준으로 그룹화 (숫자 코드만), 순서 유지
-        Map<String, List<VisitorItem>> groupedByArea = result.items().stream()
+        Map<String, List<VisitorItem>> groupedByArea = items.stream()
                 .filter(item -> item.getAreaCode() != null && item.getAreaCode().chars().allMatch(Character::isDigit))
                 .collect(Collectors.groupingBy(VisitorItem::getAreaCode, LinkedHashMap::new, Collectors.toList()));
 
@@ -132,20 +135,14 @@ public class RegionPopularityService {
     }
 
     /**
-     * 기초(locgo)에서 지원하는 시 카테고리(강릉 등)의 방문자 수를 signguCode로 필터해 채운다.
+     * 기초(locgo) 응답 항목에서 지원하는 시 카테고리(강릉 등)의 방문자 수를 signguCode로 필터해 채운다.
      */
-    private void putCityCategoryCounts(Map<DomesticRegionCategory, Long> counts, String startYmd, String endYmd) {
-        VisitorFetchResult result = visitorClient.fetchCityVisitors(startYmd, endYmd);
-        if (!result.isSuccess()) {
-            log.warn("기초 방문자 수 조회 실패. 시 단위 지역을 이번 갱신에서 제외합니다.");
-            return;
-        }
-
+    private void putCityCategoryCounts(Map<DomesticRegionCategory, Long> counts, List<VisitorItem> cityItems) {
         for (TourApiAreaCode areaCode : TourApiAreaCode.findByVisitorQueryLevel(VisitorQueryLevel.CITY)) {
             Set<String> targetSignguCodes = areaCode.getSigunguCodes().stream()
                     .map(String::valueOf)
                     .collect(Collectors.toSet());
-            List<VisitorItem> items = result.items().stream()
+            List<VisitorItem> items = cityItems.stream()
                     .filter(item -> targetSignguCodes.contains(item.getSignguCode()))
                     .toList();
             counts.put(areaCode.getDomesticRegionCategory(), sumTouristCounts(items));

--- a/backend/turip-app/src/main/java/turip/region/service/RegionPopularityService.java
+++ b/backend/turip-app/src/main/java/turip/region/service/RegionPopularityService.java
@@ -1,0 +1,163 @@
+package turip.region.service;
+
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import turip.infrastructure.client.KoreaTourismVisitorClient;
+import turip.infrastructure.client.dto.KoreaTourismVisitorResponse.VisitorItem;
+import turip.infrastructure.client.dto.VisitorFetchResult;
+import turip.region.domain.DomesticRegionCategory;
+import turip.region.domain.ProvinceVisitorCount;
+import turip.region.domain.RegionPopularitySnapshot;
+import turip.region.domain.TourApiAreaCode;
+import turip.region.domain.VisitorQueryLevel;
+
+/**
+ * 지역별 관광 인기도(방문 인원수) 조회/캐싱 서비스
+ * 방문자 수 API(광역/기초)를 호출해 두 가지를 집계하고 불변 스냅샷으로 보관한다.
+ * - 전체 시도(17개) 방문 인원수: 히트맵용 (지원/미지원 무관, 광역 metco)
+ * - 지원 지역 카테고리(14개)별 방문 인원수: 인기 여행지 Top N용 (시도는 metco, 시는 기초 locgo)
+ * 스냅샷은 스케줄러가 월 1회 갱신하며, 비어있으면 지연 로딩한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RegionPopularityService {
+
+    // 관광객 구분 코드 - 2: 외지인, 3: 외국인 (1: 현지인은 제외)
+    private static final Set<String> TOURIST_DIVISION_CODES = Set.of("2", "3");
+    private static final DateTimeFormatter YEAR_MONTH_FORMATTER = DateTimeFormatter.ofPattern("yyyyMM");
+    private static final DateTimeFormatter YMD_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private final KoreaTourismVisitorClient visitorClient;
+
+    private final AtomicReference<RegionPopularitySnapshot> snapshot =
+            new AtomicReference<>(RegionPopularitySnapshot.empty());
+
+    /**
+     * 캐시된 인기도 스냅샷을 반환한다. 스냅샷이 비어있으면 동기적으로 한 번 갱신한다.
+     */
+    public RegionPopularitySnapshot getPopularity() {
+        RegionPopularitySnapshot current = snapshot.get();
+        if (current.isEmpty()) {
+            refresh();
+            current = snapshot.get();
+        }
+        return current;
+    }
+
+    /**
+     * 방문자 수 API를 호출해 스냅샷을 갱신한다. 갱신에 실패하면 기존 스냅샷을 유지한다.
+     */
+    public synchronized void refresh() {
+        Optional<String> latestBaseMonth = visitorClient.findLatestBaseMonth();
+        if (latestBaseMonth.isEmpty()) {
+            log.warn("방문자 수 기준월을 찾지 못해 인기도 스냅샷 갱신을 건너뜁니다.");
+            return;
+        }
+        String baseMonth = latestBaseMonth.get();
+
+        YearMonth yearMonth = YearMonth.parse(baseMonth, YEAR_MONTH_FORMATTER);
+        String startYmd = yearMonth.atDay(1).format(YMD_FORMATTER);
+        String endYmd = yearMonth.atEndOfMonth().format(YMD_FORMATTER);
+
+        List<ProvinceVisitorCount> provinceVisitors = fetchProvinceVisitors(startYmd, endYmd);
+        Map<DomesticRegionCategory, Long> categoryCounts = new EnumMap<>(DomesticRegionCategory.class);
+        putProvinceCategoryCounts(categoryCounts, provinceVisitors);
+        putCityCategoryCounts(categoryCounts, startYmd, endYmd);
+
+        if (provinceVisitors.isEmpty() && categoryCounts.isEmpty()) {
+            log.warn("방문자 수 집계 결과가 비어 인기도 스냅샷을 유지합니다. baseMonth={}", baseMonth);
+            return;
+        }
+
+        snapshot.set(new RegionPopularitySnapshot(baseMonth, provinceVisitors, categoryCounts));
+        log.info("지역 인기도 스냅샷 갱신 완료. baseMonth={}, 시도 수={}, 지원 지역 수={}",
+                baseMonth, provinceVisitors.size(), categoryCounts.size());
+    }
+
+    /**
+     * 광역(metco)에서 전체 시도의 방문 인원수를 시도별로 집계한다.
+     */
+    private List<ProvinceVisitorCount> fetchProvinceVisitors(String startYmd, String endYmd) {
+        VisitorFetchResult result = visitorClient.fetchProvinceVisitors(startYmd, endYmd);
+        if (!result.isSuccess()) {
+            log.warn("광역 방문자 수 조회 실패. 시도 히트맵 데이터를 이번 갱신에서 제외합니다.");
+            return List.of();
+        }
+
+        // areaCode 기준으로 그룹화 (숫자 코드만), 순서 유지
+        Map<String, List<VisitorItem>> groupedByArea = result.items().stream()
+                .filter(item -> item.getAreaCode() != null && item.getAreaCode().chars().allMatch(Character::isDigit))
+                .collect(Collectors.groupingBy(VisitorItem::getAreaCode, LinkedHashMap::new, Collectors.toList()));
+
+        List<ProvinceVisitorCount> provinceVisitors = new ArrayList<>();
+        for (Map.Entry<String, List<VisitorItem>> entry : groupedByArea.entrySet()) {
+            int areaCode = Integer.parseInt(entry.getKey());
+            String areaName = entry.getValue().get(0).getAreaName();
+            long count = sumTouristCounts(entry.getValue());
+            provinceVisitors.add(new ProvinceVisitorCount(areaCode, areaName, count));
+        }
+        return provinceVisitors;
+    }
+
+    /**
+     * 시도 전체 방문자 수에서 지원하는 시도 카테고리(서울·부산 등)의 값을 채운다.
+     */
+    private void putProvinceCategoryCounts(
+            Map<DomesticRegionCategory, Long> counts,
+            List<ProvinceVisitorCount> provinceVisitors
+    ) {
+        if (provinceVisitors.isEmpty()) {
+            return;
+        }
+        Map<Integer, Long> countByAreaCode = provinceVisitors.stream()
+                .collect(Collectors.toMap(ProvinceVisitorCount::areaCode, ProvinceVisitorCount::visitorCount));
+
+        for (TourApiAreaCode areaCode : TourApiAreaCode.findByVisitorQueryLevel(VisitorQueryLevel.PROVINCE)) {
+            long count = countByAreaCode.getOrDefault(areaCode.getAreaCode(), 0L);
+            counts.put(areaCode.getDomesticRegionCategory(), count);
+        }
+    }
+
+    /**
+     * 기초(locgo)에서 지원하는 시 카테고리(강릉 등)의 방문자 수를 signguCode로 필터해 채운다.
+     */
+    private void putCityCategoryCounts(Map<DomesticRegionCategory, Long> counts, String startYmd, String endYmd) {
+        VisitorFetchResult result = visitorClient.fetchCityVisitors(startYmd, endYmd);
+        if (!result.isSuccess()) {
+            log.warn("기초 방문자 수 조회 실패. 시 단위 지역을 이번 갱신에서 제외합니다.");
+            return;
+        }
+
+        for (TourApiAreaCode areaCode : TourApiAreaCode.findByVisitorQueryLevel(VisitorQueryLevel.CITY)) {
+            Set<String> targetSignguCodes = areaCode.getSigunguCodes().stream()
+                    .map(String::valueOf)
+                    .collect(Collectors.toSet());
+            List<VisitorItem> items = result.items().stream()
+                    .filter(item -> targetSignguCodes.contains(item.getSignguCode()))
+                    .toList();
+            counts.put(areaCode.getDomesticRegionCategory(), sumTouristCounts(items));
+        }
+    }
+
+    private long sumTouristCounts(List<VisitorItem> items) {
+        double sum = items.stream()
+                .filter(item -> item.getTouristDivisionCode() != null
+                        && TOURIST_DIVISION_CODES.contains(item.getTouristDivisionCode()))
+                .mapToDouble(item -> item.getTouristCount() == null ? 0.0 : item.getTouristCount())
+                .sum();
+        return Math.round(sum);
+    }
+}

--- a/backend/turip-app/src/main/java/turip/region/service/RegionPopularityService.java
+++ b/backend/turip-app/src/main/java/turip/region/service/RegionPopularityService.java
@@ -39,11 +39,14 @@ public class RegionPopularityService {
     private static final Set<String> TOURIST_DIVISION_CODES = Set.of("2", "3");
     private static final DateTimeFormatter YEAR_MONTH_FORMATTER = DateTimeFormatter.ofPattern("yyyyMM");
     private static final DateTimeFormatter YMD_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+    // 빈 스냅샷 상태에서 갱신이 실패하면 이 간격 동안은 지연 로딩 갱신을 재시도하지 않는다.
+    private static final long LAZY_REFRESH_RETRY_INTERVAL_MILLIS = 60_000L;
 
     private final KoreaTourismVisitorClient visitorClient;
 
     private final AtomicReference<RegionPopularitySnapshot> snapshot =
             new AtomicReference<>(RegionPopularitySnapshot.empty());
+    private volatile long lastRefreshFailedAtMillis = 0L;
 
     /**
      * 캐시된 인기도 스냅샷을 반환한다. 스냅샷이 비어있으면 동기적으로 한 번 갱신한다.
@@ -59,24 +62,38 @@ public class RegionPopularityService {
     /**
      * 지연 로딩 경로. 락 획득 후 스냅샷이 여전히 비어있을 때만 갱신한다.
      * 대기하는 동안 앞선 스레드가 이미 채웠다면 중복 갱신(무거운 API 호출)을 피한다.
+     * 외부 API 장애로 최근 갱신이 실패했다면 재시도 간격 전까지는 빈 스냅샷을 즉시 반환해
+     * 요청마다 실패하는 API를 직렬로 호출하는 것을 막는다.
      * (스케줄러의 월간 강제 갱신은 refresh()를 직접 호출한다.)
      */
     private synchronized RegionPopularitySnapshot refreshIfEmpty() {
-        if (!snapshot.get().isEmpty()) {
-            return snapshot.get();
+        RegionPopularitySnapshot current = snapshot.get();
+        if (!current.isEmpty()) {
+            return current;
+        }
+        if (System.currentTimeMillis() - lastRefreshFailedAtMillis < LAZY_REFRESH_RETRY_INTERVAL_MILLIS) {
+            return current;
         }
         refresh();
         return snapshot.get();
     }
 
     /**
-     * 방문자 수 API를 호출해 스냅샷을 갱신한다. 갱신에 실패하면 기존 스냅샷을 유지한다.
+     * 방문자 수 API를 호출해 스냅샷을 갱신한다. 갱신에 실패하면 기존 스냅샷을 유지하고 실패 시각을 기록한다.
      */
     public synchronized void refresh() {
+        if (updateSnapshot()) {
+            lastRefreshFailedAtMillis = 0L;
+        } else {
+            lastRefreshFailedAtMillis = System.currentTimeMillis();
+        }
+    }
+
+    private boolean updateSnapshot() {
         Optional<String> latestBaseMonth = visitorClient.findLatestBaseMonth();
         if (latestBaseMonth.isEmpty()) {
             log.warn("방문자 수 기준월을 찾지 못해 인기도 스냅샷 갱신을 건너뜁니다.");
-            return;
+            return false;
         }
         String baseMonth = latestBaseMonth.get();
 
@@ -90,7 +107,7 @@ public class RegionPopularityService {
         if (!provinceResult.isSuccess() || !cityResult.isSuccess()) {
             log.warn("방문자 수 조회 실패로 인기도 스냅샷을 유지합니다. baseMonth={}, provinceSuccess={}, citySuccess={}",
                     baseMonth, provinceResult.isSuccess(), cityResult.isSuccess());
-            return;
+            return false;
         }
 
         List<ProvinceVisitorCount> provinceVisitors = aggregateProvinceVisitors(provinceResult.items());
@@ -100,12 +117,13 @@ public class RegionPopularityService {
 
         if (provinceVisitors.isEmpty() && categoryCounts.isEmpty()) {
             log.warn("방문자 수 집계 결과가 비어 인기도 스냅샷을 유지합니다. baseMonth={}", baseMonth);
-            return;
+            return false;
         }
 
         snapshot.set(new RegionPopularitySnapshot(baseMonth, provinceVisitors, categoryCounts));
         log.info("지역 인기도 스냅샷 갱신 완료. baseMonth={}, 시도 수={}, 지원 지역 수={}",
                 baseMonth, provinceVisitors.size(), categoryCounts.size());
+        return true;
     }
 
     /**

--- a/backend/turip-app/src/main/resources/application.yml
+++ b/backend/turip-app/src/main/resources/application.yml
@@ -63,6 +63,9 @@ korea-tourism:
   api:
     key: ${KOREA_TOURISM_API_KEY}
     url: https://apis.data.go.kr/B551011/TarRlteTarService1/areaBasedList1
+  visitor-api:
+    metco-url: https://apis.data.go.kr/B551011/DataLabService/metcoRegnVisitrDDList
+    locgo-url: https://apis.data.go.kr/B551011/DataLabService/locgoRegnVisitrDDList
 
 apple:
   client-id: ${APPLE_CLIENT_ID}

--- a/backend/turip-app/src/test/java/turip/region/controller/dto/response/PopularDestinationsResponseTest.java
+++ b/backend/turip-app/src/test/java/turip/region/controller/dto/response/PopularDestinationsResponseTest.java
@@ -1,0 +1,51 @@
+package turip.region.controller.dto.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import turip.region.controller.dto.response.PopularDestinationsResponse.PopularDestination;
+import turip.region.domain.DomesticRegionCategory;
+import turip.region.domain.RegionPopularitySnapshot;
+
+class PopularDestinationsResponseTest {
+
+    @DisplayName("방문 인원수 상위 10개만 순위와 함께 내림차순으로 내려준다")
+    @Test
+    void ranksTop10Descending() {
+        // given - 11개 카테고리 중 가장 낮은 공주(50)는 Top10에서 제외되어야 한다
+        Map<DomesticRegionCategory, Long> counts = new EnumMap<>(DomesticRegionCategory.class);
+        counts.put(DomesticRegionCategory.SEOUL, 1000L);
+        counts.put(DomesticRegionCategory.BUSAN, 900L);
+        counts.put(DomesticRegionCategory.JEJU, 800L);
+        counts.put(DomesticRegionCategory.INCHEON, 700L);
+        counts.put(DomesticRegionCategory.DAEGU, 600L);
+        counts.put(DomesticRegionCategory.DAEJEON, 500L);
+        counts.put(DomesticRegionCategory.GYEONGJU, 400L);
+        counts.put(DomesticRegionCategory.GANGNEUNG, 300L);
+        counts.put(DomesticRegionCategory.JEONJU, 200L);
+        counts.put(DomesticRegionCategory.SUWON, 100L);
+        counts.put(DomesticRegionCategory.GONGJU, 50L);
+        RegionPopularitySnapshot snapshot = new RegionPopularitySnapshot("202506", List.of(), counts);
+
+        // when
+        PopularDestinationsResponse response = PopularDestinationsResponse.from(snapshot);
+
+        // then
+        List<PopularDestination> destinations = response.destinations();
+        assertAll(
+                () -> assertThat(destinations).hasSize(10),
+                () -> assertThat(destinations.get(0).rank()).isEqualTo(1),
+                () -> assertThat(destinations.get(0).regionCategory()).isEqualTo("서울"),
+                () -> assertThat(destinations.get(0).visitorCount()).isEqualTo(1000L),
+                () -> assertThat(destinations.get(9).rank()).isEqualTo(10),
+                () -> assertThat(destinations.get(9).regionCategory()).isEqualTo("수원"),
+                () -> assertThat(destinations).extracting(PopularDestination::regionCategory)
+                        .doesNotContain("공주")  // 11위는 제외
+        );
+    }
+}

--- a/backend/turip-app/src/test/java/turip/region/controller/dto/response/RegionPopularityResponseTest.java
+++ b/backend/turip-app/src/test/java/turip/region/controller/dto/response/RegionPopularityResponseTest.java
@@ -1,0 +1,42 @@
+package turip.region.controller.dto.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import turip.region.controller.dto.response.RegionPopularityResponse.RegionPopularity;
+import turip.region.domain.ProvinceVisitorCount;
+import turip.region.domain.RegionPopularitySnapshot;
+
+class RegionPopularityResponseTest {
+
+    @DisplayName("전체 시도를 방문 인원수 내림차순으로 정렬한다 (미지원 시도 포함)")
+    @Test
+    void sortsAllProvincesDescending() {
+        // given - 경기도(41)는 미지원 시도지만 히트맵에는 포함된다
+        RegionPopularitySnapshot snapshot = new RegionPopularitySnapshot(
+                "202506",
+                List.of(
+                        new ProvinceVisitorCount(11, "서울특별시", 50L),
+                        new ProvinceVisitorCount(41, "경기도", 1000L),
+                        new ProvinceVisitorCount(26, "부산광역시", 15L)
+                ),
+                Map.of()
+        );
+
+        // when
+        RegionPopularityResponse response = RegionPopularityResponse.from(snapshot);
+
+        // then
+        List<RegionPopularity> regions = response.regions();
+        assertAll(
+                () -> assertThat(regions).extracting(RegionPopularity::regionName)
+                        .containsExactly("경기도", "서울특별시", "부산광역시"),  // 내림차순
+                () -> assertThat(regions.get(0).areaCode()).isEqualTo(41),
+                () -> assertThat(regions.get(0).visitorCount()).isEqualTo(1000L)
+        );
+    }
+}

--- a/backend/turip-app/src/test/java/turip/region/domain/TourApiAreaCodeTest.java
+++ b/backend/turip-app/src/test/java/turip/region/domain/TourApiAreaCodeTest.java
@@ -1,0 +1,58 @@
+package turip.region.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TourApiAreaCodeTest {
+
+    @DisplayName("PROVINCE 집계 단위 지역은 시도 전체 카테고리만 반환한다")
+    @Test
+    void findByVisitorQueryLevelProvince() {
+        // when
+        List<TourApiAreaCode> provinces = TourApiAreaCode.findByVisitorQueryLevel(VisitorQueryLevel.PROVINCE);
+
+        // then
+        assertThat(provinces).containsExactlyInAnyOrder(
+                TourApiAreaCode.SEOUL,
+                TourApiAreaCode.INCHEON,
+                TourApiAreaCode.DAEJEON,
+                TourApiAreaCode.BUSAN,
+                TourApiAreaCode.JEJU,
+                TourApiAreaCode.DAEGU
+        );
+    }
+
+    @DisplayName("CITY 집계 단위 지역은 특정 시군구 카테고리만 반환한다")
+    @Test
+    void findByVisitorQueryLevelCity() {
+        // when
+        List<TourApiAreaCode> cities = TourApiAreaCode.findByVisitorQueryLevel(VisitorQueryLevel.CITY);
+
+        // then
+        assertThat(cities).containsExactlyInAnyOrder(
+                TourApiAreaCode.GANGNEUNG,
+                TourApiAreaCode.SOKCHO,
+                TourApiAreaCode.GYEONGJU,
+                TourApiAreaCode.JEONJU,
+                TourApiAreaCode.GONGJU,
+                TourApiAreaCode.YEOSU,
+                TourApiAreaCode.SUWON,
+                TourApiAreaCode.GUNSAN
+        );
+    }
+
+    @DisplayName("집계 단위 조회 결과에는 NOT_FOUND가 포함되지 않는다")
+    @Test
+    void findByVisitorQueryLevelExcludesNotFound() {
+        // when
+        List<TourApiAreaCode> provinces = TourApiAreaCode.findByVisitorQueryLevel(VisitorQueryLevel.PROVINCE);
+        List<TourApiAreaCode> cities = TourApiAreaCode.findByVisitorQueryLevel(VisitorQueryLevel.CITY);
+
+        // then
+        assertThat(provinces).doesNotContain(TourApiAreaCode.NOT_FOUND);
+        assertThat(cities).doesNotContain(TourApiAreaCode.NOT_FOUND);
+    }
+}

--- a/backend/turip-app/src/test/java/turip/region/service/RegionPopularityServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/region/service/RegionPopularityServiceTest.java
@@ -1,0 +1,154 @@
+package turip.region.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import turip.infrastructure.client.KoreaTourismVisitorClient;
+import turip.infrastructure.client.dto.KoreaTourismVisitorResponse.VisitorItem;
+import turip.infrastructure.client.dto.VisitorFetchResult;
+import turip.region.domain.DomesticRegionCategory;
+import turip.region.domain.ProvinceVisitorCount;
+import turip.region.domain.RegionPopularitySnapshot;
+
+@ExtendWith(MockitoExtension.class)
+class RegionPopularityServiceTest {
+
+    @InjectMocks
+    private RegionPopularityService regionPopularityService;
+
+    @Mock
+    private KoreaTourismVisitorClient visitorClient;
+
+    @DisplayName("전체 시도를 집계하되 미지원 시도도 포함하고, 외지인·외국인만 합산한다")
+    @Test
+    void aggregatesAllProvincesIncludingUnsupported() {
+        // given
+        List<VisitorItem> provinceItems = List.of(
+                provinceItem("11", "서울특별시", "1", 100.0),  // 현지인 - 제외
+                provinceItem("11", "서울특별시", "2", 30.0),
+                provinceItem("11", "서울특별시", "3", 20.0),
+                provinceItem("26", "부산광역시", "2", 10.5),
+                provinceItem("26", "부산광역시", "3", 4.5),
+                provinceItem("41", "경기도", "2", 1000.0)      // 미지원 시도
+        );
+        given(visitorClient.findLatestBaseMonth()).willReturn(Optional.of("202506"));
+        given(visitorClient.fetchProvinceVisitors(any(), any()))
+                .willReturn(VisitorFetchResult.success(provinceItems));
+        given(visitorClient.fetchCityVisitors(any(), any()))
+                .willReturn(VisitorFetchResult.success(List.of()));
+
+        // when
+        RegionPopularitySnapshot snapshot = regionPopularityService.getPopularity();
+
+        // then
+        assertAll(
+                () -> assertThat(snapshot.provinceVisitors()).hasSize(3),
+                () -> assertThat(countOfArea(snapshot, 11)).isEqualTo(50L),
+                () -> assertThat(countOfArea(snapshot, 26)).isEqualTo(15L),
+                () -> assertThat(countOfArea(snapshot, 41)).isEqualTo(1000L),  // 미지원도 포함
+                () -> assertThat(snapshot.categoryCounts().get(DomesticRegionCategory.SEOUL)).isEqualTo(50L),
+                () -> assertThat(snapshot.categoryCounts().get(DomesticRegionCategory.BUSAN)).isEqualTo(15L)
+        );
+    }
+
+    @DisplayName("시 카테고리는 자신의 시군구 코드로만 필터해 합산한다")
+    @Test
+    void aggregatesCityBySignguCodesOnly() {
+        // given
+        List<VisitorItem> cityItems = List.of(
+                cityItem("51150", "2", 5.0),   // 강릉시
+                cityItem("52111", "2", 5.0),   // 전주 완산구
+                cityItem("52113", "2", 5.0),   // 전주 덕진구
+                cityItem("41111", "2", 5.0),   // 수원 장안구
+                cityItem("41115", "2", 5.0),   // 수원 팔달구
+                cityItem("41117", "2", 5.0),   // 수원 영통구
+                cityItem("11110", "2", 999.0)  // 종로구 - 어떤 지원 카테고리에도 없음
+        );
+        given(visitorClient.findLatestBaseMonth()).willReturn(Optional.of("202506"));
+        given(visitorClient.fetchProvinceVisitors(any(), any()))
+                .willReturn(VisitorFetchResult.success(List.of()));
+        given(visitorClient.fetchCityVisitors(any(), any()))
+                .willReturn(VisitorFetchResult.success(cityItems));
+
+        // when
+        RegionPopularitySnapshot snapshot = regionPopularityService.getPopularity();
+
+        // then
+        assertAll(
+                () -> assertThat(snapshot.categoryCounts().get(DomesticRegionCategory.GANGNEUNG)).isEqualTo(5L),
+                () -> assertThat(snapshot.categoryCounts().get(DomesticRegionCategory.JEONJU)).isEqualTo(10L),
+                () -> assertThat(snapshot.categoryCounts().get(DomesticRegionCategory.SUWON)).isEqualTo(15L)
+        );
+    }
+
+    @DisplayName("광역 조회가 실패하면 시도 히트맵과 시도 카테고리는 제외하고 시 카테고리만 집계한다")
+    @Test
+    void skipsProvinceWhenProvinceFetchFails() {
+        // given
+        List<VisitorItem> cityItems = List.of(cityItem("51150", "2", 5.0));
+        given(visitorClient.findLatestBaseMonth()).willReturn(Optional.of("202506"));
+        given(visitorClient.fetchProvinceVisitors(any(), any())).willReturn(VisitorFetchResult.failure());
+        given(visitorClient.fetchCityVisitors(any(), any()))
+                .willReturn(VisitorFetchResult.success(cityItems));
+
+        // when
+        RegionPopularitySnapshot snapshot = regionPopularityService.getPopularity();
+
+        // then
+        assertAll(
+                () -> assertThat(snapshot.provinceVisitors()).isEmpty(),
+                () -> assertThat(snapshot.categoryCounts()).doesNotContainKey(DomesticRegionCategory.SEOUL),
+                () -> assertThat(snapshot.categoryCounts().get(DomesticRegionCategory.GANGNEUNG)).isEqualTo(5L)
+        );
+    }
+
+    @DisplayName("기준월을 찾지 못하면 스냅샷은 비어 있다")
+    @Test
+    void keepsEmptySnapshotWhenNoBaseMonth() {
+        // given
+        given(visitorClient.findLatestBaseMonth()).willReturn(Optional.empty());
+
+        // when
+        RegionPopularitySnapshot snapshot = regionPopularityService.getPopularity();
+
+        // then
+        assertThat(snapshot.isEmpty()).isTrue();
+    }
+
+    private long countOfArea(RegionPopularitySnapshot snapshot, int areaCode) {
+        return snapshot.provinceVisitors().stream()
+                .filter(province -> province.areaCode() == areaCode)
+                .mapToLong(ProvinceVisitorCount::visitorCount)
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private VisitorItem provinceItem(String areaCode, String areaName, String touDivCd, double touNum) {
+        VisitorItem item = mock(VisitorItem.class);
+        lenient().when(item.getAreaCode()).thenReturn(areaCode);
+        lenient().when(item.getAreaName()).thenReturn(areaName);
+        lenient().when(item.getTouristDivisionCode()).thenReturn(touDivCd);
+        lenient().when(item.getTouristCount()).thenReturn(touNum);
+        return item;
+    }
+
+    private VisitorItem cityItem(String signguCode, String touDivCd, double touNum) {
+        VisitorItem item = mock(VisitorItem.class);
+        lenient().when(item.getSignguCode()).thenReturn(signguCode);
+        lenient().when(item.getTouristDivisionCode()).thenReturn(touDivCd);
+        lenient().when(item.getTouristCount()).thenReturn(touNum);
+        return item;
+    }
+}


### PR DESCRIPTION
## Issues
- closed #708

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description

### 한국관광 데이터랩 방문자 수 API 연동

- `KoreaTourismVisitorClient`: 광역(metco) / 기초(locgo) 방문자 수 조회 클라이언트
  - metco/locgo 모두 지역 필터 파라미터가 없어 전체(17시도 / 전국 시군구)를 페이지네이션으로 수집한 뒤, 호출부에서 areaCode·signguCode로 필터합니다.
  - 방문 인원수는 **외지인(touDivCd=2) + 외국인(3)** 합산이고, 현지인(1)은 제외했어요.
  - 방문자 수 데이터는 1~2개월 지연 공개돼서, `findLatestBaseMonth()`로 **데이터가 존재하는 최신 완결 월**을 역순 탐색해 동적으로 사용합니다.
  - HTTP 에러 / 응답 실패 시 빈 결과를 반환합니다(부분 실패 허용).
- `TourApiAreaCode`: 지역별 집계 단위(`VisitorQueryLevel` PROVINCE/CITY)를 추가했어요. 시도는 areaCode, 시는 signguCode 기준으로 집계합니다.

### 스냅샷 캐싱 / 월간 갱신 스케줄러

- 방문자 수는 월 단위 데이터인데 메인 화면 트래픽이 몰리므로, **미리 계산한 스냅샷을 인메모리에 캐시**합니다.
  - `AtomicReference<RegionPopularitySnapshot>` + 불변 값 객체(`record`) + `copyOf` 방어적 복사로 스레드 안전하게 관리했어요.
- `RegionPopularityScheduler`: 매월 1일 04시에 스냅샷을 갱신하고, 스냅샷이 비어있으면 최초 조회 시점에 지연 로딩합니다.
- 갱신 실패(기준월 못 찾음 / 외부 API 실패) 시에는 **이전 스냅샷을 유지**해 빈 응답을 방지합니다.

### 지역별 관광 인기도(히트맵) 조회 API

- Endpoint: `GET /api/v1/regions/popularity`
- 최근 한 달 기준 **전체 시도(17개)**의 방문 인원수를 방문 인원수 내림차순으로 내려줍니다. 튜립 미지원 시도도 포함해요(히트맵 전체 색칠용).
- Response:
```json
{
  "baseMonth": "202506",
  "regions": [
    { "areaCode": 11, "regionName": "서울특별시", "visitorCount": 28470000 },
    { "areaCode": 41, "regionName": "경기도", "visitorCount": 19800000 }
  ]
}
```

### 최근 한 달 인기 여행지 Top 10 조회 API

- Endpoint: `GET /api/v1/regions/popular-destinations`
- 튜립이 지원하는 지역 카테고리(14개) 중 방문 인원수 **상위 10개**를 순위와 함께 반환합니다. 클릭 시 기존 지역별 콘텐츠 조회(`/contents?regionCategory=`)로 연결돼요.
- Response:
```json
{
  "baseMonth": "202506",
  "destinations": [
    { "rank": 1, "regionCategory": "서울", "visitorCount": 28470000 },
    { "rank": 2, "regionCategory": "부산", "visitorCount": 13200000 }
  ]
}
```

## 📷 Screenshot

## 📚 Reference

- 한국관광공사_빅데이터_지역별 방문자수: https://www.data.go.kr/data/15101972/openapi.do


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 지역별 관광 인기도 조회 기능을 제공합니다.
  * 시도별 방문자 수를 비교해 지역 인기도를 확인할 수 있습니다.
  * 인기 관광 목적지 상위 10곳을 방문자 수와 순위로 제공합니다.
  * 최신 관광 데이터를 기준으로 결과를 매월 자동 갱신합니다.
* **개선 사항**
  * 외지인·외국인 방문자 데이터를 기반으로 통계를 집계합니다.
  * 지원 여부와 관계없이 시도별 방문자 정보를 제공합니다.
  * 관광 데이터 조회 실패 시 기존 정보를 유지하고, 일시적 오류 후 재시도합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->