### PR TITLE
[feat] 연관관광지 API 개선(WebClient, Mono)

### DIFF
--- a/backend/turip-app/build.gradle
+++ b/backend/turip-app/build.gradle
@@ -8,6 +8,7 @@ jar {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation "io.micrometer:micrometer-registry-prometheus"
     implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'

--- a/backend/turip-app/src/main/java/turip/common/configuration/AsyncConfiguration.java
+++ b/backend/turip-app/src/main/java/turip/common/configuration/AsyncConfiguration.java
@@ -1,7 +1,6 @@
 package turip.common.configuration;
 
 import java.util.concurrent.Executor;
-import java.util.concurrent.RejectedExecutionException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -48,29 +47,6 @@ public class AsyncConfiguration {
                         executorInstance.getQueue().remainingCapacity()
                 )
         );
-
-        executor.setWaitForTasksToCompleteOnShutdown(true);
-        executor.setAwaitTerminationSeconds(30);
-
-        return executor;
-    }
-
-    @Bean(name = "koreaTourismApiExecutor")
-    public Executor koreaTourismApiExecutor() {
-        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(10);
-        executor.setMaxPoolSize(10);
-        executor.setQueueCapacity(50);
-        executor.setThreadNamePrefix("KOREA-TOURISM-API-");
-
-        executor.setRejectedExecutionHandler((r, executorInstance) -> {
-            log.warn(
-                    "[KOREA-TOURISM-API-ThreadPool] API 호출 거부됨 - Thread pool 포화 상태 (현재 활성 스레드: {}, 잔여 큐 용량: {})",
-                    executorInstance.getActiveCount(),
-                    executorInstance.getQueue().remainingCapacity()
-            );
-            throw new RejectedExecutionException("Thread pool 포화로 인한 API 호출 거부");
-        });
 
         executor.setWaitForTasksToCompleteOnShutdown(true);
         executor.setAwaitTerminationSeconds(30);

--- a/backend/turip-app/src/main/java/turip/common/configuration/WebClientConfiguration.java
+++ b/backend/turip-app/src/main/java/turip/common/configuration/WebClientConfiguration.java
@@ -1,0 +1,35 @@
+package turip.common.configuration;
+
+import io.netty.channel.ChannelOption;
+import java.time.Duration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
+
+@Configuration
+public class WebClientConfiguration {
+
+    private static final int MAX_CONNECTIONS = 10;
+    private static final int CONNECT_TIMEOUT_MILLIS = 2000;
+    private static final Duration PENDING_ACQUIRE_TIMEOUT = Duration.ofSeconds(3);
+    private static final Duration RESPONSE_TIMEOUT = Duration.ofSeconds(5);
+
+    @Bean
+    public WebClient baseWebClient() {
+        ConnectionProvider connectionProvider = ConnectionProvider.builder("base-webclient")
+                .maxConnections(MAX_CONNECTIONS)
+                .pendingAcquireTimeout(PENDING_ACQUIRE_TIMEOUT)
+                .build();
+
+        HttpClient httpClient = HttpClient.create(connectionProvider)
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONNECT_TIMEOUT_MILLIS)
+                .responseTimeout(RESPONSE_TIMEOUT);
+
+        return WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+}

--- a/backend/turip-app/src/main/java/turip/common/configuration/WebClientConfiguration.java
+++ b/backend/turip-app/src/main/java/turip/common/configuration/WebClientConfiguration.java
@@ -2,20 +2,25 @@ package turip.common.configuration;
 
 import io.netty.channel.ChannelOption;
 import java.time.Duration;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.resources.ConnectionProvider;
+import turip.common.log.ExternalApiLoggingFilter;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebClientConfiguration {
 
     private static final int MAX_CONNECTIONS = 10;
     private static final int CONNECT_TIMEOUT_MILLIS = 2000;
     private static final Duration PENDING_ACQUIRE_TIMEOUT = Duration.ofSeconds(3);
     private static final Duration RESPONSE_TIMEOUT = Duration.ofSeconds(5);
+
+    private final ExternalApiLoggingFilter loggingFilter;
 
     @Bean
     public WebClient baseWebClient() {
@@ -30,6 +35,7 @@ public class WebClientConfiguration {
 
         return WebClient.builder()
                 .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .filter(loggingFilter.filter())
                 .build();
     }
 }

--- a/backend/turip-app/src/main/java/turip/common/log/ExternalApiLogFormat.java
+++ b/backend/turip-app/src/main/java/turip/common/log/ExternalApiLogFormat.java
@@ -1,0 +1,36 @@
+package turip.common.log;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 외부 API 요청/응답 로깅에서 공통으로 쓰이는 포맷팅 유틸.
+ * RestClient(ExternalApiLoggingInterceptor)와 WebClient(ExternalApiLoggingFilter)가
+ * 각자의 프레임워크 계약(동기/리액티브)에 맞게 로그를 남기되, 민감정보 마스킹 로직은 여기서 공유한다.
+ */
+public final class ExternalApiLogFormat {
+
+    private static final Set<String> SENSITIVE_PARAMS = Set.of("key", "apikey", "api_key", "token");
+
+    private ExternalApiLogFormat() {
+    }
+
+    public static String maskSensitiveParams(URI uri) {
+        String query = uri.getQuery();
+        if (query == null) {
+            return uri.toString();
+        }
+        String maskedQuery = Arrays.stream(query.split("&"))
+                .map(param -> {
+                    String[] kv = param.split("=", 2);
+                    if (kv.length == 2 && SENSITIVE_PARAMS.contains(kv[0].toLowerCase())) {
+                        return kv[0] + "=***";
+                    }
+                    return param;
+                })
+                .collect(Collectors.joining("&"));
+        return uri.toString().replace(query, maskedQuery);
+    }
+}

--- a/backend/turip-app/src/main/java/turip/common/log/ExternalApiLoggingFilter.java
+++ b/backend/turip-app/src/main/java/turip/common/log/ExternalApiLoggingFilter.java
@@ -1,0 +1,25 @@
+package turip.common.log;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+
+@Slf4j
+@Component
+public class ExternalApiLoggingFilter {
+
+    public ExchangeFilterFunction filter() {
+        return (request, next) -> {
+            long startTime = System.currentTimeMillis();
+
+            log.info("[외부 API 요청] method: {}, uri: {}",
+                    request.method(), ExternalApiLogFormat.maskSensitiveParams(request.url()));
+
+            return next.exchange(request)
+                    .doOnNext(response -> {
+                        long duration = System.currentTimeMillis() - startTime;
+                        log.info("[외부 API 응답] status: {}, duration: {}ms", response.statusCode(), duration);
+                    });
+        };
+    }
+}

--- a/backend/turip-app/src/main/java/turip/common/log/ExternalApiLoggingInterceptor.java
+++ b/backend/turip-app/src/main/java/turip/common/log/ExternalApiLoggingInterceptor.java
@@ -1,10 +1,6 @@
 package turip.common.log;
 
 import java.io.IOException;
-import java.net.URI;
-import java.util.Arrays;
-import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpRequest;
@@ -17,32 +13,14 @@ import org.springframework.stereotype.Component;
 @Component
 public class ExternalApiLoggingInterceptor implements ClientHttpRequestInterceptor {
 
-    private static final Set<String> SENSITIVE_PARAMS = Set.of("key", "apikey", "api_key", "token");
-
-    private String maskSensitiveParams(URI uri) {
-        String query = uri.getQuery();
-        if (query == null) {
-            return uri.toString();
-        }
-        String maskedQuery = Arrays.stream(query.split("&"))
-                .map(param -> {
-                    String[] kv = param.split("=", 2);
-                    if (kv.length == 2 && SENSITIVE_PARAMS.contains(kv[0].toLowerCase())) {
-                        return kv[0] + "=***";
-                    }
-                    return param;
-                })
-                .collect(Collectors.joining("&"));
-        return uri.toString().replace(query, maskedQuery);
-    }
-
     @Override
     @NonNull
     public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution)
             throws IOException {
         long startTime = System.currentTimeMillis();
 
-        log.info("[외부 API 요청] method: {}, uri: {}", request.getMethod(), maskSensitiveParams(request.getURI()));
+        log.info("[외부 API 요청] method: {}, uri: {}",
+                request.getMethod(), ExternalApiLogFormat.maskSensitiveParams(request.getURI()));
 
         ClientHttpResponse response = execution.execute(request, body);
 

--- a/backend/turip-app/src/main/java/turip/infrastructure/client/KoreaTourismRelatedSpotClient.java
+++ b/backend/turip-app/src/main/java/turip/infrastructure/client/KoreaTourismRelatedSpotClient.java
@@ -61,6 +61,9 @@ public class KoreaTourismRelatedSpotClient {
                 .uri(uri)
                 .retrieve()
                 .bodyToMono(KoreaTourismRelatedSpotResponse.class)
+                .switchIfEmpty(Mono.fromRunnable(() ->
+                        log.warn("한국관광공사 연관 관광지 API 응답 본문이 비어있음: areaCode={}, sigunguCode={}",
+                                areaCode, sigunguCode)))
                 .map(response -> {
                     if (!response.isSuccess()) {
                         log.warn("한국관광공사 연관 관광지 API 응답 실패: resultCode={}, resultMsg={}",
@@ -70,6 +73,7 @@ public class KoreaTourismRelatedSpotClient {
                     // API 호출 성공, 데이터가 비어있어도 success로 반환
                     return RelatedSpotResult.success(response.getRelatedSpots());
                 })
+                .defaultIfEmpty(RelatedSpotResult.failure())
                 .onErrorResume(e -> {
                     log.warn("한국관광공사 연관 관광지 API 호출 실패: areaCode={}, sigunguCode={}, message={}",
                             areaCode, sigunguCode, e.getMessage());

--- a/backend/turip-app/src/main/java/turip/infrastructure/client/KoreaTourismRelatedSpotClient.java
+++ b/backend/turip-app/src/main/java/turip/infrastructure/client/KoreaTourismRelatedSpotClient.java
@@ -7,7 +7,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
-import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 import turip.infrastructure.client.dto.KoreaTourismRelatedSpotResponse;
 import turip.infrastructure.client.dto.RelatedSpotResult;
 
@@ -25,66 +26,55 @@ public class KoreaTourismRelatedSpotClient {
     private static final DateTimeFormatter YEAR_MONTH_FORMATTER = DateTimeFormatter.ofPattern("yyyyMM");
 
     private final RestClient restClient;
+    private final WebClient webClient;
     private final String koreaTourismApiKey;
     private final String koreaTourismApiUrl;
 
     private volatile String currentBaseYm = DEFAULT_BASE_YM; // 동적으로 관리되는 기준월
 
     public KoreaTourismRelatedSpotClient(RestClient baseRestClient,
+                                         WebClient baseWebClient,
                                          @Value("${korea-tourism.api.key}") String koreaTourismApiKey,
                                          @Value("${korea-tourism.api.url}") String koreaTourismApiUrl) {
         this.restClient = baseRestClient;
+        this.webClient = baseWebClient;
         this.koreaTourismApiKey = koreaTourismApiKey;
         this.koreaTourismApiUrl = koreaTourismApiUrl;
     }
 
-    public RelatedSpotResult searchRelatedSpots(int areaCode, int sigunguCode) {
-        try {
-            // URI를 완전히 수동으로 생성 (이중 인코딩 방지)
-            StringBuilder uriString = new StringBuilder(koreaTourismApiUrl)
-                    .append("?serviceKey=").append(koreaTourismApiKey)
-                    .append("&pageNo=").append(DEFAULT_PAGE_NO)
-                    .append("&numOfRows=").append(DEFAULT_NUM_OF_ROWS)
-                    .append("&MobileOS=").append(MOBILE_OS)
-                    .append("&MobileApp=").append(MOBILE_APP)
-                    .append("&_type=").append(RESPONSE_TYPE)
-                    .append("&baseYm=").append(currentBaseYm)
-                    .append("&areaCd=").append(areaCode)
-                    .append("&signguCd=").append(sigunguCode);
+    public Mono<RelatedSpotResult> searchRelatedSpots(int areaCode, int sigunguCode) {
+        // URI를 완전히 수동으로 생성 (이중 인코딩 방지)
+        StringBuilder uriString = new StringBuilder(koreaTourismApiUrl)
+                .append("?serviceKey=").append(koreaTourismApiKey)
+                .append("&pageNo=").append(DEFAULT_PAGE_NO)
+                .append("&numOfRows=").append(DEFAULT_NUM_OF_ROWS)
+                .append("&MobileOS=").append(MOBILE_OS)
+                .append("&MobileApp=").append(MOBILE_APP)
+                .append("&_type=").append(RESPONSE_TYPE)
+                .append("&baseYm=").append(currentBaseYm)
+                .append("&areaCd=").append(areaCode)
+                .append("&signguCd=").append(sigunguCode);
 
-            URI uri = URI.create(uriString.toString());
-            KoreaTourismRelatedSpotResponse response = restClient.get()
-                    .uri(uri)
-                    .retrieve()
-                    .body(KoreaTourismRelatedSpotResponse.class);
+        URI uri = URI.create(uriString.toString());
 
-            if (response == null) {
-                log.warn("한국관광공사 연관 관광지 API 응답 파싱 실패");
-                return RelatedSpotResult.failure();
-            }
-
-            if (!response.isSuccess()) {
-                log.warn("한국관광공사 연관 관광지 API 응답 실패: resultCode={}, resultMsg={}",
-                        response.getResultCode(), response.getResultMsg());
-                return RelatedSpotResult.failure();
-            }
-
-            // API 호출 성공, 데이터가 비어있어도 success로 반환
-            return RelatedSpotResult.success(response.getRelatedSpots());
-        } catch (RestClientResponseException e) {
-            log.warn("한국관광공사 연관 관광지 API 호출 실패: areaCode={}, sigunguCode={}, statusCode={}, message={}",
-                    areaCode,
-                    sigunguCode,
-                    e.getStatusCode().value(),
-                    e.getMessage());
-            return RelatedSpotResult.failure();
-        } catch (Exception e) {
-            log.warn("한국관광공사 연관 관광지 API 호출 실패: areaCode={}, sigunguCode={}, message={}",
-                    areaCode,
-                    sigunguCode,
-                    e.getMessage());
-            return RelatedSpotResult.failure();
-        }
+        return webClient.get()
+                .uri(uri)
+                .retrieve()
+                .bodyToMono(KoreaTourismRelatedSpotResponse.class)
+                .map(response -> {
+                    if (!response.isSuccess()) {
+                        log.warn("한국관광공사 연관 관광지 API 응답 실패: resultCode={}, resultMsg={}",
+                                response.getResultCode(), response.getResultMsg());
+                        return RelatedSpotResult.failure();
+                    }
+                    // API 호출 성공, 데이터가 비어있어도 success로 반환
+                    return RelatedSpotResult.success(response.getRelatedSpots());
+                })
+                .onErrorResume(e -> {
+                    log.warn("한국관광공사 연관 관광지 API 호출 실패: areaCode={}, sigunguCode={}, message={}",
+                            areaCode, sigunguCode, e.getMessage());
+                    return Mono.just(RelatedSpotResult.failure());
+                });
     }
 
     /**

--- a/backend/turip-app/src/main/java/turip/infrastructure/scheduler/KoreaTourismApiHealthCheckScheduler.java
+++ b/backend/turip-app/src/main/java/turip/infrastructure/scheduler/KoreaTourismApiHealthCheckScheduler.java
@@ -26,7 +26,7 @@ public class KoreaTourismApiHealthCheckScheduler {
             RelatedSpotResult result = koreaTourismRelatedSpotClient.searchRelatedSpots(
                     TourApiAreaCode.SEOUL.getAreaCode(),
                     TourApiAreaCode.SEOUL.getSigunguCodes().get(0)
-            );
+            ).block();
 
             if (!result.isSuccess()) {
                 log.error("{} 헬스체크 실패 - API 응답 실패", LOG_HEADER);

--- a/backend/turip-app/src/main/java/turip/region/controller/RelatedSpotController.java
+++ b/backend/turip-app/src/main/java/turip/region/controller/RelatedSpotController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
 import turip.region.controller.dto.response.RelatedSpotsResponse;
 import turip.region.domain.DomesticRegionCategory;
 import turip.region.service.RelatedSpotService;
@@ -63,11 +64,11 @@ public class RelatedSpotController {
             )
     })
     @GetMapping("/related-spots")
-    public ResponseEntity<RelatedSpotsResponse> readRelatedSpots(
+    public Mono<ResponseEntity<RelatedSpotsResponse>> readRelatedSpots(
             @Parameter(description = "지역 카테고리 (서울, 부산, 제주, 인천, 대전, 전주, 강릉, 속초, 경주)", required = true, example = "서울")
             @RequestParam(name = "regionCategory") DomesticRegionCategory regionCategory
     ) {
-        RelatedSpotsResponse response = relatedSpotService.findRelatedSpotsByRegionCategory(regionCategory);
-        return ResponseEntity.ok(response);
+        return relatedSpotService.findRelatedSpotsByRegionCategory(regionCategory)
+                .map(ResponseEntity::ok);
     }
 }

--- a/backend/turip-app/src/main/java/turip/region/service/RelatedSpotService.java
+++ b/backend/turip-app/src/main/java/turip/region/service/RelatedSpotService.java
@@ -1,11 +1,10 @@
 package turip.region.service;
 
+import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 import turip.common.exception.ErrorTag;
 import turip.common.exception.custom.IllegalArgumentException;
 import turip.infrastructure.client.KoreaTourismRelatedSpotClient;
@@ -21,24 +20,45 @@ import turip.region.domain.TourApiAreaCode;
 public class RelatedSpotService {
 
     private final KoreaTourismRelatedSpotClient koreaTourismRelatedSpotClient;
-    private final Executor koreaTourismApiExecutor;
 
-    public RelatedSpotService(
-            KoreaTourismRelatedSpotClient koreaTourismRelatedSpotClient,
-            @Qualifier("koreaTourismApiExecutor") Executor koreaTourismApiExecutor) {
+    public RelatedSpotService(KoreaTourismRelatedSpotClient koreaTourismRelatedSpotClient) {
         this.koreaTourismRelatedSpotClient = koreaTourismRelatedSpotClient;
-        this.koreaTourismApiExecutor = koreaTourismApiExecutor;
     }
 
-    public RelatedSpotsResponse findRelatedSpotsByRegionCategory(DomesticRegionCategory category) {
+    public Mono<RelatedSpotsResponse> findRelatedSpotsByRegionCategory(DomesticRegionCategory category) {
         TourApiAreaCode areaCode = parseToAreaCode(category);
         if (!areaCode.isFound()) {
             log.warn("지역 카테고리에 매핑되는 TourAPI 지역 코드를 찾을 수 없습니다: {}", category);
-            return RelatedSpotsResponse.empty();
+            return Mono.just(RelatedSpotsResponse.empty());
         }
 
-        List<RelatedSpotResult> results = getRelatedSpotsByAreaCode(areaCode);
+        return getRelatedSpotsByAreaCode(areaCode)
+                .map(results -> toRelatedSpotsResponse(category, results));
+    }
 
+    private TourApiAreaCode parseToAreaCode(DomesticRegionCategory category) {
+        if (category == DomesticRegionCategory.OTHER_DOMESTIC) {
+            throw new IllegalArgumentException(ErrorTag.REGION_CATEGORY_INVALID);
+        }
+        return TourApiAreaCode.fromDomesticRegionCategory(category);
+    }
+
+    private Mono<List<RelatedSpotResult>> getRelatedSpotsByAreaCode(TourApiAreaCode areaCode) {
+        // 여러 시군구 코드에 대해 WebClient로 비동기 논블로킹 병렬 호출
+        List<Mono<RelatedSpotResult>> monos = areaCode.getSigunguCodes().stream()
+                .map(sigunguCode -> koreaTourismRelatedSpotClient.searchRelatedSpots(
+                        areaCode.getAreaCode(),
+                        sigunguCode
+                ))
+                .toList();
+
+        return Mono.zip(monos, results -> Arrays.stream(results)
+                .map(result -> (RelatedSpotResult) result)
+                .toList());
+    }
+
+    private RelatedSpotsResponse toRelatedSpotsResponse(DomesticRegionCategory category,
+                                                        List<RelatedSpotResult> results) {
         // API 호출이 모두 실패했거나, 성공했지만 데이터가 비어있는 경우 fallback 사용
         if (shouldUseFallback(results)) {
             RelatedTuripSpots relatedTuripSpots = RelatedTuripSpots.from(category);
@@ -50,38 +70,6 @@ public class RelatedSpotService {
                 .flatMap(result -> result.spots().stream())
                 .toList();
         return RelatedSpotsResponse.from(relatedSpots);
-    }
-
-    private TourApiAreaCode parseToAreaCode(DomesticRegionCategory category) {
-        if (category == DomesticRegionCategory.OTHER_DOMESTIC) {
-            throw new IllegalArgumentException(ErrorTag.REGION_CATEGORY_INVALID);
-        }
-        return TourApiAreaCode.fromDomesticRegionCategory(category);
-    }
-
-    private List<RelatedSpotResult> getRelatedSpotsByAreaCode(TourApiAreaCode areaCode) {
-        // 여러 시군구 코드에 대해 전용 스레드풀에서 병렬로 API 호출
-        List<CompletableFuture<RelatedSpotResult>> futures = areaCode.getSigunguCodes().stream()
-                .map(sigunguCode -> CompletableFuture.supplyAsync(
-                        () -> koreaTourismRelatedSpotClient.searchRelatedSpots(
-                                areaCode.getAreaCode(),
-                                sigunguCode
-                        ),
-                        koreaTourismApiExecutor
-                ))
-                .toList();
-
-        // 모든 비동기 작업 완료 대기 (스레드풀 거부 등 예외 발생 시 실패로 처리)
-        return futures.stream()
-                .map(future -> {
-                    try {
-                        return future.join();
-                    } catch (Exception e) {
-                        log.warn("연관 관광지 API 호출 중 예외 발생: {}", e.getMessage());
-                        return RelatedSpotResult.failure();
-                    }
-                })
-                .toList();
     }
 
     private boolean shouldUseFallback(List<RelatedSpotResult> results) {

--- a/backend/turip-app/src/test/java/turip/common/log/ExternalApiLogFormatTest.java
+++ b/backend/turip-app/src/test/java/turip/common/log/ExternalApiLogFormatTest.java
@@ -1,26 +1,21 @@
 package turip.common.log;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import java.lang.reflect.Method;
-import java.net.URI;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ExternalApiLoggingInterceptorTest {
+import java.net.URI;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
-    private final ExternalApiLoggingInterceptor interceptor = new ExternalApiLoggingInterceptor();
+class ExternalApiLogFormatTest {
 
     @Test
     @DisplayName("URI의 쿼리 파라미터에 민감한 정보(key)가 포함되어 있으면 마스킹한다.")
     void maskSensitiveParamsWithKey() throws Exception {
         // given
         URI uri = new URI("https://www.googleapis.com/youtube/v3/videos?part=snippet&id=videoId&key=AIzaSyA_...&other=param");
-        Method method = ExternalApiLoggingInterceptor.class.getDeclaredMethod("maskSensitiveParams", URI.class);
-        method.setAccessible(true);
 
         // when
-        String maskedUri = (String) method.invoke(interceptor, uri);
+        String maskedUri = ExternalApiLogFormat.maskSensitiveParams(uri);
 
         // then
         assertThat(maskedUri).contains("key=***");
@@ -33,11 +28,9 @@ class ExternalApiLoggingInterceptorTest {
     void maskSensitiveParamsWithApiKey() throws Exception {
         // given
         URI uri = new URI("https://www.googleapis.com/youtube/v3/videos?part=snippet&id=videoId&apiKey=AIzaSyA_...&other=param");
-        Method method = ExternalApiLoggingInterceptor.class.getDeclaredMethod("maskSensitiveParams", URI.class);
-        method.setAccessible(true);
 
         // when
-        String maskedUri = (String) method.invoke(interceptor, uri);
+        String maskedUri = ExternalApiLogFormat.maskSensitiveParams(uri);
 
         // then
         assertThat(maskedUri).contains("apiKey=***");
@@ -50,11 +43,9 @@ class ExternalApiLoggingInterceptorTest {
     void maskSensitiveParamsWithoutSensitiveInfo() throws Exception {
         // given
         URI uri = new URI("https://www.googleapis.com/youtube/v3/videos?part=snippet&id=videoId&other=param");
-        Method method = ExternalApiLoggingInterceptor.class.getDeclaredMethod("maskSensitiveParams", URI.class);
-        method.setAccessible(true);
 
         // when
-        String maskedUri = (String) method.invoke(interceptor, uri);
+        String maskedUri = ExternalApiLogFormat.maskSensitiveParams(uri);
 
         // then
         assertThat(maskedUri).isEqualTo(uri.toString());
@@ -65,11 +56,9 @@ class ExternalApiLoggingInterceptorTest {
     void maskSensitiveParamsWithoutQuery() throws Exception {
         // given
         URI uri = new URI("https://www.googleapis.com/youtube/v3/videos");
-        Method method = ExternalApiLoggingInterceptor.class.getDeclaredMethod("maskSensitiveParams", URI.class);
-        method.setAccessible(true);
 
         // when
-        String maskedUri = (String) method.invoke(interceptor, uri);
+        String maskedUri = ExternalApiLogFormat.maskSensitiveParams(uri);
 
         // then
         assertThat(maskedUri).isEqualTo(uri.toString());

--- a/backend/turip-app/src/test/java/turip/infrastructure/client/KoreaTourismRelatedSpotClientTest.java
+++ b/backend/turip-app/src/test/java/turip/infrastructure/client/KoreaTourismRelatedSpotClientTest.java
@@ -2,44 +2,50 @@ package turip.infrastructure.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
-import java.util.List;
+import java.io.IOException;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.client.MockRestServiceServer;
-import turip.common.configuration.RestClientConfiguration;
-import turip.common.log.ExternalApiLoggingInterceptor;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.reactive.function.client.WebClient;
 import turip.infrastructure.client.dto.KoreaTourismRelatedSpotResponse.RelatedSpot;
 import turip.infrastructure.client.dto.RelatedSpotResult;
 
-@ActiveProfiles({"test", "h2"})
-@RestClientTest(KoreaTourismRelatedSpotClient.class)
-@Import({RestClientConfiguration.class, ExternalApiLoggingInterceptor.class})
 class KoreaTourismRelatedSpotClientTest {
 
-    @Autowired
-    private MockRestServiceServer mockRestServiceServer;
+    private static final String API_KEY = "test-service-key";
 
-    @Autowired
+    private MockWebServer mockWebServer;
     private KoreaTourismRelatedSpotClient koreaTourismRelatedSpotClient;
 
-    @Value("${korea-tourism.api.url}")
-    private String koreaTourismApiUrl;
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
 
-    @Value("${korea-tourism.api.key}")
-    private String koreaTourismApiKey;
+        String baseUrl = mockWebServer.url("/").toString();
+        koreaTourismRelatedSpotClient = new KoreaTourismRelatedSpotClient(
+                RestClient.builder().build(),
+                WebClient.builder().build(),
+                API_KEY,
+                baseUrl
+        );
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
 
     @Test
     @DisplayName("한국관광공사 연관 관광지 API를 호출하고 응답을 올바르게 파싱한다.")
-    void searchRelatedSpots() {
+    void searchRelatedSpots() throws InterruptedException {
         // given
         String mockResponse = """
                 {
@@ -80,22 +86,12 @@ class KoreaTourismRelatedSpotClientTest {
                 }
                 """;
 
-        String expectedUrl = koreaTourismApiUrl
-                + "?serviceKey=" + koreaTourismApiKey
-                + "&pageNo=1"
-                + "&numOfRows=30"
-                + "&MobileOS=ETC"
-                + "&MobileApp=Turip"
-                + "&_type=json"
-                + "&baseYm=202606"
-                + "&areaCd=11"
-                + "&signguCd=11110";
-
-        mockRestServiceServer.expect(requestTo(expectedUrl))
-                .andRespond(withSuccess(mockResponse, MediaType.APPLICATION_JSON));
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(mockResponse)
+                .addHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE));
 
         // when
-        RelatedSpotResult result = koreaTourismRelatedSpotClient.searchRelatedSpots(11, 11110);
+        RelatedSpotResult result = koreaTourismRelatedSpotClient.searchRelatedSpots(11, 11110).block();
 
         // then
         assertAll(
@@ -112,7 +108,17 @@ class KoreaTourismRelatedSpotClientTest {
                 () -> assertThat(spot.getRelatedRank()).isEqualTo(1)
         );
 
-        mockRestServiceServer.verify();
+        RecordedRequest recordedRequest = mockWebServer.takeRequest();
+        assertThat(recordedRequest.getPath())
+                .contains("serviceKey=" + API_KEY)
+                .contains("pageNo=1")
+                .contains("numOfRows=30")
+                .contains("MobileOS=ETC")
+                .contains("MobileApp=Turip")
+                .contains("_type=json")
+                .contains("baseYm=202606")
+                .contains("areaCd=11")
+                .contains("signguCd=11110");
     }
 
     @Test
@@ -136,29 +142,33 @@ class KoreaTourismRelatedSpotClientTest {
                 }
                 """;
 
-        String expectedUrl = koreaTourismApiUrl
-                + "?serviceKey=" + koreaTourismApiKey
-                + "&pageNo=1"
-                + "&numOfRows=30"
-                + "&MobileOS=ETC"
-                + "&MobileApp=Turip"
-                + "&_type=json"
-                + "&baseYm=202606"
-                + "&areaCd=11"
-                + "&signguCd=11110";
-
-        mockRestServiceServer.expect(requestTo(expectedUrl))
-                .andRespond(withSuccess(mockResponse, MediaType.APPLICATION_JSON));
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(mockResponse)
+                .addHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE));
 
         // when
-        RelatedSpotResult result = koreaTourismRelatedSpotClient.searchRelatedSpots(11, 11110);
+        RelatedSpotResult result = koreaTourismRelatedSpotClient.searchRelatedSpots(11, 11110).block();
 
         // then
         assertAll(
                 () -> assertThat(result.isSuccess()).isTrue(),
                 () -> assertThat(result.spots()).isEmpty()
         );
+    }
 
-        mockRestServiceServer.verify();
+    @Test
+    @DisplayName("API 호출이 실패하면 실패 결과를 반환한다.")
+    void searchRelatedSpots_whenApiFails_returnsFailure() {
+        // given
+        mockWebServer.enqueue(new MockResponse().setResponseCode(500));
+
+        // when
+        RelatedSpotResult result = koreaTourismRelatedSpotClient.searchRelatedSpots(11, 11110).block();
+
+        // then
+        assertAll(
+                () -> assertThat(result.isSuccess()).isFalse(),
+                () -> assertThat(result.spots()).isEmpty()
+        );
     }
 }

--- a/backend/turip-app/src/test/java/turip/infrastructure/client/KoreaTourismRelatedSpotClientTest.java
+++ b/backend/turip-app/src/test/java/turip/infrastructure/client/KoreaTourismRelatedSpotClientTest.java
@@ -171,4 +171,23 @@ class KoreaTourismRelatedSpotClientTest {
                 () -> assertThat(result.spots()).isEmpty()
         );
     }
+
+    @Test
+    @DisplayName("응답 본문이 완전히 비어있으면 실패 결과를 반환한다.")
+    void searchRelatedSpots_whenBodyIsEmpty_returnsFailure() {
+        // given
+        mockWebServer.enqueue(new MockResponse()
+                .setBody("")
+                .addHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE));
+
+        // when
+        RelatedSpotResult result = koreaTourismRelatedSpotClient.searchRelatedSpots(11, 11110).block();
+
+        // then
+        assertAll(
+                () -> assertThat(result).isNotNull(),
+                () -> assertThat(result.isSuccess()).isFalse(),
+                () -> assertThat(result.spots()).isEmpty()
+        );
+    }
 }

--- a/backend/turip-app/src/test/java/turip/region/api/RelatedSpotApiTest.java
+++ b/backend/turip-app/src/test/java/turip/region/api/RelatedSpotApiTest.java
@@ -17,6 +17,7 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import reactor.core.publisher.Mono;
 import turip.infrastructure.client.KoreaTourismRelatedSpotClient;
 import turip.infrastructure.client.dto.KoreaTourismRelatedSpotResponse.RelatedSpot;
 import turip.infrastructure.client.dto.RelatedSpotResult;
@@ -57,11 +58,11 @@ class RelatedSpotApiTest {
 
             // 서울의 3개 시군구 코드에 대해 모킹
             given(koreaTourismRelatedSpotClient.searchRelatedSpots(11, 11110))
-                    .willReturn(RelatedSpotResult.success(List.of(spot1)));
+                    .willReturn(Mono.just(RelatedSpotResult.success(List.of(spot1))));
             given(koreaTourismRelatedSpotClient.searchRelatedSpots(11, 11440))
-                    .willReturn(RelatedSpotResult.success(List.of(spot2)));
+                    .willReturn(Mono.just(RelatedSpotResult.success(List.of(spot2))));
             given(koreaTourismRelatedSpotClient.searchRelatedSpots(11, 11140))
-                    .willReturn(RelatedSpotResult.success(List.of(spot3)));
+                    .willReturn(Mono.just(RelatedSpotResult.success(List.of(spot3))));
 
             // when & then
             RestAssured.given().port(port)
@@ -81,7 +82,7 @@ class RelatedSpotApiTest {
         void readRelatedSpots2() {
             // given
             given(koreaTourismRelatedSpotClient.searchRelatedSpots(anyInt(), anyInt()))
-                    .willReturn(RelatedSpotResult.failure());
+                    .willReturn(Mono.just(RelatedSpotResult.failure()));
 
             // when & then
             RestAssured.given().port(port)

--- a/backend/turip-app/src/test/java/turip/region/service/RelatedSpotServiceTest.java
+++ b/backend/turip-app/src/test/java/turip/region/service/RelatedSpotServiceTest.java
@@ -3,20 +3,17 @@ package turip.region.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 
 import java.util.List;
-import java.util.concurrent.Executor;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
 import turip.infrastructure.client.KoreaTourismRelatedSpotClient;
 import turip.infrastructure.client.dto.KoreaTourismRelatedSpotResponse.RelatedSpot;
 import turip.infrastructure.client.dto.RelatedSpotResult;
@@ -31,19 +28,6 @@ class RelatedSpotServiceTest {
 
     @Mock
     private KoreaTourismRelatedSpotClient koreaTourismRelatedSpotClient;
-
-    @Mock
-    private Executor koreaTourismApiExecutor;
-
-    @BeforeEach
-    void setUp() {
-        // Executor가 동기적으로 즉시 실행되도록 모킹
-        lenient().doAnswer(invocation -> {
-            Runnable task = invocation.getArgument(0);
-            task.run();
-            return null;
-        }).when(koreaTourismApiExecutor).execute(any(Runnable.class));
-    }
 
     @DisplayName("지역 카테고리로 연관 관광지를 조회한다")
     @Test
@@ -64,14 +48,14 @@ class RelatedSpotServiceTest {
 
         // 서울의 3개 시군구 코드에 대해 각각 모킹
         given(koreaTourismRelatedSpotClient.searchRelatedSpots(11, 11110))
-                .willReturn(RelatedSpotResult.success(List.of(spot1)));
+                .willReturn(Mono.just(RelatedSpotResult.success(List.of(spot1))));
         given(koreaTourismRelatedSpotClient.searchRelatedSpots(11, 11440))
-                .willReturn(RelatedSpotResult.success(List.of(spot2)));
+                .willReturn(Mono.just(RelatedSpotResult.success(List.of(spot2))));
         given(koreaTourismRelatedSpotClient.searchRelatedSpots(11, 11140))
-                .willReturn(RelatedSpotResult.success(List.of(spot3)));
+                .willReturn(Mono.just(RelatedSpotResult.success(List.of(spot3))));
 
         // when
-        RelatedSpotsResponse response = relatedSpotService.findRelatedSpotsByRegionCategory(category);
+        RelatedSpotsResponse response = relatedSpotService.findRelatedSpotsByRegionCategory(category).block();
 
         // then
         assertAll(
@@ -101,14 +85,14 @@ class RelatedSpotServiceTest {
 
         // 서울의 3개 시군구 코드에 대해 모두 실패 반환
         given(koreaTourismRelatedSpotClient.searchRelatedSpots(11, 11110))
-                .willReturn(RelatedSpotResult.failure());
+                .willReturn(Mono.just(RelatedSpotResult.failure()));
         given(koreaTourismRelatedSpotClient.searchRelatedSpots(11, 11440))
-                .willReturn(RelatedSpotResult.failure());
+                .willReturn(Mono.just(RelatedSpotResult.failure()));
         given(koreaTourismRelatedSpotClient.searchRelatedSpots(11, 11140))
-                .willReturn(RelatedSpotResult.failure());
+                .willReturn(Mono.just(RelatedSpotResult.failure()));
 
         // when
-        RelatedSpotsResponse response = relatedSpotService.findRelatedSpotsByRegionCategory(category);
+        RelatedSpotsResponse response = relatedSpotService.findRelatedSpotsByRegionCategory(category).block();
 
         // then
         assertThat(response.relatedSpots()).isNotEmpty();
@@ -122,14 +106,14 @@ class RelatedSpotServiceTest {
 
         // 서울의 3개 시군구 코드에 대해 성공했지만 빈 데이터 반환
         given(koreaTourismRelatedSpotClient.searchRelatedSpots(11, 11110))
-                .willReturn(RelatedSpotResult.success(List.of()));
+                .willReturn(Mono.just(RelatedSpotResult.success(List.of())));
         given(koreaTourismRelatedSpotClient.searchRelatedSpots(11, 11440))
-                .willReturn(RelatedSpotResult.success(List.of()));
+                .willReturn(Mono.just(RelatedSpotResult.success(List.of())));
         given(koreaTourismRelatedSpotClient.searchRelatedSpots(11, 11140))
-                .willReturn(RelatedSpotResult.success(List.of()));
+                .willReturn(Mono.just(RelatedSpotResult.success(List.of())));
 
         // when
-        RelatedSpotsResponse response = relatedSpotService.findRelatedSpotsByRegionCategory(category);
+        RelatedSpotsResponse response = relatedSpotService.findRelatedSpotsByRegionCategory(category).block();
 
         // then
         assertThat(response.relatedSpots()).isNotEmpty();


### PR DESCRIPTION
## Issues
- closed #712

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description

### 배경

* 현재 한국관광공사 연관관광지 API(외부 API) 호출 클라이언트는 **RestClient**로 구현되어 있습니다. 전용 스레드풀(koreaTourismExecutor, size=10)을 이용합니다.
* 3번의 외부 api에 3개의 전용 스레드가 각각 할당됩니다. 각 외부 api의 응답을 기다리는 동안, **전용 스레드는 블로킹**됩니다.
* 톰캣 스레드는 3번의 api를 비동기로 호출하기에 각 요청을 병렬로 진행할 수 있습니다. 그러나 future.join()을 통해 결과를 기다리는데, 여기서 **톰캣 스레드는 블로킹**됩니다.

-> 외부 api를 비동기로 호출하지만, **톰캣 스레드와 외부 api전용 스레드 모두 블로킹**됩니다.

### WebClient 전환

- 한국관광공사 연관관광지 API(외부 API) 호출 클라이언트를 **WebClient**로 구현하면, **netty 기반 이벤트 루프 스레드**가 외부 api를 요청하고 결과를 기다립니다. 
- 서비스 코드에서는 외부 api 결과가 도착하면 실행할 **콜백**을 등록합니다. 이벤트 루프 스레드가 외부 api 응답을 읽어온 뒤 아래 콜백을 실행합니다.
  - 각 외부 api 결과를 DTO로 변환한다(Mono.map)
  - 최대 3개의 외부 api 결과를 하나로 합친다(Mono.zip)
  - 3개의 결과가 모두 비어있다면 폴백 데이터로 채운다(Mono.map)

### 테스트 결과(개선 근거)

테스트 설정, 자세한 결과 지표는 노션에 정리했습니다.

| | 평균 TPS | 최대 TPS | p95 | p99 |
|---|---|---|---|---|
| Test1 (RestClient, pool10) | 3.07 | 3.33 | 13.2s | 16.8s |
| Test2 (WebClient, service block) | 264 | 312 | 166ms | 179ms |
| Test3 (WebClient, controller Mono) | 297 | 355 | 146ms | 175ms |
| Test4 (RestClient, pool50) | 7.52 | 11.1 | 4.98s | 5.15s |




## 📷 Screenshot

## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 외부 API 요청·응답의 상태와 처리 시간을 기록합니다.
  * 로그에 포함된 인증 정보 등 민감한 파라미터를 자동으로 마스킹합니다.

* **개선 사항**
  * 연관 관광지 조회를 비동기·논블로킹 방식으로 처리해 응답 처리를 개선했습니다.
  * 외부 API 연결 및 응답 시간 제한을 적용해 안정성을 높였습니다.

* **버그 수정**
  * 외부 API의 오류 응답이나 빈 응답을 실패 결과로 안정적으로 처리합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->